### PR TITLE
Fix default HTTPS certificate

### DIFF
--- a/core/tests/10_cluster_sanity/80_trefik_check_certificate_apis.robot
+++ b/core/tests/10_cluster_sanity/80_trefik_check_certificate_apis.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Library    RequestsLibrary
+Library    SSHLibrary
+
+*** Test Cases ***
+Set node FQDN certificate
+    ${output}  ${rc} =    Execute Command    api-cli run set-certificate --agent module/traefik1 --data '{"fqdn":"${NODE_ADDR}"}'
+    ...    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+
+Check that admin iterface is accessible with a valid certificate
+    Wait Until Keyword Succeeds    20 times    1 seconds    GET    https://${NODE_ADDR}/cluster-admin/

--- a/traefik/imageroot/actions/create-module/20certificate
+++ b/traefik/imageroot/actions/create-module/20certificate
@@ -31,7 +31,7 @@ set -e
 exec 1>&2
 
 NAME="selfsigned"
-FQDN=$(hostname -f)
+FQDN="$(hostname -f).test"
 addresses=''
 
 # Do not override existing certs


### PR DESCRIPTION
If the node's FQDN is used in the default selfsigned certificate, when a valid certificate for the node's FQDN is requested using the `set-certificate` action, `traefik` will not request a new certificate via Let's Encrypt, but will use the already present selfsigned certificate.
This is caused by the fact that in the system is already present a certificate for the requested domain (in the selfsigned certificate) and to avoid this problem the tld `.test` is used in the selfsigned certificate.
The `CN` of the selfsigned certificate will be `FQDN + .test`