### PR TITLE
uninstall: remove all rootfull services

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/uninstall.sh
+++ b/core/imageroot/var/lib/nethserver/node/uninstall.sh
@@ -37,7 +37,8 @@ for modulehome in /var/lib/nethserver/*; do
     fi
     moduleid=$(basename $modulehome)
     echo "Deleting rootfull module ${moduleid}..."
-    systemctl disable --now eventsgw@${moduleid} agent@${moduleid} && rm -rf "${modulehome}"
+    systemctl disable --now eventsgw@${moduleid} agent@${moduleid} ${moduleid} && rm -rf "${modulehome}"
+    rm -f /etc/systemd/system/${moduleid}.service
 done
 
 echo "Uninstalling the core image files"

--- a/core/tests/cluster-sanity/40_promtail.robot
+++ b/core/tests/cluster-sanity/40_promtail.robot
@@ -1,0 +1,9 @@
+*** Settings ***
+Force Tags  promtail
+Library    SSHLibrary
+
+*** Test Cases ***
+Service has not failed
+    ${rc} =    Execute Command    systemctl is-failed -q promtail1
+    ...    return_rc=True  return_stdout=False
+    Should Be Equal As Integers    ${rc}    1


### PR DESCRIPTION
Make sure also promtail1 has been uninstalled.

Without this fix, after the uninstall, `promtail1` service was still in place.