### PR TITLE
Refactoring of journal `CONTAINER_TAG` field

### DIFF
--- a/core/imageroot/usr/local/agent/actions/create-module/10log_tag
+++ b/core/imageroot/usr/local/agent/actions/create-module/10log_tag
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+exec 1>&2
+set -e
+
+if [[ $(id -u) != 0 ]]; then
+    mkdir -p ${HOME}/.config/containers/containers.conf.d
+    cat <<EOF > ${HOME}/.config/containers/containers.conf.d/log_tag.conf
+[containers]
+log_tag = "${MODULE_ID}"
+EOF
+fi

--- a/core/tests/10_cluster_sanity/70_check_rootless_modules_logs.robot
+++ b/core/tests/10_cluster_sanity/70_check_rootless_modules_logs.robot
@@ -1,0 +1,21 @@
+*** Settings ***
+Library           SSHLibrary
+
+*** Test Cases ***
+Check logs for ldapproxy1
+    ${output}  ${rc} =    Execute Command  logcli query -q --no-labels '{job="systemd-journal"} | json | CONTAINER_TAG="ldapproxy1" | line_format "{{.nodename}} --> {{.MESSAGE}}"'
+    ...    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Be Equal As Strings    ${output}    ''
+
+Check logs for loki1
+    ${output}  ${rc} =    Execute Command  logcli query -q --no-labels '{job="systemd-journal"} | json | CONTAINER_TAG="loki1" | line_format "{{.nodename}} --> {{.MESSAGE}}"'
+    ...    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Be Equal As Strings    ${output}    ''
+
+Check logs for traefik1
+    ${output}  ${rc} =    Execute Command  logcli query -q --no-labels '{job="systemd-journal"} | json | CONTAINER_TAG="traefik1" | line_format "{{.nodename}} --> {{.MESSAGE}}"'
+    ...    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Be Equal As Strings    ${output}    ''

--- a/core/tests/10_cluster_sanity/71_check_rootfull_modules_logs.robot
+++ b/core/tests/10_cluster_sanity/71_check_rootfull_modules_logs.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Library           SSHLibrary
+
+*** Test Cases ***
+Check logs for promtail1
+    ${output}  ${rc} =    Execute Command  logcli query -q --no-labels '{job="systemd-journal"} | json | CONTAINER_TAG="promtail1" | line_format "{{.nodename}} --> {{.MESSAGE}}"'
+    ...    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Be Equal As Strings    ${output}    ''
+
+Check logs for samba1
+    ${output}  ${rc} =    Execute Command  logcli query -q --no-labels '{job="systemd-journal"} | json | CONTAINER_TAG="samba1" | line_format "{{.nodename}} --> {{.MESSAGE}}"'
+    ...    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Be Equal As Strings    ${output}    ''

--- a/ldapproxy/imageroot/systemd/user/ldapproxy.service
+++ b/ldapproxy/imageroot/systemd/user/ldapproxy.service
@@ -17,7 +17,6 @@ ExecStart=/usr/bin/podman run \
     --cidfile=%t/ldapproxy.ctr-id \
     --cgroups=no-conmon \
     --network=host \
-    --log-opt=tag=%u \
     --replace --name=%N \
     --volume=./nginx:/srv:z \
     ${NGINX_IMAGE} nginx -g "daemon off;" -c /srv/nginx.conf

--- a/loki/imageroot/systemd/user/loki-server.service
+++ b/loki/imageroot/systemd/user/loki-server.service
@@ -14,7 +14,6 @@ ExecStart=/usr/bin/podman run \
     --cidfile=%t/loki-server.ctr-id \
     --cgroups=no-conmon \
     --pod-id-file %t/loki.pod-id \
-    --log-opt=tag=%u-server \
     --replace \
     --name=%N \
     --volume=loki-server-data:/loki \

--- a/loki/imageroot/systemd/user/traefik.service
+++ b/loki/imageroot/systemd/user/traefik.service
@@ -15,7 +15,6 @@ ExecStart=/usr/bin/podman run \
     --cidfile=%t/traefik.ctr-id \
     --cgroups=no-conmon \
     --pod-id-file %t/loki.pod-id \
-    --log-opt=tag=%u-traefik \
     --replace \
     --name=%N \
     --volume=./traefik.yaml:/etc/traefik.yaml:Z \

--- a/promtail/imageroot/promtail.service
+++ b/promtail/imageroot/promtail.service
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/podman run \
     --cidfile %t/%N.cid \
     --cgroups=no-conmon \
     --replace \
-    --log-opt=tag=%N \
+    --log-opt=tag=${MODULE_ID} \
     --name %N \
     --privileged \
     --network=host \

--- a/samba/imageroot/actions/configure-module/40start_provisioning
+++ b/samba/imageroot/actions/configure-module/40start_provisioning
@@ -41,7 +41,7 @@ adminpass="${input[1]:?}"
     --env SVCPASS \
     --env SVCUSER \
     --hostname=${HOSTNAME:?} \
-    --log-opt=tag=${MODULE_ID:?}-provision \
+    --log-opt=tag=${MODULE_ID:?} \
     --rm --name=${MODULE_ID}-provision \
     --volume=${MODULE_ID}-data:/var/lib/samba:Z \
     --volume=${MODULE_ID}-config:/etc/samba:z \

--- a/samba/imageroot/etc/samba-dc.service
+++ b/samba/imageroot/etc/samba-dc.service
@@ -29,7 +29,7 @@ ExecStart=/usr/bin/podman run \
     --cap-drop=all \
     --cap-add=chown,dac_override,dac_read_search,fowner,setgid,setuid,sys_admin \
     --hostname=${HOSTNAME} \
-    --log-opt=tag=samba-dc \
+    --log-opt=tag=${MODULE_ID} \
     --replace --name=%N \
     --volume=%N-data:/var/lib/samba:Z \
     --volume=%N-config:/etc/samba:z \

--- a/traefik/imageroot/systemd/user/traefik.service
+++ b/traefik/imageroot/systemd/user/traefik.service
@@ -13,7 +13,6 @@ ExecStart=/usr/bin/podman run \
     --cidfile=%t/traefik.ctr-id \
     --cgroups=no-conmon \
     --network=host \
-    --log-opt=tag=%u \
     --replace --name=%N \
     --volume=traefik-acme:/etc/traefik/acme \
     --volume=./traefik.yaml:/etc/traefik/traefik.yaml:Z \


### PR DESCRIPTION
- core. add default log tag to rootless modules
- Remove `--log-opt` option from rootless modules
- core, test: add rootless logs tests
- Unified use of `--log-opt` for rootfull modules
- core, test: add rootfull logs tests


