### PR TITLE
Add module flags

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
@@ -124,7 +124,8 @@ def list_installed(rdb):
         logo = logos.get(image) or ''
         if url not in installed.keys():
             installed[url] = []
-        installed[url].append({ 'id': vars["MODULE_ID"], 'ui_name': module_ui_name, 'node': vars['NODE_ID'], 'digest': vars["IMAGE_DIGEST"], 'source': url, 'version': tag, 'logo': logo, 'module': image })
+        flags = list(rdb.smembers(f'module/{vars["MODULE_ID"]}/flags')) or []
+        installed[url].append({ 'id': vars["MODULE_ID"], 'ui_name': module_ui_name, 'node': vars['NODE_ID'], 'digest': vars["IMAGE_DIGEST"], 'source': url, 'version': tag, 'logo': logo, 'module': image, 'flags': flags})
 
     return installed
 

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
@@ -85,6 +85,11 @@ if 'org.nethserver.images' in inspect_labels:
 else:
     extra_images = []
 
+if 'org.nethserver.flags' in inspect_labels:
+    flags = inspect_labels['org.nethserver.flags'].split()
+else:
+    flags = []
+
 # Increment the module sequence for image_id (e.g. traefik => traefik1)
 module_id = image_id + str(rdb.incr(f'cluster/module_sequence/{image_id}'))
 
@@ -195,6 +200,14 @@ for userk in rdb.scan_iter('roles/*'):
     user_auths = rdb.hgetall(userk)
     if 'cluster' in user_auths and user_auths['cluster'] == 'owner':
         cluster.grants.alter_user(rdb, user=userk[len('roles/'):], revoke=False, role='owner', on_clause=f'module/{module_id}')
+
+# Save flags inside redis
+rdb.sadd(f'module/{module_id}/flags', *flags)
+# Map rootfull label to a flag
+if is_rootfull:
+    rdb.sadd(f'module/{module_id}/flags', 'rootfull')
+else:
+    rdb.sadd(f'module/{module_id}/flags', 'rootless')
 
 json.dump({
     "module_id": module_id,

--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-backups/50list
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-backups/50list
@@ -71,12 +71,11 @@ for mbackup in rdb.scan_iter('module/*/backups'):
 
 unconfigured_instances = []
 
-# XXX module blacklist -- this should be implemented elsewhere:
-skip_modules = ["promtail", "loki", "ldapproxy", "traefik"]
-
+# The user will not be warned if the following modules have the `no_data_backup` flag.
 for xins in rdb.scan_iter('module/*/environment'):
     mid = xins.removesuffix('/environment').removeprefix('module/')
-    if [mskip for mskip in skip_modules if mid.startswith(mskip)]:
+    flags = rdb.smembers(f'module/{mid}/flags')
+    if 'no_data_backup' in flags:
         continue
     if not mid in configured_instances:
         unconfigured_instances.append({

--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-installed-modules/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-installed-modules/validate-output.json
@@ -13,7 +13,8 @@
           "source": "ghcr.io/nethserver/traefik",
           "version": "latest",
           "logo": "https://raw.githubusercontent.com/NethServer/ns8-repomd/repomd/dokuwiki/logo.png",
-          "module": "traefik"
+          "module": "traefik",
+          "flags": ["no_data_backup", "core_module"]
         }
       ],
       "ghcr.io/nethserver/dokuwiki": [
@@ -24,7 +25,8 @@
           "source": "ghcr.io/nethserver/dokuwiki",
           "version": "0.0.1-alpha1",
           "logo": "https://raw.githubusercontent.com/NethServer/ns8-repomd/repomd/dokuwiki/logo.png",
-          "module": "dokuwiki"
+          "module": "dokuwiki",
+	  "flags": []
         },
         {
           "id": "dokuwiki1",
@@ -33,7 +35,8 @@
           "source": "ghcr.io/nethserver/dokuwiki",
           "version": "0.0.1-alpha1",
           "logo": "https://raw.githubusercontent.com/NethServer/ns8-repomd/repomd/dokuwiki/logo.png",
-          "module": "dokuwiki"
+          "module": "dokuwiki",
+	  "flags": []
         }
       ]
     }
@@ -72,6 +75,13 @@
           "module": {
             "type": "string",
             "description": "Name of the module of the instance"
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "List of flags from org.nethserver.flags image label"
           }
         },
         "required": [
@@ -81,7 +91,8 @@
           "source",
           "version",
           "logo",
-          "module"
+          "module",
+	  "flags"
         ]
       }
     }

--- a/ldapproxy/build-image.sh
+++ b/ldapproxy/build-image.sh
@@ -11,6 +11,7 @@ buildah add "${container}" imageroot /imageroot
 buildah add "${container}" ui /ui
 buildah config \
     --label='org.nethserver.tcp-ports-demand=8' \
+    --label='org.nethserver.flags=core_module no_data_backup' \
     --label='org.nethserver.images=docker.io/library/nginx:1.20-alpine' \
     --entrypoint=/ "${container}"
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/loki/build-image.sh
+++ b/loki/build-image.sh
@@ -12,6 +12,7 @@ buildah add "${container}" ui /ui
 buildah config --entrypoint=/ \
 	--label="org.nethserver.images=docker.io/traefik:v2.4 docker.io/grafana/loki:2.2.1" \
 	--label="org.nethserver.tcp-ports-demand=1" \
+    --label='org.nethserver.flags=core_module' \
 	"${container}"
 buildah commit "${container}" "${repobase}/${reponame}"
 images+=("${repobase}/${reponame}")

--- a/promtail/build-image.sh
+++ b/promtail/build-image.sh
@@ -11,6 +11,7 @@ buildah add "${container}" imageroot /imageroot
 buildah add "${container}" ui /ui
 buildah config --entrypoint=/ "${container}"
 buildah config --label="org.nethserver.rootfull=1" \
+    --label="org.nethserver.flags=core_module no_data_backup" \
 	--label="org.nethserver.images=docker.io/grafana/promtail:2.2.1" \
 	"${container}"
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/samba/build-image.sh
+++ b/samba/build-image.sh
@@ -41,6 +41,7 @@ buildah config \
     --label 'org.nethserver.rootfull=1' \
     --label "org.nethserver.images=ghcr.io/nethserver/samba-dc:${IMAGETAG:-latest}" \
     --label 'org.nethserver.authorizations=ldapproxy@node:accountprovider cluster:accountprovider' \
+    --label 'org.nethserver.flags=core_module account_provider' \
     --entrypoint=/ "${container}"
 buildah commit "${container}" "${repobase}/${reponame}"
 images+=("${repobase}/${reponame}")


### PR DESCRIPTION
Flags are a new image label named `org.nethserver.flags`.
It contains a space separated list of flags with known values.
Flags can be used to mark modules inside the UI and eventually enforce module behavior.
Currently available flags are:    
- `core_module`
- `account_provider`
- `no_data_backup`
- `rootless` (calculated from `org.nethserver.rootfull` label)
- `rootfull` (calculated from `org.nethserver.rootfull` label)
