### PR TITLE
add-backup-repository: reuse admin sha256 pass

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-backup-repository/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-backup-repository/50update
@@ -25,7 +25,6 @@ import sys
 import json
 import uuid
 import agent
-import hashlib
 import cluster.backup
 
 request = json.load(sys.stdin)
@@ -38,10 +37,9 @@ rid = str(uuid.uuid5(uuid.NAMESPACE_URL, url))
 if request['password']:
     password = request['password']
 else:
-    # Generate random password for backup encryption
-    m = hashlib.sha256()
-    m.update(uuid.uuid4().bytes)
-    password = m.hexdigest()
+    # Use admin sha256 password
+    admin = rdb.acl_getuser('admin')
+    password = admin['passwords'][0]
 
 if request['name']:
     name = request['name']


### PR DESCRIPTION
Simplify the flow for the admin: do not generate a random password, but reuse the sha of the admin user.
If the user will lose the cluster configuration, there are changes the backups can be still recovered.