### PR TITLE
Cluster disaster recovery

### DIFF
--- a/core/imageroot/usr/local/agent/bin/cluster-backup
+++ b/core/imageroot/usr/local/agent/bin/cluster-backup
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import json
+
+#
+# Dump cluster configuration in JSON format and print it to stdout
+#
+
+rdb = agent.redis_connect(host='127.0.0.1')
+
+VERSION = "1"
+
+dump = { 'version': VERSION, 'modules': {}, 'vpn': {}, 'cluster': { 'repository': {}, 'backup': {}, 'backup_repository': {}, 'user_domain': { 'ldap': {} } } }
+
+# cluster: software repositories
+for r in rdb.scan_iter('cluster/repository/*'):
+    k = r.removeprefix('cluster/repository/')
+    dump['cluster']['repository'][k] = rdb.hgetall(r)
+
+# cluster: backup repositories
+for r in rdb.scan_iter('cluster/backup_repository/*'):
+    k = r.removeprefix('cluster/backup_repository/')
+    dump['cluster']['backup_repository'][k] = rdb.hgetall(r)
+
+# cluster: backups
+for r in rdb.scan_iter('cluster/backup/*'):
+    k = r.removeprefix('cluster/backup/')
+    dump['cluster']['backup'][k] = rdb.hgetall(r)
+
+# cluster ldap user domains
+for d in rdb.scan_iter('cluster/user_domain/ldap/*/conf'):
+    k = d.removeprefix('cluster/user_domain/ldap/')
+    k = k.removesuffix('/conf')
+    dump['cluster']['user_domain']['ldap'][k] = { 'conf' : None, 'providers': None }
+    dump['cluster']['user_domain']['ldap'][k]['conf'] = rdb.hgetall(d)
+    dump['cluster']['user_domain']['ldap'][k]['providers'] = rdb.lrange(f'cluster/user_domain/ldap/{k}/providers', 0, -1)
+    if rdb.exists(f'cluster/user_domain/ldap/{k}/ui_names'):
+        dump['cluster']['user_domain']['ldap'][k]['ui_names'] = rdb.hgetall(f'cluster/user_domain/ldap/{k}/ui_names')
+
+# cluster: vpn network, label
+for k in ['network', 'ui_name']:
+    dump['cluster'][k] = rdb.get(f'cluster/{k}')
+
+# cluster: favorite apps
+dump['cluster']['favorites'] = list(rdb.smembers(f'cluster/favorites'))
+
+# modules: basic environment, label, backups
+for m in rdb.scan_iter('module/*/environment'):
+    k = m.removeprefix('module/')
+    k = k.removesuffix('/environment')
+    ui_name = ""
+    backups = []
+    if rdb.exists(f'module/{k}/ui_name'):
+        ui_name = rdb.get(f'module/{k}/ui_name')
+    if rdb.exists(f'module/{k}/backups'):
+        backups = list(rdb.smembers(f'module/{k}/backups'))
+
+    if ui_name or backups:
+        dump['modules'][rdb.hget(m, 'MODULE_UUID')] = {'ui_name': ui_name, 'backups': backups}
+
+# nodes: vpn, label
+for v in rdb.scan_iter('node/*/vpn'):
+    k = v.removeprefix('node/')
+    k = k.removesuffix('/vpn')
+    if rdb.hexists(v, 'endpoint'):
+        for f in ['endpoint', 'listen_port', 'destinations']:
+            dump['vpn'][f] = rdb.hget(v, f)
+
+
+# dump to JSON
+print(json.dumps(dump))

--- a/core/imageroot/usr/local/agent/bin/cluster-backup
+++ b/core/imageroot/usr/local/agent/bin/cluster-backup
@@ -20,12 +20,16 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+import os
 import agent
 import json
+import subprocess
 
 #
 # Dump cluster configuration in JSON format and print it to stdout
 #
+
+output_dir = f'{os.environ["AGENT_STATE_DIR"]}/backup'
 
 rdb = agent.redis_connect(host='127.0.0.1')
 
@@ -89,4 +93,11 @@ for v in rdb.scan_iter('node/*/vpn'):
 
 
 # dump to JSON
-print(json.dumps(dump))
+os.makedirs(output_dir, exist_ok=True)
+
+with open(f'{output_dir}/dump.json', 'w') as fp:
+    fp.write(json.dumps(dump))
+
+subprocess.run(['gzip', '-f', f'{output_dir}/dump.json'], check = True)
+
+subprocess.run(['gpg', '--batch', '-c', '--pinentry-mode', 'loopback', '--passphrase-file', f'{output_dir}/passphrase', f'{output_dir}/dump.json.gz'], check = True)

--- a/core/imageroot/usr/local/agent/bin/cluster-backup
+++ b/core/imageroot/usr/local/agent/bin/cluster-backup
@@ -21,9 +21,11 @@
 #
 
 import os
-import agent
+import sys
 import json
+import agent
 import subprocess
+from datetime import datetime, timezone
 
 #
 # Dump cluster configuration in JSON format and print it to stdout
@@ -34,8 +36,10 @@ output_dir = f'{os.environ["AGENT_STATE_DIR"]}/backup'
 rdb = agent.redis_connect(host='127.0.0.1')
 
 VERSION = "1"
+# pythonic wat to retrieve current timestamp on UTC timezone
+now = int(datetime.now(timezone.utc).replace(tzinfo=timezone.utc).timestamp())
 
-dump = { 'version': VERSION, 'modules': {}, 'vpn': {}, 'cluster': { 'repository': {}, 'backup': {}, 'backup_repository': {}, 'user_domain': { 'ldap': {} } } }
+dump = { 'version': VERSION, 'timestamp': now, 'modules': {}, 'vpn': {}, 'cluster': { 'repository': {}, 'backup': {}, 'backup_repository': {}, 'user_domain': { 'ldap': {} } } }
 
 # cluster: software repositories
 for r in rdb.scan_iter('cluster/repository/*'):
@@ -91,6 +95,7 @@ for v in rdb.scan_iter('node/*/vpn'):
         for f in ['endpoint', 'listen_port', 'destinations']:
             dump['vpn'][f] = rdb.hget(v, f)
 
+rdb.close()
 
 # dump to JSON
 os.makedirs(output_dir, exist_ok=True)
@@ -98,6 +103,19 @@ os.makedirs(output_dir, exist_ok=True)
 with open(f'{output_dir}/dump.json', 'w') as fp:
     fp.write(json.dumps(dump))
 
+# compress the JSON dump
 subprocess.run(['gzip', '-f', f'{output_dir}/dump.json'], check = True)
 
+# if the passhprase does not exists, use the sha256 of admin password
+if not os.path.isfile(f'{output_dir}/passphrase'):
+    rdb = agent.redis_connect(host='127.0.0.1', privileged = True)
+    admin = rdb.acl_getuser('admin')
+    rdb.close()
+
+    with open(f'{output_dir}/passphrase', 'w') as fp:
+        fp.write(admin['passwords'][0])
+
+# remove existing gpg file, otherwise gpg will fail
+os.remove(f'{output_dir}/dump.json.gz.gpg')
+# encrypt the backup
 subprocess.run(['gpg', '--batch', '-c', '--pinentry-mode', 'loopback', '--passphrase-file', f'{output_dir}/passphrase', f'{output_dir}/dump.json.gz'], check = True)

--- a/core/imageroot/usr/local/agent/bin/cluster-backup
+++ b/core/imageroot/usr/local/agent/bin/cluster-backup
@@ -24,6 +24,7 @@ import os
 import sys
 import json
 import agent
+import tempfile
 import subprocess
 from datetime import datetime, timezone
 
@@ -106,16 +107,24 @@ with open(f'{output_dir}/dump.json', 'w') as fp:
 # compress the JSON dump
 subprocess.run(['gzip', '-f', f'{output_dir}/dump.json'], check = True)
 
+# remove existing gpg file, otherwise gpg will fail
+try:
+   os.remove(f'{output_dir}/dump.json.gz.gpg')
+except:
+    pass
+
 # if the passhprase does not exists, use the sha256 of admin password
-if not os.path.isfile(f'{output_dir}/passphrase'):
+if os.path.isfile(f'{output_dir}/passphrase'):
+    subprocess.run(['gpg', '--batch', '-c', '--pinentry-mode', 'loopback', '--passphrase-file', f'{output_dir}/passphrase', f'{output_dir}/dump.json.gz'], check = True)
+else:
     rdb = agent.redis_connect(host='127.0.0.1', privileged = True)
     admin = rdb.acl_getuser('admin')
     rdb.close()
 
-    with open(f'{output_dir}/passphrase', 'w') as fp:
-        fp.write(admin['passwords'][0])
-
-# remove existing gpg file, otherwise gpg will fail
-os.remove(f'{output_dir}/dump.json.gz.gpg')
-# encrypt the backup
-subprocess.run(['gpg', '--batch', '-c', '--pinentry-mode', 'loopback', '--passphrase-file', f'{output_dir}/passphrase', f'{output_dir}/dump.json.gz'], check = True)
+    fp = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    fp.write(admin['passwords'][0])
+    fp.close()
+    try:
+        subprocess.run(['gpg', '--batch', '-c', '--pinentry-mode', 'loopback', '--passphrase-file', fp.name, f'{output_dir}/dump.json.gz'], check = True)
+    finally:
+        os.remove(fp.name)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/download-cluster-backup/50backup
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/download-cluster-backup/50backup
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+exec 1>&2
+
+cluster-backup

--- a/core/imageroot/var/lib/nethserver/cluster/actions/download-cluster-backup/60link
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/download-cluster-backup/60link
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+BACKUP="/var/lib/nethserver/cluster/state/backup/dump.json.gz.gpg"
+OUT_DIR="/var/lib/nethserver/cluster/ui/backup/"
+
+if [ ! -f $BACKUP ]; then
+    echo "Backup '$BACKUP' not found"
+    exit 1
+fi
+
+rm -rf $OUT_DIR
+sha=$(sha256sum -z $BACKUP | awk '{print $1}')
+mkdir -p $OUT_DIR/$sha/
+cp $BACKUP $OUT_DIR/$sha/
+
+echo "{\"path\": \"$sha/dump.json.gz.gpg\"}"

--- a/core/imageroot/var/lib/nethserver/cluster/actions/download-cluster-backup/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/download-cluster-backup/validate-output.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "download-cluster-backup output",
+    "$id": "http://schema.nethserver.org/cluster/download-cluster-backup-output.json",
+    "description": "Generate an URL to download an encrypted file containing the cluster backup",
+    "examples": [
+        {"path": "ad40cfe5342d731cc4423daefc535e9489666a39264cf8659bc8a4a0e6c4f32e/dump.json.gz.gpg"}
+    ]
+}

--- a/core/imageroot/var/lib/nethserver/cluster/actions/read-backup-repositories/50read
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/read-backup-repositories/50read
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import sys
+import json
+import agent
+import subprocess
+import os
+from datetime import datetime, timezone
+
+request = json.load(sys.stdin)
+
+popen_args={"encoding": 'utf-8', "stdout": subprocess.PIPE, "stderr": sys.stderr}
+
+rdb = agent.redis_connect(privileged=False)
+
+backups = list()
+for krepo in rdb.scan_iter('cluster/backup_repository/*'):
+    repo_uuid = krepo.removeprefix('cluster/backup_repository/')
+    rclone_cmd = ['rclone-wrapper', repo_uuid, 'lsjson']
+    repo = rdb.hgetall(krepo)
+
+    proot = subprocess.Popen(rclone_cmd + ["REMOTE_PATH"], **popen_args)
+    for oroot in json.load(proot.stdout):
+        if oroot["IsDir"] is False:
+            continue # skip non-dir entries
+        pchild = subprocess.Popen(rclone_cmd + ["REMOTE_PATH/" + oroot['Path']], **popen_args)
+        for backup in json.load(pchild.stdout):
+            # parse ISO 8601 date but remove ending Z (UTC timezone)
+            mod_time = datetime.fromisoformat(backup['ModTime'][0:-1])
+            mod_time = mod_time.replace(tzinfo=timezone.utc).timestamp()
+
+            if not '@' in backup["Path"] or backup["IsDir"] is False:
+                continue # skip non-repo entries
+            parts = backup['Path'].split('@')
+            backups.append({'name': oroot['Path'], 'path': f'{oroot["Path"]}/{backup["Path"]}', 'instance': parts[0], 'uuid': parts[1], 'timestamp': int(mod_time), 'repository_id' : repo_uuid, 'repository_name': repo['name'], 'repository_provider': repo['provider'], 'repository_url': repo['url']})
+
+print(json.dumps(backups))

--- a/core/imageroot/var/lib/nethserver/cluster/actions/read-backup-repositories/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/read-backup-repositories/validate-output.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "read-backup-repository output",
+    "$id": "http://schema.nethserver.org/cluster/read-all-backup-repositories-output.json",
+    "description": "Read the content of all backup repositories",
+    "examples": [
+        [
+            {
+                "name": "dokuwiki",
+                "path": "dokuwiki/dokuwiki1@cc7335d7-4d67-408c-8c35-42257667e51b",
+                "instance": "dokuwiki1",
+                "uuid": "cc7335d7-4d67-408c-8c35-42257667e51b",
+                "timestamp": 1644403745,
+                "repository_id": "e181c936-1bc3-5032-a809-d8b0551eebe9",
+                "repository_name": "B2 repo",
+                "repository_provider": "backblaze",
+                "repository_url": "b2:giacomons8"
+            }
+        ]
+    ]
+}

--- a/core/imageroot/var/lib/nethserver/cluster/actions/read-backup-snapshots/50read
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/read-backup-snapshots/50read
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import os
+import sys
+import json
+import agent
+import subprocess
+from datetime import datetime, timezone
+
+request = json.load(sys.stdin)
+
+# source
+repository = request['repository']
+path = request['path']
+
+rdb = agent.redis_connect()
+
+snapshots = []
+pret = agent.run_restic(rdb, repository, path, ["--workdir=/srv"], ["snapshots", "--json"], text=True, encoding='utf-8', stdout=subprocess.PIPE, check=True)
+for el in json.loads(pret.stdout):
+    # transform time like "2022-02-05T05:00:13.028068843Z" to a UTC timestamp
+    sec_index = el['time'].rfind('.')
+    # remove seconds and timezone before parsing
+    time = datetime.strptime(el['time'][0:sec_index],'%Y-%m-%dT%H:%M:%S')
+    time = int(time.replace(tzinfo=timezone.utc).timestamp())
+    snapshots.append({'timestamp': time, 'id': el['id']})
+
+print(json.dumps(snapshots))

--- a/core/imageroot/var/lib/nethserver/cluster/actions/read-backup-snapshots/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/read-backup-snapshots/validate-input.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "read-backup-snaphots input",
+    "$id": "http://schema.nethserver.org/cluster/read-backup-snapshots-input.json",
+    "description": "Input schema of the read-backup-snapshots action",
+    "examples": [
+        {
+            "repository": "48ce000a-79b7-5fe6-8558-177fd70c27b4",
+            "path": "dokuwiki/dokuwiki1@f5d24fcd-819c-4b1d-98ad-a1b2ebcee8cf"
+        }
+    ],
+    "type": "object",
+    "required": [
+        "repository",
+        "path"
+    ],
+    "properties": {
+        "repository": {
+            "title": "Repository ID",
+            "description": "Backup source repository",
+            "type": "string",
+            "minLength": 1
+        },
+        "path": {
+            "title": "Backup path",
+            "description": "Path of the backup in the source repository",
+            "type": "string",
+            "minLength": 1
+        }
+    }
+}

--- a/core/imageroot/var/lib/nethserver/cluster/actions/read-backup-snapshots/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/read-backup-snapshots/validate-output.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "read-backup-snapshots output",
+    "$id": "http://schema.nethserver.org/cluster/read-backup-snapshots-output.json",
+    "description": "Read the snaphost list of a given backup",
+    "examples": [
+        [
+            {
+                "timestamp": 1643964838,
+                "id": "a2a4cb238e4bd428900756376d4ff94009a8f487effe25c145bfaffa72406693"
+            },
+            {
+                "timestamp": 1644037213,
+                "id": "e993a67283eefa7a5d148284790e526f70f360788ed71e17e18406bc5a8a1185"
+            },
+            {
+                "timestamp": 1644123618,
+                "id": "4ea007b7770cfab125ab6035ae5371fe0e87464b8caa1607b2ced8c7e8732b4a"
+            },
+            {
+                "timestamp": 1644210013,
+                "id": "72a3cecc8b6acbd1610ebabd9aae1ac2b0b96864fa986a7437188036378e61ad"
+            },
+            {
+                "timestamp": 1644296416,
+                "id": "ebd99130107f282e47e7eb161de8fe14e0b832b7eacb04c9bf60761407e6081a"
+            }
+        ]
+
+    ]
+}

--- a/core/imageroot/var/lib/nethserver/cluster/actions/restore-cluster/20create
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/restore-cluster/20create
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import os
+import sys
+import json
+import gzip
+import agent
+import agent.tasks
+
+dump_file = './backup/dump.json.gz'
+
+if not os.path.isfile(dump_file):
+    print(f"Cluster backup '{dump_file}' not found", file=sys.stderr)
+    sys.exit(1)
+
+# load json from gzip file
+fgz = gzip.open(dump_file, mode='r')
+dump = json.loads(fgz.read().decode('utf-8'))
+fgz.close()
+
+create_retval = agent.tasks.run(
+    agent_id=f"cluster",
+    action="create-cluster",
+    data={
+        "network": dump["cluster"]["network"],
+        "endpoint": dump["vpn"]["endpoint"],
+        "listen_port": int(dump["vpn"]["listen_port"])
+    },
+    endpoint="redis://cluster-leader"
+)
+
+if create_retval['exit_code'] != 0:
+    print(agent.SD_ERR + f"There was an error during cluster-create. Check the subtask for details.", file=sys.stderr)
+    sys.exit(4)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/restore-cluster/30load
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/restore-cluster/30load
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import os
+import sys
+import json
+import gzip
+import agent
+
+dump_file = './backup/dump.json.gz'
+
+# load json from gzip file
+fgz = gzip.open(dump_file, mode='r')
+dump = json.loads(fgz.read().decode('utf-8'))
+fgz.close()
+
+rdb = agent.redis_connect(privileged=True)
+
+# Restore simple keys
+for config in ['network', 'ui_name']:
+    rdb.set(f'cluster/{config}', dump['cluster'][config])
+    del(dump['cluster'][config])
+
+# Restore favorites
+for f in dump['cluster']['favorites']:
+    rdb.sadd('cluster/favorites', f)
+del(dump['cluster']['favorites'])
+
+# Restore ldap user domains
+for d in dump['cluster']['user_domain']['ldap'].keys():
+    domain = dump['cluster']['user_domain']['ldap'][d]
+    rdb.hset(f'cluster/user_domain/ldap/{d}/conf', mapping=domain['conf'])
+    rdb.hset(f'cluster/user_domain/ldap/{d}/ui_names', mapping=domain['ui_names'])
+    for p in domain['providers']:
+        r = rdb.lpush(f'cluster/user_domain/ldap/{d}/providers', p)
+
+del(dump['cluster']['user_domain'])
+
+# Restore backup repositories
+for r in dump['cluster']['backup_repository'].keys():
+    rdb.hset(f'cluster/backup_repository/{r}', mapping=dump['cluster']['backup_repository'][r])
+
+# Restore backups, make sure backup_sequence is consistent
+max_backup = -1
+for b in dump['cluster']['backup'].keys():
+    max_backup = max(max_backup, int(b))
+    rdb.hset(f'cluster/backup/{b}', mapping=dump['cluster']['backup'][b])
+rdb.set('cluster/backup_sequence', max_backup)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/restore-modules/50restore_modules
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/restore-modules/50restore_modules
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import sys
+import os
+import agent.tasks
+import json
+import tempfile
+
+errors = 0
+request = json.load(sys.stdin)
+
+# source
+for module in request:
+    data = module
+    data.setdefault('snapshot', '')
+    data.setdefault('node', 1)
+    task = agent.tasks.run(agent_id = 'cluster', action = 'restore-module', data = data,  endpoint = "redis://cluster-leader")
+    errors = errors + task['exit_code']
+
+if errors > 0:
+    json.dumps(errors)
+    sys.exit(10+errors)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/restore-modules/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/restore-modules/validate-input.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "restore-module input",
+    "$id": "http://schema.nethserver.org/cluster/restore-module-input.json",
+    "description": "Input schema of the restore-module action",
+    "examples": [
+        [
+            {
+                "repository": "48ce000a-79b7-5fe6-8558-177fd70c27b4",
+                "path": "dokuwiki/dokuwiki1@f5d24fcd-819c-4b1d-98ad-a1b2ebcee8cf",
+                "snapshot": "",
+                "node": 1
+            }
+        ]
+    ],
+    "type": "array",
+    "items": {
+        "type": "object",
+        "required": [
+            "repository",
+            "path"
+        ],
+        "properties": {
+            "repository": {
+                "title": "Repository ID",
+                "description": "Backup source repository",
+                "type": "string",
+                "minLength": 1
+            },
+            "path": {
+                "title": "Backup path",
+                "description": "Path of the backup in the source repository",
+                "type": "string",
+                "minLength": 1
+            },
+            "snapshot": {
+                "title": "Snapshot ID",
+                "type": "string"
+            },
+            "node": {
+                "title": "Node ID",
+                "description": "Node identifier where the module has to be restored",
+                "type": "integer",
+                "minimum": 1
+            }
+        }
+    }
+}

--- a/core/imageroot/var/lib/nethserver/cluster/actions/retrieve-cluster-backup/10validate
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/retrieve-cluster-backup/10validate
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import os
+import sys
+import json
+import agent
+import base64
+import hashlib
+import tempfile
+import requests
+import subprocess
+
+errors = []
+
+agent.set_weight(os.path.basename(__file__), 0) # Validation step, no task progress at all
+request = json.load(sys.stdin)
+
+output_dir = './backup'
+os.makedirs(output_dir, exist_ok=True)
+tmp_pass = f'{output_dir}/passphrase.tmp'
+tmp_dump = f'{output_dir}/dump.tmp'
+
+utype = request['type']
+passphrase = request.get('password', '') 
+
+if passphrase:
+   # generate sha256 from passphrase and store to a temporary file
+    h = hashlib.new('sha256')
+    h.update(passphrase.encode('utf-8'))
+    with open(tmp_pass, 'w') as fp:
+        fp.write(h.hexdigest())
+else:
+    # use admin password from redis
+    rdb = agent.redis_connect(host='127.0.0.1', privileged = True)
+    admin = rdb.acl_getuser('admin')
+    rdb.close()
+    
+    fp = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    fp.write(admin['passwords'][0])
+    fp.close()
+    tmp_pass = fp.name
+
+
+if utype == "file":
+    # decode base64 and save to a temporary file
+    with open(tmp_dump, 'wb') as fp:
+        fp.write(base64.b64decode(request['file']))
+else:
+    # download file from URL
+    req = requests.get(request['url'], verify=request['tls_verify'], allow_redirects=True)
+    with open(tmp_dump, 'wb') as fp:
+        fp.write(req.content)
+
+# check if the file is a valid gpg file
+pf = subprocess.run(['file', '-b0', tmp_dump], env={"LANG": "C"}, capture_output = True)
+if not 'GPG' in pf.stdout.decode('ASCII'):
+    errors.append('not_valid_gpg_file')
+
+# skip check if not a valid gpg file
+if not errors:
+    # check if the passphrase is good
+    pg = subprocess.run(['gpg', '--batch', '-d', '--pinentry-mode', 'loopback', '--passphrase-file', tmp_pass, '-o', '/dev/null', tmp_dump])
+    if pg.returncode > 0:
+        errors.append('invalid_passphrase')
+
+# if everything is ok, keep temporary files to be reused on next step
+if errors:
+    try:
+        os.remove(tmp_dump)
+        os.remove(tmp_pass)
+    except:
+        pass
+    agent.set_status('validation-failed')
+    json.dump(errors, fp=sys.stdout)
+    sys.exit(2)
+

--- a/core/imageroot/var/lib/nethserver/cluster/actions/retrieve-cluster-backup/20save
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/retrieve-cluster-backup/20save
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import os
+import sys
+import json
+import gzip
+import agent
+import tempfile
+import subprocess
+
+errors = []
+output_dir = './backup'
+tmp_pass = f'{output_dir}/passphrase.tmp'
+tmp_dump = f'{output_dir}/dump.tmp'
+
+request = json.load(sys.stdin)
+
+# rename temporary files
+if os.path.isfile(tmp_pass):
+    os.rename(tmp_pass, f'{output_dir}/passphrase')
+os.rename(tmp_dump, f'{output_dir}/dump.json.gz.gpg')
+
+# make sure destination decrypted file doesn't already exists
+try:
+    os.remove(f'{output_dir}/dump.json.gz')
+except:
+    pass
+
+# decrypt the backup file
+# if the passhprase does not exists, use the sha256 of admin password
+pass_file = ""
+cmd = ['gpg', '--batch', '-d', '--pinentry-mode', 'loopback', '-o', f'{output_dir}/dump.json.gz', '--passphrase-file']
+
+# passhprase file has the precedence
+if os.path.isfile(f'{output_dir}/passphrase'):
+    pg = subprocess.run(cmd + [f'{output_dir}/passphrase', f'{output_dir}/dump.json.gz.gpg'], check = True)
+else:
+    rdb = agent.redis_connect(host='127.0.0.1', privileged = True)
+    admin = rdb.acl_getuser('admin')
+    rdb.close()
+
+    fp = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    fp.write(admin['passwords'][0])
+    fp.close()
+
+    try:
+        pg = subprocess.run(cmd + [fp.name, f'{output_dir}/dump.json.gz.gpg'], check = True)
+    finally:
+        os.remove(fp.name)
+
+# load json from gzip file
+fgz = gzip.open(f'{output_dir}/dump.json.gz', mode='r')
+dump = json.loads(fgz.read())
+fgz.close()
+
+result = {'timestamp': dump['timestamp'], 'cluster': dump['cluster']['ui_name'], 'modules': len(dump['modules']), "vpn": dump['vpn']['endpoint'], 'domains': len(dump['cluster']['user_domain']), 'backup_repositories': len(dump['cluster']['backup_repository'])}
+
+json.dump(result, fp=sys.stdout)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/retrieve-cluster-backup/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/retrieve-cluster-backup/validate-input.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "retrieve-cluster-backup input",
+    "$id": "http://schema.nethserver.org/cluster/retrieve-cluster-backup-input.json",
+    "description": "Retrieve cluster backup from base64 field or download it from a HTTP URL",
+    "examples": [
+        {
+            "type": "file",
+            "password": "mypassword",
+            "file": "jA0ECQMC2c...94FL/8y2KV"
+        },
+        {
+            "type": "url",
+            "password": "mypassword",
+            "url": "https://myserver.org/dump.json.gz.gpg",
+            "tls_verify": true
+        }
+    ],
+    "type": "object",
+    "required": [
+        "type",
+        "password"
+    ],
+    "if": {
+        "properties": { "type": { "const": "url" } }
+    },
+     "then": {
+        "required": ["url", "tls_verify"]
+    },
+    "else": {
+        "required": ["file"]
+    },
+    "properties": {
+        "password": {
+            "title": "GPG passhprase",
+            "description": "Passhprase for backup encryption",
+            "type": "string"
+        },
+        "type": {
+            "title": "Select backup retrieve method",
+            "description": "Choose if the backup is uploaded inside the payload or should be downloaded from a URL. Can be 'file' or 'url'",
+            "type": "string"
+        },
+        "url": {
+            "title": "HTTP/ss URL",
+            "description": "HTTP/s URL of remote backup",
+            "type": "string",
+            "format": "uri"
+        },
+        "tls_verify": {
+            "title": "TLS verfication flag",
+            "description": "Enable or disable TLS verification",
+            "type": "boolean"
+        },
+        "file": {
+            "title": "Backup file",
+            "description": "Backup file encoded with base64",
+            "type": "string",
+            "contentEncoding": "base64",
+            "contentMediaType": "application/octet-stream"
+        }
+    }
+}

--- a/core/imageroot/var/lib/nethserver/cluster/actions/retrieve-cluster-backup/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/retrieve-cluster-backup/validate-output.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "retrieve-cluster-backup output",
+    "$id": "http://schema.nethserver.org/cluster/rstrieve-cluster-backup-output.json",
+    "description": "Return info from cluster backup",
+    "examples": [
+        {
+            "timestamp": 1644230044,
+            "cluster": "mycluster1",
+            "modules": 2,
+            "vpn": "cs1.leader.cluster0.gs.nethserver.net:55820",
+            "domains": 1,
+            "backup_repositories": 1
+        }
+    ],
+    "type": "object",
+    "required": [
+        "timestamp",
+        "cluster",
+        "vpn",
+        "domains",
+        "backup_repositories"
+    ],
+    "properties": {
+        "timestamp": {
+            "title": "Backup timestamp",
+            "description": "Date and time of the backup, timestamp in UTC timezone",
+            "type": "integer"
+        },
+        "cluster": {
+            "title": "Cluster label",
+            "description": "User defined cluster label, can be empty'",
+            "type": "string"
+        },
+        "vpn": {
+            "title": "VPN endpoint",
+            "description": "Original VPN host and port",
+            "type": "string"
+        },
+        "modules": {
+            "title": "Number of installed modules",
+            "description": "Number of non-core modules installed in the original cluster",
+            "type": "integer"
+        },
+        "domains": {
+            "title": "Number of domains",
+            "description": "Number of user domains configured in the original cluster",
+            "type": "integer"
+        },
+        "backup_repositories": {
+            "title": "Number of backup repositories",
+            "description": "Number of backup repositories configured in the original cluster",
+            "type": "integer"
+        }
+    }
+}


### PR DESCRIPTION
# Changes

- Add `/usr/local/agent/bin/cluster-backup` binary used by `download-cluster-backup` cluster API
- Add `retrieve-cluster-backup` cluster API
- Add `restore-cluster` cluster API
- Add `restore-modules` cluster API
- Add `read-backup-repositories` cluster API
- Add `read-backup-snapshots` cluster API

Disaster recovery flow: 
1. `retrieve-cluster-backup`: download or upload the encrypted and compressed JSON dump
2. `restore-cluster`: create the cluster with data from the dump
3. `read-backup-repositories`: search for modules inside the backup
4. `restore-modules`: restore the selected modules


## download-cluster-backup

Dump backup configuration in JSON format. The dump is compressed using `gzip` and finally encrypted using `gpg`.

Execute a backup:
```
api-cli run download-cluster-backup
```

Response example:
```json
{"path": "ad40cfe5342d731cc4423daefc535e9489666a39264cf8659bc8a4a0e6c4f32e/dump.json.gz.gpg"}
```



The backup is encrypted with the passphrase contained inside `/var/lib/nethserver/cluster/state/backup/passphrase`.
The passphrase is a SHA256 sum.
If the above file is empty, the `cluster-backup` will use the SHA256 of the admin password from redis.


Conventions:
- the dump contains a `version` field that an be used to handle multiple type of backups during the restore
- the JSON `cluster` field mimic redis namespaces, `vpn` field contains Wireguard configuration, `modules` contains a map between module instances, labels and backups
- redis fields with set type are converted to lists

Generated `backup.gz` should be quite small, on a test machine, it is ~1.1KB.

Example:
```json
{
  "version": "1",
  "timestamp": 1644228067,
  "modules": {
    "cc7335d7-4d67-408c-8c35-42257667e51b": {
      "backups": [
        "1"
      ]
    }
  },
  "vpn": {
    "endpoint": "cs1.leader.cluster0.gs.nethserver.net:55820",
    "listen_port": "55820",
    "destinations": ""
  },
  "cluster": {
    "repository": {
      "default": {
        "url": "https://raw.githubusercontent.com/NethServer/ns8-repomd/repomd/",
        "status": "1",
        "testing": "1"
      }
    },
    "backup": {
      "1": {
        "enabled": "1",
        "repository": "e181c936-1bc3-5032-a809-d8b0551eebe9",
        "schedule_hint": "{\"custom\": \"\", \"interval\": \"daily\", \"minute\": \"0\", \"monthDay\": \"1\", \"time\": \"00:00\", \"weekDay\": \"sunday\"}",
        "retention": "5",
        "name": "Backup to B2 repo",
        "schedule": "*-*-* 00:00:00"
      }
    },
    "backup_repository": {
      "e181c936-1bc3-5032-a809-d8b0551eebe9": {
        "url": "b2:giacomons8",
        "password": "d49784aa7a9a22885354aaaeb8cbe581df5ec4f53280xxxxxxxxxxxxxxxxxxxxx",
        "name": "B2 repo",
        "provider": "backblaze",
        "b2_account_id": "003648087fdefxxxxxxxxxxx",
        "b2_account_key": "K003Frjo2poKxxxxxxxxxxxxxxxxxx"
      }
    },
    "user_domain": {
      "ldap": {
        "ns.test": {
          "conf": {
            "schema": "rfc2307",
            "bind_dn": "cn=test",
            "bind_password": "mypass",
            "base_dn": "dc=test",
            "tls": "on",
            "tls_verify": "on"
          },
          "providers": [
            "ldap.ns.test:389"
          ],
          "ui_names": {
            "ldap.ns.test:389": "myprovider"
          }
        }
      }
    },
    "network": "10.5.4.0/24",
    "ui_name": "mycluster1",
    "favorites": [
      "dokuwiki1"
    ]
  }
}
```

Not saved:
- UI users, roles and passwords
- Audit logs from SQLite database
- Traefik certificates

## retrieve-cluster-backup

The backup can be loaded inside the cluster from a URL or UI upload.

Retrieve backup from URL.
If `password` is empty, try to decode with sha254 of `admin` user from Redis, otherwise use the given password:
```
api-cli run retrieve-cluster-backup --data '{"type": "url", "url": "https://myserver/dump.json.gz.gpg", "tls_verify": true, "password": ""}'
```

## restore-cluster

After the backup has been retrieved, just execute:
```
api-cli run restore-cluster
```

## read-backup-repositories

List all backups inside all all backup repositories:
```
api-cli run read-all-backup-repositories
```

## read-backup-snapshots

List all snapshots inside a given backup. Example:
```
api-cli run read-backup-snapshots --data '{"path": "dokuwiki/dokuwiki1@cc7335d7-4d67-408c-8c35-42257667e51b", "repository": "e181c936-1bc3-5032-a809-d8b0551eebe9"}' 
```

Response example:
```
[
  {
    "timestamp": 1643964838,
    "id": "a2a4cb238e4bd428900756376d4ff94009a8f487effe25c145bfaffa72406693"
  },
  {
    "timestamp": 1644037213,
    "id": "e993a67283eefa7a5d148284790e526f70f360788ed71e17e18406bc5a8a1185"
  },
  {
    "timestamp": 1644123618,
    "id": "4ea007b7770cfab125ab6035ae5371fe0e87464b8caa1607b2ced8c7e8732b4a"
  },
  {
    "timestamp": 1644210013,
    "id": "72a3cecc8b6acbd1610ebabd9aae1ac2b0b96864fa986a7437188036378e61ad"
  },
  {
    "timestamp": 1644296416,
    "id": "ebd99130107f282e47e7eb161de8fe14e0b832b7eacb04c9bf60761407e6081a"
  }
]
```

## restore-modules

Restore a list of modules, example:
```
api-cli run bulk-restore-modules --data '[{"path": "dokuwiki/dokuwiki1@cc7335d7-4d67-408c-8c35-42257667e51b", "repository": "e181c936-1bc3-5032-a809-d8b0551eebe9"}]' 
```