### PR TITLE
install.sh: restart journald

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -39,6 +39,11 @@ else
     exit 1
 fi
 
+if [[ $(journalctl --output cat -n 1) == "" ]]; then
+    echo "Journal is empty, attempting a systemd-journald restart:"
+    systemctl restart systemd-journald.service
+fi
+
 echo "Set kernel parameters:"
 sysctl -w net.ipv4.ip_unprivileged_port_start=23 -w user.max_user_namespaces=28633 -w net.ipv4.ip_forward=1 | tee /etc/sysctl.d/80-nethserver.conf
 
@@ -190,9 +195,6 @@ add-user --role owner --password "${ADMIN_PASSWORD:-Nethesis,1234}" admin
 
 echo "Enable the events gateway for the node agent:"
 systemctl enable --now eventsgw@node
-
-echo "Restart systemd-journald:"
-systemctl restart systemd-journald
 
 cat - <<EOF
 

--- a/core/install.sh
+++ b/core/install.sh
@@ -191,6 +191,9 @@ add-user --role owner --password "${ADMIN_PASSWORD:-Nethesis,1234}" admin
 echo "Enable the events gateway for the node agent:"
 systemctl enable --now eventsgw@node
 
+echo "Restart systemd-journald:"
+systemctl restart systemd-journald
+
 cat - <<EOF
 
 NethServer 8 Scratchpad


### PR DESCRIPTION
Sometimes, `journalctl` is not correctly displaying the messages.

This is has been tested on a Debian 11 running on Digital Ocean:
```
# journalctl 
No journal files were found.
-- No entries --
```

The fix:
```
# systemctl restart systemd-journalctl
```

Outcome:
```
# journalctl 
-- Journal begins at Fri 2022-02-11 13:15:51 UTC, ends at Fri 2022-02-11 13:15:51 UTC. --
Feb 11 13:15:51 debian-s-1vcpu-1gb-intel-lon1-01 systemd[1]: Stopping Journal Service...
Feb 11 13:15:51 debian-s-1vcpu-1gb-intel-lon1-01 systemd-journald[222]: Received SIGTERM from PID 1 (systemd).
Feb 11 13:15:51 debian-s-1vcpu-1gb-intel-lon1-01 systemd[1]: systemd-journald.service: Succeeded.
...
```