### PR TITLE
traefik: use fixed length `CN` in self signed cert

### DIFF
--- a/traefik/imageroot/actions/create-module/20certificate
+++ b/traefik/imageroot/actions/create-module/20certificate
@@ -31,7 +31,7 @@ set -e
 exec 1>&2
 
 NAME="selfsigned"
-FQDN="$(hostname -f).test"
+FQDN="host-$(printf %05d ${RANDOM}).ns8.test"
 addresses=''
 
 # Do not override existing certs


### PR DESCRIPTION
The `CN` of the self signed certificate was made by concatenating the
`FQDN` of the node with the `.test` tld, this can cause a failure during
the certificate generation if the `FQDN` is already at maximum allowed
length. This was the case with the GitHub Actions runner.

To solve this problem the value of `CN` will be:
* `host-<five random numbers>.ns8.test`