### PR TITLE
Use official Samba backup/restore tool

### DIFF
--- a/samba/build-image.sh
+++ b/samba/build-image.sh
@@ -13,7 +13,7 @@ if ! buildah inspect --type container "${container}" &>/dev/null; then
     buildah run "${container}" -- bash <<EOF
 set -e
 apt-get update
-apt-get -y install samba winbind krb5-user iputils-ping
+apt-get -y install samba winbind krb5-user iputils-ping bzip2
 apt-get clean
 find /var/lib/apt/lists/ -type f -delete
 EOF

--- a/samba/imageroot/actions/restore-module/06copyenv
+++ b/samba/imageroot/actions/restore-module/06copyenv
@@ -40,8 +40,23 @@ for evar in [
 
 # The "samba-tool domain backup restore" procedure expects a new DC hostname,
 # a new one must be provided, now!
-dcname, _ = original_environment['HOSTNAME'].split('.', 1) # short hostname
-dcname = 'o' + dcname[14::-1] # "o" + reversed short hostname, trimmed at 14 chars max
-agent.set_env('HOSTNAME', dcname + '.' + original_environment['REALM'].lower())
+def generate_new_dc_name(name):
+    if len(name) > 1 and (name[-2].isnumeric() and name[-1].isalpha()):
+        newname = name[:-2] + \
+                alphabet[(1 + alphabet.find(name[-2])) % len(alphabet)] + \
+                alphabet[(1 + alphabet.find(name[-1])) % len(alphabet)]
+
+    elif name[-1].isnumeric():
+        newname = name + 'r'
+    else:
+        newname = name + '0'
+
+    if len(newname) > 14:
+        newname = newname[:13] + newname[-2:]
+
+    return newname
+
+hname, _ = original_environment['HOSTNAME'].split('.', 1) # short hostname
+agent.set_env('HOSTNAME', generate_new_dc_name(hname) + '.' + original_environment['REALM'].lower())
 
 agent.dump_env()

--- a/samba/imageroot/actions/restore-module/06copyenv
+++ b/samba/imageroot/actions/restore-module/06copyenv
@@ -32,11 +32,16 @@ for evar in [
         'PROVISION_TYPE',
         'NBDOMAIN',
         'REALM',
-        'HOSTNAME',
         'IPADDRESS',
         'SVCUSER',
         'SVCPASS',
     ]:
     agent.set_env(evar, original_environment[evar])
+
+# The "samba-tool domain backup restore" procedure expects a new DC hostname,
+# a new one must be provided, now!
+dcname, _ = original_environment['HOSTNAME'].split('.', 1) # short hostname
+dcname = 'o' + dcname[14::-1] # "o" + reversed short hostname, trimmed at 14 chars max
+agent.set_env('HOSTNAME', dcname + '.' + original_environment['REALM'].lower())
 
 agent.dump_env()

--- a/samba/imageroot/actions/restore-module/60resume_state
+++ b/samba/imageroot/actions/restore-module/60resume_state
@@ -24,12 +24,26 @@ exec 1>&2
 set -e
 
 echo "Resume Samba DC state:"
-podman run --privileged --interactive --workdir=/srv --rm --entrypoint=[] \
-    --volume="${MODULE_ID}-data":/srv \
+podman run --hostname="${HOSTNAME}" --privileged --interactive --workdir=/var/lib/samba --rm --entrypoint=[] \
+    --volume="${MODULE_ID}-config":/etc/samba \
+    --volume="${MODULE_ID}-data":/var/lib/samba \
     "${SAMBA_DC_IMAGE}" bash -s <<'EOF'
-find . -type f -name '*.[l,t]db.bak' -print0 | while read -d $'\0' elem ; do
-    mv -vf "${elem}" "${elem%.bak}"
-done
+
+set -e
+nbname=$(hostname -s | tr "[a-z]" "[A-Z]")
+
+samba-tool domain backup restore \
+    --backup-file=backup/samba-backup.tar.bz2 \
+    --targetdir=restore \
+    --newservername=${nbname}
+
+sed "s/netbios name = .*/netbios name = ${nbname}/" restore/etc/smb.conf.orig | tee /etc/samba/smb.conf
+
+rm -rvf private sysvol
+mv -v restore/private .
+mv -v restore/state/sysvol .
+rm -rvf restore backup
+
 EOF
 
 # Enable and start the NSDC service

--- a/samba/imageroot/bin/module-cleanup-state
+++ b/samba/imageroot/bin/module-cleanup-state
@@ -21,4 +21,4 @@
 #
 
 echo "Cleaning up Samba DC state:"
-podman exec -w /var/lib/samba/ -i "${MODULE_ID}" find . -name "*.bak" -print -delete
+podman exec -w /var/lib/samba/ -i "${MODULE_ID}" rm -rvf backup

--- a/samba/imageroot/bin/module-dump-state
+++ b/samba/imageroot/bin/module-dump-state
@@ -22,5 +22,9 @@
 
 echo "Dumping Samba DC state to disk:"
 podman exec -w /var/lib/samba -i "${MODULE_ID}" bash -s <<'EOF'
-find . -name "*.[t,l]db" -a -not -name netlogon_creds_cli.tdb -print0 -fprint /dev/stderr | xargs -0 -- tdbbackup
+set -e
+rm -rvf backup
+samba-tool domain backup offline --targetdir=backup
+cd backup
+mv -v samba-backup-*.tar.bz2 samba-backup.tar.bz2
 EOF

--- a/samba/imageroot/etc/state-include.conf
+++ b/samba/imageroot/etc/state-include.conf
@@ -4,11 +4,4 @@
 # Restic --files-from: https://restic.readthedocs.io/en/stable/040_backup.html#including-files
 #
 volumes/config
-volumes/data/private/krb5.conf
-volumes/data/private/tls
-volumes/data/private/spn_update_list
-volumes/data/private/encrypted_secrets.key
-volumes/data/sysvol
-volumes/data/*.bak
-volumes/data/*/*.bak
-volumes/data/*/*/*.bak
+volumes/data/backup


### PR DESCRIPTION
The Samba official restore procedure requires that a new DC host name is
assigned. The host name is generated from the old one, it should be
random enough to avoid collisions.