### PR TITLE
Fix Samba restore preconditions

### DIFF
--- a/samba/imageroot/actions/restore-module/02samba_device
+++ b/samba/imageroot/actions/restore-module/02samba_device
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import sys
+import json
+import agent
+import os
+
+agent.set_weight(os.path.basename(__file__), 0) # Pre-validation step, no task progress at all
+
+request = json.load(sys.stdin)
+
+original_environment = request['environment']
+ipaddress = original_environment['IPADDRESS']
+
+# Ensure a network device with the IPADDRESS exists
+os.environ['IPADDRESS'] = ipaddress
+agent.run_helper('samba-network', 'up').check_returncode()

--- a/samba/imageroot/bin/expand_dns_forwarder
+++ b/samba/imageroot/bin/expand_dns_forwarder
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import dns.resolver
+import os
+import sys
+
+# Raise error if not nameservers are found
+rsv = dns.resolver.Resolver()
+
+# Send any output to the hosts file
+with open('dns_forwarder.expand','w') as fp:
+    print(" ".join(rsv.nameservers), file=fp)
+
+os.rename('dns_forwarder.expand', 'dns_forwarder')

--- a/samba/imageroot/bin/samba-network
+++ b/samba/imageroot/bin/samba-network
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+set -e
+
+function interface_exists()
+{
+    if [[ -e "/sys/class/net/${MODULE_ID}" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function cmd_up()
+{
+    if [[ -n $(ip -o address show to "${IPADDRESS}/32" up) ]]; then
+        return # nothing to do, the IP address is available
+    fi
+
+    if interface_exists; then
+        return
+    fi
+
+    echo "Configuring dummy network interface ${MODULE_ID}..."
+    ip link add name "${MODULE_ID}" type dummy
+    ip addr replace "${IPADDRESS}/32" dev "${MODULE_ID}"
+    ip link set dev "${MODULE_ID}" up
+}
+
+function cmd_down()
+{
+    if ! interface_exists; then
+        return
+    fi
+
+    echo "Removing dummy network interface ${MODULE_ID}..."
+    ip link del "${MODULE_ID}"
+    while interface_exists; do
+        # Wait until the device disappears
+        sleep 0.4
+    done
+}
+
+subcommand=${1:?missing argument}
+
+if [[ ${subcommand} == "up" ]]; then
+    cmd_up
+elif [[ ${subcommand} == "down" ]]; then
+    cmd_down
+fi

--- a/samba/imageroot/etc/samba-dc.service
+++ b/samba/imageroot/etc/samba-dc.service
@@ -15,7 +15,8 @@ TimeoutStopSec=70
 SuccessExitStatus=127
 ExecStartPre=/bin/rm -f %t/%N.pid %t/%N.cid
 # Workaround SELinux access denied:
-ExecStartPre=-python3 /var/lib/nethserver/%N/bin/expand_resolv_conf
+ExecStartPre=-runagent -m %N expand_resolv_conf
+ExecStartPre=runagent -m %N samba-network up
 ExecStart=/usr/bin/podman run \
     --dns=none \
     --no-hosts \
@@ -37,6 +38,7 @@ ExecStart=/usr/bin/podman run \
     ${SAMBA_DC_IMAGE} run-dc
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%N.cid -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%N.cid
+ExecStopPost=runagent -m %N samba-network down
 PIDFile=%t/%N.pid
 WorkingDirectory=/var/lib/nethserver/%N/state
 SyslogIdentifier=%N

--- a/samba/imageroot/etc/samba-dc.service
+++ b/samba/imageroot/etc/samba-dc.service
@@ -16,6 +16,7 @@ SuccessExitStatus=127
 ExecStartPre=/bin/rm -f %t/%N.pid %t/%N.cid
 # Workaround SELinux access denied:
 ExecStartPre=-runagent -m %N expand_resolv_conf
+ExecStartPre=runagent -m %N expand_dns_forwarder
 ExecStartPre=runagent -m %N samba-network up
 ExecStart=/usr/bin/podman run \
     --dns=none \
@@ -32,6 +33,7 @@ ExecStart=/usr/bin/podman run \
     --replace --name=%N \
     --volume=%N-data:/var/lib/samba:Z \
     --volume=%N-config:/etc/samba:z \
+    --volume=./dns_forwarder:/etc/dns_forwarder:z \
     --volume=./hosts:/etc/hosts:z \
     --volume=./resolv.conf:/etc/resolv.conf:z \
     --volume=./krb5.conf:/etc/krb5.conf:z \


### PR DESCRIPTION
If Samba is restored on a different hardware:
1. the IPADDRESS could be missing
2. dns forwarder may be different

This PR ensures that IPADDRESS can always be found, by creating a dummy network interface on the fly, if requested.

Furthermore, whenever samba starts, the "dns forwarder" Samba option is set to reflect the nameserver list defined in the host /etc/resolv.conf