### PR TITLE
api: add clean-repositories-cache

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/clean-repositories-cache/10clean
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/clean-repositories-cache/10clean
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+
+rdb = agent.redis_connect(privileged=True)
+
+# Remove all repository cache
+for m in rdb.scan_iter('cluster/repository_cache/*'):
+    rdb.delete(m)


### PR DESCRIPTION
Force software repository metadata download

Usage:
```
api-cli run clean-repositories-cache
```

See also https://trello.com/c/b6qMwYOT/120-software-center-refresh-metadata