### PR TITLE
Cleanup units from rootfull modules

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/uninstall.sh
+++ b/core/imageroot/var/lib/nethserver/node/uninstall.sh
@@ -73,6 +73,9 @@ systemctl disable --now \
   agent@cluster.service
 rm -rf /var/lib/nethserver/cluster /var/lib/nethserver/node
 
+echo "Removing main directories"
+rm -rf /usr/local/agent /var/lib/nethserver /etc/nethserver
+
 echo "Uninstalling the core image files"
 (
   while read image_entry; do


### PR DESCRIPTION
Fix removal of units from rootfull modules in the `uninstall.sh` script.

Refs https://github.com/NethServer/ns8-core/pull/156