### PR TITLE
add-module: fix port allocation

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
@@ -38,7 +38,7 @@ def allocate_tcp_ports_range(node_id, module_environment, size):
 
     seq = rdb.incrby(f'node/{int(node_id)}/tcp_ports_sequence', size)
     agent.assert_exp(int(seq) > 0)
-    module_environment['TCP_PORT'] = f'{seq - 1}' # Always set the first port
+    module_environment['TCP_PORT'] = f'{seq - size}' # Always set the first port
     if size > 1: # Multiple ports: always set the ports range variable
         module_environment['TCP_PORTS_RANGE'] = f'{seq - size}-{seq - 1}'
     if size <= 8: # Few ports: set also a comma-separated list of ports variable


### PR DESCRIPTION
When a module requests 2 or more ports, the TCP_PORT
env variable should contain the first allocated one.

Before this commit, TCP_PORT was set to the last port of the range.