### PR TITLE
API: add hostname and machine id to get-cluster-status

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/get-cluster-status/50read
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/get-cluster-status/50read
@@ -27,6 +27,7 @@ import redis
 import socket
 import hashlib
 import subprocess
+import agent.tasks
 
 def get_ip(host):
     ip_list = socket.gethostbyaddr(host)[2]
@@ -57,6 +58,15 @@ if network is not None:
         endpoint = rdb.hget(node, 'endpoint')
         if endpoint:
             ret['leader_url'] = f'https://{endpoint.partition(":")[0]}/cluster-admin/'
+        get_info_result = agent.tasks.run(
+            agent_id=f'node/{node_id}',
+            action='get-info',
+            endpoint="redis://cluster-leader",
+        )
+        if get_info_result['exit_code'] == 0:
+            for key in get_info_result['output'].keys():
+                 vpn[ip_addr][key] = get_info_result['output'][key]
+
 else:
     json.dump(ret, fp=sys.stdout)
     sys.exit(0)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/get-cluster-status/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/get-cluster-status/validate-output.json
@@ -21,7 +21,10 @@
             "rcvd": 5989132,
             "sent": 6097216,
             "keepalive": 25
-          }
+          },
+          "hostname": "dn2.worker.cluster0.gs.nethserver.net",
+          "machine_id": "96b91e27d15ae6d7ef0cc79c621f7904",
+          "local": false
         },
         {
           "id": 1,
@@ -30,7 +33,10 @@
           "vpn": {
             "ip_address": "10.5.4.1",
             "public_key": "c4BSbQV3zG1qIK1eSUfVvwLtTBxRuI1y5IWmddZgals="
-          }
+          },
+          "hostname": "dn1.leader.cluster0.gs.nethserver.net",
+          "machine_id": "751361a048c35d6bc123be6b621f797a",
+          "local": true
         }
       ],
       "leader_url": "https://server1.nethserver.org/cluster-admin/",
@@ -75,6 +81,14 @@
           "local": {
             "description": "Set to true if the action is running on the listed node. ",
             "type": "boolean"
+          },
+          "hostname": {
+            "title": "Machine fully qualified hostname",
+            "type": "string"
+          },
+          "machine_id": {
+            "title": "Machine id from /etc/machine.id",
+            "type": "string"
           },
           "vpn": {
             "description": "WireGuard VPN details",
@@ -130,6 +144,8 @@
     "nodes",
     "leader",
     "leader_url",
-    "default_password"
+    "default_password",
+    "hostname",
+    "machine_id"
   ]
 }

--- a/core/imageroot/var/lib/nethserver/node/actions/get-info/20read
+++ b/core/imageroot/var/lib/nethserver/node/actions/get-info/20read
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+echo -n "{\"hostname\": \"$(hostname -f)\", \"machine_id\": \"$(cat /etc/machine-id)\"}"

--- a/core/imageroot/var/lib/nethserver/node/actions/get-info/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/node/actions/get-info/validate-output.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "get-info output",
+  "$id": "http://schema.nethserver.org/node/get-infp-output.json",
+  "description": "Output schema of the get-info action",
+  "examples": [
+    {
+      "hostname": "dn2.worker.cluster0.gs.nethserver.net",
+      "machine_id": "96b91e27d15ae6d7ef0cc79c621f7904"
+    }
+  ]
+}


### PR DESCRIPTION
Add hostname and machine-id to `get-cluster-status` for the API.
The `get-cluster-status` now calls a new node API named `get-info`