### PR TITLE
Add node name to get-status output

### DIFF
--- a/core/imageroot/usr/local/agent/actions/get-status/20read
+++ b/core/imageroot/usr/local/agent/actions/get-status/20read
@@ -39,6 +39,7 @@ rdb = agent.redis_connect()
 status["instance"] = os.environ["MODULE_ID"]
 status["ui_name"] = rdb.get(f'module/{os.environ["MODULE_ID"]}/ui_name') or ""
 status["node"] = rdb.hget(f'module/{os.environ["MODULE_ID"]}/environment', 'NODE_ID')
+status["node_ui_name"] = rdb.get(f'node/{status["node"]}/ui_name') or ""
 
 status["services"] = []
 for f in glob.glob(f'{os.environ["HOME"]}/.config/systemd/user/*.service'):

--- a/core/imageroot/usr/local/agent/actions/get-status/validate-output.json
+++ b/core/imageroot/usr/local/agent/actions/get-status/validate-output.json
@@ -6,7 +6,9 @@
   "examples": [
     {
       "instance": "dokuwiki1",
+      "ui_name": "mywiki",
       "node": "1",
+      "node_ui_name": "andromeda",
       "services": [
         {
           "name": "dokuwiki",
@@ -34,7 +36,9 @@
   "type": "object",
   "required": [
     "instance",
+    "ui_name",
     "node",
+    "node_ui_name",
     "services",
     "images",
     "volumes"
@@ -44,9 +48,17 @@
       "type": "string",
       "description": "Instance identifier"
     },
+    "ui_name": {
+      "type": "string",
+      "description": "UI name of the module instance"
+    },
     "node": {
       "type": "string",
       "description": "Id of the node where the instance is running"
+    },
+    "node_ui_name": {
+      "type": "string",
+      "description": "UI name of the node"
     },
     "services": {
       "type": "array",


### PR DESCRIPTION
The node ui_name is added to the get-status action output.
Fix also the JSON schema with missing information.