### PR TITLE
Clone a module instance

### DIFF
--- a/core/imageroot/usr/local/agent/actions/clone-module/02pullrsync
+++ b/core/imageroot/usr/local/agent/actions/clone-module/02pullrsync
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import sys
+import agent
+
+core_env = agent.read_envfile('/etc/nethserver/core.env') # Import URLs of core images
+agent.run_helper('podman-pull-missing', core_env['RSYNC_IMAGE']).check_returncode()

--- a/core/imageroot/usr/local/agent/actions/clone-module/05create_volumes
+++ b/core/imageroot/usr/local/agent/actions/clone-module/05create_volumes
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import sys
+import agent
+import json
+import subprocess
+
+request = json.load(sys.stdin)
+
+create_volumes = set(request['volumes'])
+with subprocess.Popen(['podman', 'volume', 'ls', '--format=json'], stdout=subprocess.PIPE) as vproc:
+    for vobj in json.load(vproc.stdout):
+        create_volumes.discard(vobj['Name']) # Discard volume if already exists
+
+for xvol in create_volumes:
+    agent.run_helper('podman', 'volume', 'create', xvol).check_returncode()

--- a/core/imageroot/usr/local/agent/actions/clone-module/05replace
+++ b/core/imageroot/usr/local/agent/actions/clone-module/05replace
@@ -1,0 +1,1 @@
+../restore-module/05replace

--- a/core/imageroot/usr/local/agent/actions/clone-module/10recvstate
+++ b/core/imageroot/usr/local/agent/actions/clone-module/10recvstate
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import sys
+import os
+import json
+import subprocess
+
+request = json.load(sys.stdin)
+port = int(request['port'])
+username, password = request['credentials']
+
+rdb = agent.redis_connect()
+cluster_network = rdb.get('cluster/network')
+
+podman_cmd = ['podman', 'run', '--rm', '--privileged', '--network=host', '--workdir=/srv',
+        '--env=RSYNCD_NETWORK=' + cluster_network,
+        '--env=RSYNCD_ADDRESS=cluster-localnode',
+        '--env=RSYNCD_PORT=' + str(port),
+        '--env=RSYNCD_USER=' + username,
+        '--env=RSYNCD_PASSWORD=' + password,
+        '--env=RSYNCD_SYSLOG_TAG=' + os.environ['MODULE_ID'],
+        '--volume=/dev/log:/dev/log',
+    ] + agent.get_existing_volume_args()
+
+core_env = agent.read_envfile('/etc/nethserver/core.env') # Import URLs of core images
+
+agent.run_helper(*podman_cmd, core_env['RSYNC_IMAGE']).check_returncode()

--- a/core/imageroot/usr/local/agent/actions/clone-module/validate-input.json
+++ b/core/imageroot/usr/local/agent/actions/clone-module/validate-input.json
@@ -1,0 +1,94 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "clone-module input",
+    "$id": "http://schema.nethserver.org/module/clone-module-input.json",
+    "description": "Clone the module state received from rsync",
+    "examples": [
+        {
+            "credentials": [
+                "dokuwiki1",
+                "s3cr3t"
+            ],
+            "environment": {
+                "IMAGE_URL": "ghcr.io/nethserver/dokuwiki:latest",
+                "MODULE_UUID": "f5d24fcd-819c-4b1d-98ad-a1b2ebcee8cf",
+                "DOKUWIKI_IMAGE": "docker.io/bitnami/dokuwiki:20200729.0.0-debian-10-r299",
+                "DOKUWIKI_WIKI_NAME": "mywiki",
+                "DOKUWIKI_USERNAME": "admin",
+                "DOKUWIKI_PASSWORD": "pass",
+                "DOKUWIKI_EMAIL": "davidep@nethesis.it",
+                "DOKUWIKI_FULL_NAME": "Wiki Admin",
+                "PHP_ENABLE_OPCACHE": "1",
+                "PHP_MEMORY_LIMIT": "512M",
+                "TRAEFIK_HOST": "mywiki.dp.nethserver.net",
+                "TRAEFIK_HTTP2HTTPS": "False",
+                "TRAEFIK_LETS_ENCRYPT": "False"
+            },
+            "port": 20027,
+            "volumes": [
+                "dokuwiki-data"
+            ],
+            "replace": false
+        }
+    ],
+    "type": "object",
+    "required": [
+        "credentials",
+        "replace",
+        "environment",
+        "volumes",
+        "port"
+    ],
+    "properties": {
+        "volumes": {
+            "title": "Initial volume set where the module state is stored",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "title": "Name of the volume element"
+            }
+        },
+        "port": {
+            "title": "Rsyncd TCP port number",
+            "type": "integer",
+            "minimum": 1
+        },
+        "environment": {
+            "type": "object",
+            "title": "Environment backup",
+            "description": "Copy of the environment of the original module",
+            "properties": {
+                "IMAGE_URL": {
+                    "type": "string",
+                    "description": "URL of the module root image",
+                    "examples": [
+                        "ghcr.io/nethserver/mymodule:v2.3.2"
+                    ],
+                    "minLength": 1
+                }
+            },
+            "patternProperties": {
+                "^[^=]+$": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "credentials": {
+            "title": "Rsyncd service credentials",
+            "description": "An array with two elements: username, password",
+            "type": "array",
+            "maxItems": 2,
+            "minItems": 2,
+            "items": {
+                "type": "string",
+                "minLength": 1
+            }
+        },
+        "replace": {
+            "title": "Replace flag",
+            "description": "If set to true the original module will be erased",
+            "type": "boolean"
+        }
+    }
+}

--- a/core/imageroot/usr/local/agent/actions/list-volumes/20list_volumes
+++ b/core/imageroot/usr/local/agent/actions/list-volumes/20list_volumes
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import json
+import agent
+import sys
+import subprocess
+import os
+
+outdata = []
+module_is_rootfull = os.geteuid() == 0
+module_id = os.environ['MODULE_ID']
+
+with subprocess.Popen(['podman', 'volume', 'ls', '--format=json'], stdout=subprocess.PIPE) as vproc:
+    for vobj in json.load(vproc.stdout):
+        if module_is_rootfull and not vobj['Name'].startswith(module_id + '-'):
+            # a rootfull module share the volume namespace with other rootfull modules:
+            # skip volumes that do not belong to our MODULE_ID
+            continue
+
+        outdata.append(vobj['Name'])
+
+json.dump(outdata, fp=sys.stdout)

--- a/core/imageroot/usr/local/agent/actions/list-volumes/validate-output.json
+++ b/core/imageroot/usr/local/agent/actions/list-volumes/validate-output.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "List module volumes",
+    "$id": "http://schema.nethserver.org/agent/list-volumes-output.json",
+    "examples": [
+        [
+            {
+                "name": "dokuwiki-data",
+                "created": "2021-07-19 10:19:45.528366456 +0200 CEST"
+            }
+        ]
+    ],
+    "type": "array",
+    "description": "A list of Podman volume names of the current module",
+    "items": {
+        "type": "string",
+        "description": "Podman volume name",
+        "minLength": 1
+    }
+}

--- a/core/imageroot/usr/local/agent/actions/transfer-state/02pullrsync
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/02pullrsync
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import sys
+import agent
+
+core_env = agent.read_envfile('/etc/nethserver/core.env') # Import URLs of core images
+agent.run_helper('podman-pull-missing', core_env['RSYNC_IMAGE']).check_returncode()

--- a/core/imageroot/usr/local/agent/actions/transfer-state/05waitserver
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/05waitserver
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import socket
+import agent
+import json
+import time
+import sys
+
+request = json.load(sys.stdin)
+address = request['address']
+port = int(request['port'])
+replace = bool(request['replace'])
+username, password = request['credentials']
+
+timeout = 5 # seconds
+
+print(f"Dialling {address}:{port}...", file=sys.stderr)
+
+for attempt in range(60): # 5s*60 = 5 minutes of attempts
+    try:
+        socket.create_connection((address, port), timeout).close()
+        break
+    except Exception as ex:
+        print(agent.SD_DEBUG + str(ex), file=sys.stderr)
+
+    time.sleep(timeout)
+else:
+    sys.exit(1)
+
+print(f"Connection with {address}:{port} established: the server is ready.", file=sys.stderr)

--- a/core/imageroot/usr/local/agent/actions/transfer-state/50sendstate
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/50sendstate
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import subprocess
+import sys
+import json
+import agent
+import os
+
+request = json.load(sys.stdin)
+address = request['address']
+port = int(request['port'])
+replace = bool(request['replace'])
+username, password = request['credentials']
+
+errors = 0
+podman_cmd = [
+    'podman', 'run', '-i', '--workdir=/srv', '--rm', '--network=host', '--privileged',
+    '--env=RSYNC_PASSWORD=' + password,
+]
+
+rsync_cmd = [
+    'rsync',
+    '-a',
+    '--info=progress2',
+    '--delete-after',
+
+    # high-priority, harcoded filter rules: they cannot be overriden
+    '--exclude=/state/agent.env',
+    '--exclude=/state/environment',
+]
+
+if os.path.isfile('state-filter-rules.rsync'):
+    rsync_cmd += ['--filter=. state-filter-rules.rsync']
+
+rsync_cmd += [
+    './', # source: workdir
+    f'rsync://{username}@{address}:{port}/data/', # destination, remote rsync "data" module
+]
+
+core_env = agent.read_envfile('/etc/nethserver/core.env') # Import URLs of core images
+
+transfer_cmd = [*podman_cmd, *agent.get_existing_volume_args(), core_env['RSYNC_IMAGE'], *rsync_cmd]
+print(agent.SD_DEBUG + " ".join(transfer_cmd), file=sys.stderr)
+with subprocess.Popen(transfer_cmd, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, text=True) as pclient:
+    # Parse rsync --info output to set the task progress
+    buf = ''
+    cprogress = 0
+    while True:
+        ch = pclient.stdout.read(1)
+        if not ch:
+            break
+        elif ch == '%':
+            try:
+                progress = int(float(buf[-3:]) * 0.99)
+                if progress > cprogress:
+                    agent.set_progress(progress)
+                    cprogress = progress
+            except:
+                pass
+            buf = ''
+        elif ch == '\r' or ch == '\n':
+            buf = ''
+        else:
+            buf += ch
+
+if pclient.returncode != 0:
+    print(agent.SD_ERR + "[ERROR] rsync transfer error " + str(pclient.returncode), file=sys.stderr)
+    errors += 1 # non-fatal: cleanup required!
+
+# Send a termination request to the server
+pterminate = agent.run_helper(*podman_cmd, core_env['RSYNC_IMAGE'], *f'rsync -q rsync://{username}@{address}:{port}/terminate'.split())
+if pterminate.returncode != 0:
+    print(agent.SD_ERR + "[ERROR] cannot send termination message to the rsync server. Exit code " + str(pterminate.returncode), file=sys.stderr)
+    errors += 1 # non-fatal: cleanup required!
+
+if errors > 0:
+    sys.exit(1)

--- a/core/imageroot/usr/local/agent/actions/transfer-state/validate-input.json
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/validate-input.json
@@ -1,0 +1,50 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "transfer-state input",
+    "$id": "http://schema.nethserver.org/module/transfer-state-input.json",
+    "description": "Transfer the module state to another module instance",
+    "examples": [
+        {
+            "replace": true,
+            "credentials": ["dokuwiki1", "s3cr3t"],
+            "address": "10.5.4.3",
+            "port": 20021
+        }
+    ],
+    "type":"object",
+    "required": [
+        "replace",
+        "credentials",
+        "address",
+        "port"
+    ],
+    "properties": {
+        "replace": {
+            "title": "Replace flag",
+            "description": "If set to true the state cannot be modified after the transfer is completed",
+            "type": "boolean"
+        },
+        "credentials": {
+            "title": "Rsyncd service credentials",
+            "description": "An array with two elements: username, password",
+            "type":"array",
+            "maxItems": 2,
+            "minItems": 2,
+            "items": {
+                "type": "string",
+                "minLength": 1
+            }
+        },
+        "address": {
+            "title": "Rsyncd remote address",
+            "description": "It must be an host name or IP address",
+            "minLength": 1,
+            "type":"string"
+        },
+        "port": {
+            "title": "Rsyncd remote TCP port number",
+            "type":"integer",
+            "minimum": 1
+        }
+    }
+}

--- a/core/imageroot/usr/local/agent/bin/redis-dump
+++ b/core/imageroot/usr/local/agent/bin/redis-dump
@@ -26,4 +26,6 @@ import agent
 rdb = agent.redis_connect(host='127.0.0.1', decode_responses=False)
 
 # Write raw binary data to stdout
-sys.stdout.buffer.write(rdb.dump(sys.argv[1]))
+data = rdb.dump(sys.argv[1])
+if data: # if the key does not exist, ignore it
+    sys.stdout.buffer.write(data)

--- a/core/imageroot/usr/local/agent/bin/redis-restore
+++ b/core/imageroot/usr/local/agent/bin/redis-restore
@@ -32,4 +32,6 @@ except IndexError:
     ttl = "0"
 
 # Read raw binary data from stdin
-rdb.restore(key, ttl, sys.stdin.buffer.raw.read())
+data = sys.stdin.buffer.raw.read()
+if data: # zero length file is ignored
+    rdb.restore(key, ttl, data)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/clone-module/50clone_module
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/clone-module/50clone_module
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import sys
+import os
+import agent.tasks
+import json
+
+request = json.load(sys.stdin)
+
+# source
+smid = request['module']
+replace = request.get('replace', False)
+
+# destination
+node_id = int(request['node'])
+
+rdb = agent.redis_connect(privileged=True)
+
+secret = str(os.getpid()) + os.getenv('AGENT_TASK_ID')
+original_environment = rdb.hgetall(f'module/{smid}/environment')
+rsyncd_addr = rdb.hget(f'node/{node_id}/vpn', 'ip_address')
+agent.assert_exp(rsyncd_addr)
+
+# Retrieve the list of volume names from the source module
+list_volumes_result = agent.tasks.run(f"module/{smid}", "list-volumes",
+    endpoint="redis://cluster-leader",
+    progress_callback=agent.get_progress_callback(2, 12)
+)
+agent.assert_exp(list_volumes_result['exit_code'] == 0) # list-volumes is successful
+svolumes = list_volumes_result['output']
+
+# Create the destination  module
+add_module_result = agent.tasks.run("cluster", "add-module",
+    data={
+        "image": original_environment['IMAGE_URL'],
+        "node": node_id,
+    }, 
+    endpoint="redis://cluster-leader",
+    progress_callback=agent.get_progress_callback(13, 25),
+)
+agent.assert_exp(add_module_result['exit_code'] == 0) # add-module is successful
+
+dmid = add_module_result['output']['module_id'] # Destination module ID
+rsyncd_port = int(rdb.incrby(f'node/{node_id}/tcp_ports_sequence', 1)) # Allocate a TCP port for rsyncd
+agent.assert_exp(rsyncd_port > 0) # valid destination port number
+
+# Rootfull modules require a volume name remapping:
+is_rootfull = rdb.sismember(f'module/{smid}/flags', 'rootfull')
+if is_rootfull:
+    dvolumes = []
+    for xvol in svolumes:
+        if xvol.startswith(smid + '-'): # replace the MODULE_ID prefix
+            dvolumes.append(dmid + xvol.removeprefix(smid))
+else:
+    dvolumes = svolumes
+
+# Prepare the task for the destination module (server)
+server_task = {
+    "agent_id": "module/" + dmid,
+    "action": "clone-module",
+    "data": {
+        "replace": replace,
+        "credentials": [smid, secret],
+        "environment": original_environment,
+        "port": rsyncd_port,
+        "volumes": dvolumes,
+    },
+}
+
+# Prepare the task for the source module (client)
+client_task = {
+    "agent_id": "module/" + smid,
+    "action": "transfer-state",
+    "data": {
+        "replace": replace,
+        "credentials": [smid, secret],
+        "address": rsyncd_addr,
+        "port": rsyncd_port,
+    }
+}
+
+# Send and receive tasks run in parallel until both finish
+clone_errors = agent.tasks.runp_brief([server_task, client_task],
+    endpoint="redis://cluster-leader",
+    progress_callback=agent.get_progress_callback(26, 94),
+)
+
+if clone_errors > 0:
+    sys.exit(1)
+
+# Copy the UI module name ui_name
+ui_name = rdb.get(f'module/{smid}/ui_name')
+if not ui_name is None:
+    rdb.set(f'module/{dmid}/ui_name', ui_name)
+
+# Erase existing module
+if replace:
+    remove_retval = agent.tasks.run("cluster", "remove-module",
+        data={
+            "module_id": smid,
+            "preserve_data": False
+        },
+        endpoint="redis://cluster-leader",
+        progress_callback=agent.get_progress_callback(95, 98),
+    )
+    if remove_retval['exit_code'] != 0:
+        print(f"Removal of module/{smid} has failed!")
+        sys.exit(1)
+
+json.dump(add_module_result['output'], fp=sys.stdout)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/clone-module/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/clone-module/validate-input.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "clone-module input",
+    "$id": "http://schema.nethserver.org/cluster/clone-module-input.json",
+    "description": "Input schema of the clone-module action",
+    "examples": [
+        {
+            "module": "dokuwiki1",
+            "node": 1,
+            "replace": false
+        }
+    ],
+    "type": "object",
+    "required": [
+        "module",
+        "replace",
+        "node"
+    ],
+    "properties": {
+        "module": {
+            "title": "Module ID",
+            "description": "The identifier of the module to be cloned",
+            "type":"string",
+            "minLength": 1
+        },
+        "node": {
+            "title": "Node ID",
+            "description": "Node identifier where the clone is created",
+            "type": "integer",
+            "minimum": 1
+        },
+        "replace": {
+            "title": "Replace flag",
+            "description": "If set to true, the clone receives the original UUID and the original module is erased. If false, the clone is just a copy of the original module.",
+            "type": "boolean"
+        }
+    }
+}

--- a/core/rsync/README.md
+++ b/core/rsync/README.md
@@ -1,0 +1,44 @@
+# rsync
+
+This directory contains scripts for the **rsync** image. It provides both
+client and server configuration to transfer a module instance state to
+another instance.
+
+Invocation (server)
+
+    podman run --rm --privileged --network=host --workdir=/srv --env=RSYNCD_NETWORK=10.5.4.0/24 --env=RSYNCD_ADDRESS=cluster-localnode --env=RSYNCD_PORT=20024 --env=RSYNCD_USER=dokuwiki1 --env=RSYNCD_PASSWORD=534421aa2c25f-d383-498f-8d77-f33c41fc01fb --volume=/dev/log:/dev/log --volume=/home/dokuwiki7/.config/state:/srv/state --volume=dokuwiki-data:/srv/volumes/dokuwiki-data ghcr.io/nethserver/rsync:latest
+
+Invocation (client)
+
+    podman run -i --workdir=/srv --rm --network=host --privileged --env=RSYNC_PASSWORD=534421aa2c25f-d383-498f-8d77-f33c41fc01fb --volume=/home/dokuwiki1/.config/state:/srv/state --volume=dokuwiki-data:/srv/volumes/dokuwiki-data ghcr.io/nethserver/rsync:latest rsync -a --info=progress2 --delete-after --filter=". -" ./ rsync://dokuwiki1@10.5.4.1:20024/state/
+
+## Basic Podman flags
+
+- `--network=host`: the rsyncd server must be accessible from other nodes
+  of the cluster, see also the RSYNCD_ADDRESS environment variable.
+- `--privileged`: both the client and the server need full access to volume contents
+
+## Volume mounts
+
+When the server is started, mount the following volumes:
+
+- `--volume=/dev/log:/dev/log`: to send log messages to syslog/journald with RSYNCD_SYSLOG_TAG
+- `--volume=$AGENT_STATE_DIR:/srv/state`: `state/` directory is always mounted, like backups
+- `--volume=volname:/srv/volumes/volname`: mount the volumes under `/srv/volumes`, like backups
+
+For the client side, /dev/log is not necessary.
+
+## Environment variables
+
+Server
+
+- RSYNCD_ADDRESS: rsyncd listen address
+- RSYNCD_PORT: rsyncd listen port
+- RSYNCD_USER: user name for rsync authentication
+- RSYNCD_PASSWORD: password for rsync authentication
+- RSYNCD_NETWORK: allow connection only if client comes from the given network
+- RSYNCD_SYSLOG_TAG: set the syslog identity
+
+Client
+
+- RSYNC_PASSWORD: client password, username is specified in the command arguments

--- a/core/rsync/entrypoint.sh
+++ b/core/rsync/entrypoint.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+set -e
+
+echo "${RSYNCD_USER}:${RSYNCD_PASSWORD}" >/etc/rsyncd.secrets
+chmod 600 /etc/rsyncd.secrets
+
+cat >/etc/rsyncd.conf <<EOF
+#
+# rsyncd configuration for module state transferring
+#
+address = ${RSYNCD_ADDRESS}
+port = ${RSYNCD_PORT}
+syslog tag = ${RSYNCD_SYSLOG_TAG}
+reverse lookup = no
+forward lookup = no
+uid = 0
+gid = 0
+auth users = ${RSYNCD_USER}
+secrets file = /etc/rsyncd.secrets
+# If chroot is enabled, -a/--perms flag does not work
+use chroot = no
+
+[data]
+path = /srv
+read only = no
+numeric ids = yes
+hosts allow = 127.0.0.1 ::1 ${RSYNCD_NETWORK:-0.0.0.0/0}
+
+[terminate]
+path = /var/empty
+read only = yes
+list = no
+early exec = kill -TERM 1
+EOF
+
+
+# Start the container CMD
+exec "${@}"

--- a/docs/core/clone_module.md
+++ b/docs/core/clone_module.md
@@ -1,0 +1,119 @@
+---
+layout: default
+title: Cloning a module
+nav_order: 10
+parent: Core
+---
+
+# Cloning a module
+
+A (source) module instance can be cloned (copied) by the
+`cluster/clone-module` action. This action creates a new module instance
+(destination) that is equivalent to the source one.
+
+For example to create a clone/copy of instance `dokuwiki1` on node 1, run
+
+    api-cli run clone-module --data '{"module":"dokuwiki1","replace":false,"node":1}'
+
+The cluster **node** where the destination runs can be the same of the
+source instance or not; generally if the services provided by the instance
+do not require exclusive access to a particular system resource (i.e. bind
+a given TCP port number) there should be no limitation on running multiple
+instances of the same module on the same node. In the end, this kind of
+limitations must be managed by the module itself.
+
+In a nutshell, `clone-module`:
+
+- Creates a new module instance for the destination using `cluster/add-module`
+- Starts two parallel subtasks:
+  - `transfer-state` on the source instance
+  - `clone-module` on the destination instance
+- When both subtasks are succesfully completed and if a full **replace**
+  is required, the source instance is removed with `cluster/remove-module`
+- The destination instance has the same MODULE_UUID if replace is required
+
+Modules can implement `transfer-state` and `clone-module` to correctly
+support module cloning. The core provides a partial implementation of
+those actions that is explained in the following sections.
+
+## Implementation of `transfer-state`
+
+The core implementation of the `transfer-state` action runs a Rsync client
+process that transfers the contents of the module volumes and the
+AGENT_STATE_DIR (`state/`) directory to the destination instance. The
+action input is like:
+
+```json
+{
+    "replace": true,
+    "credentials": ["dokuwiki1", "s3cr3t"],
+    "address": "10.5.4.3",
+    "port": 20021
+}
+```
+
+Any step that runs after `05waitserver` can assume the Rsync server
+process is ready to receive data.
+
+At step `50sendstate` all volume contents are transferred to the
+destination with a `rsync` client that runs in a privileged Podman
+container.
+
+This Podman container mounts all module volumes to correctly map numeric
+UID/GIDs.
+
+Note also that
+
+* it is possible to run an additional rsync pass before `50sendstate`,
+  expecially if there is a lot of data to transfer. Look at the action
+  journal to grasp the rsync client invocation command line
+
+* it is possible to add a Rsync filter to select what files/dirs are
+  transferred: just drop a `state-filter-rules.rsync` in the
+  AGENT_STATE_DIR. See `man 1 rsync` for the file syntax
+
+If the transfer is successful the Rsync client sends a "terminate"
+signal to the server.
+
+The module could add service stop/start steps before and after
+`50sendstate`. Consider the `replace` input boolean to decide if services
+should be left stopped or not.
+
+## Implementation of `clone-module`
+
+The core implementation of the `clone-module` step runs a Rsync server
+that receives volume and `state/` directory contents.
+
+The action input could be:
+
+```json
+{
+    "credentials": ["dokuwiki1", "s3cr3t"],
+    "environment": {
+        "IMAGE_URL": "ghcr.io/nethserver/dokuwiki:latest",
+        "MODULE_UUID": "f5d24fcd-819c-4b1d-98ad-a1b2ebcee8cf"
+    },
+    "port": 20027,
+    "volumes": [
+        "dokuwiki-data"
+    ],
+    "replace": false
+}
+```
+
+Note that the `environment` object (here partially redacted) is a copy of
+the source instance module environment.
+
+At step `05create_volumes` the `volumes` input array is used to re-create
+the same set of volumes of the source module, if they are not already
+created by `create-module`.
+
+The `05replace` step replaces MODULE_UUID, if the `replace` flag is
+`true`.
+
+Finally `rsyncd` runs at step `10recvstate`. This step blocks until the
+"terminate" signal is received from the client, or the task itself is
+canceled.
+
+Additional steps implemented by the module can then adjust the module and
+finally start its services.


### PR DESCRIPTION
This PR implements module instance cloning in the `cluster/clone-module` action. As for backup/restore, the clone can be created to replace the original module or not. The `replace` flag controls that behavior.

    api-cli run clone-module --data '{"module":"dokuwiki1","replace":false,"node":1}'

- module: original module identifier
- replace: the behavior flag
- node: the identifier of the node where the clone is instantiated

To clone a module instance, the module state files are generated with the module-dump-state/module-cleanup-state commands that are already invoked by backup/restore.

Module state files are transferred to the clone via rsync. The clone runs a rsyncd server, listening on a dedicated TCP port.
Temporary authentication credentials are shared between the origin and clone module to establish the rsync connection.

The origin (client) side can run rsync as many times as needed. When the state is safely transferred a special rsync module, `terminate` can be opened to start the rsyncd server shutdown and complete the `cluster/clone-module` action.

Rsync client and server run as containers, like Restic, to mount the module volumes properly. Rsync containers are based on this image: https://github.com/NethServer/ns8-core/blob/clone-rsyncd/core/rsync/README.md

