### PR TITLE
Fix update-core action

### DIFF
--- a/core/imageroot/usr/local/agent/bin/extract-image
+++ b/core/imageroot/usr/local/agent/bin/extract-image
@@ -47,7 +47,7 @@ podman export "${cid}" | tar \
     --exclude-caches-under \
     --strip-components="${stripcount}" \
     -x -v -f - "${imageroot}" \
-    | sort \
+    | LC_ALL=C sort \
     | tee ${lst_file}
 
 # Clean up old files that are no longer shipped with the image:

--- a/core/imageroot/usr/local/agent/bin/install-coreimage
+++ b/core/imageroot/usr/local/agent/bin/install-coreimage
@@ -36,7 +36,7 @@ trap 'podman rm -f "${cid}" >/dev/null' EXIT
 # Extract the image contents, generating the new image index, and
 # unlinking existing files as it is necessary to properly replace
 # executables and libraries:
-podman export "${cid}" | tar --totals --no-overwrite-dir --no-same-owner -x -v -f - | sort | tee ${lst_file}
+podman export "${cid}" | tar --totals --no-overwrite-dir --no-same-owner -x -v -f - | LC_ALL=C sort | tee ${lst_file}
 
 dirs_list=()
 

--- a/core/install.sh
+++ b/core/install.sh
@@ -62,7 +62,7 @@ fi
 echo "Extracting core sources:"
 mkdir -pv /var/lib/nethserver/node/state
 cid=$(podman create "ghcr.io/nethserver/core:latest")
-podman export ${cid} | tar --totals -C / --no-overwrite-dir --no-same-owner -x -v -f - | sort | tee /var/lib/nethserver/node/state/coreimage.lst
+podman export ${cid} | tar --totals -C / --no-overwrite-dir --no-same-owner -x -v -f - | LC_ALL=C sort | tee /var/lib/nethserver/node/state/coreimage.lst
 podman rm -f ${cid}
 
 echo "Pulling rclone image ${RCLONE_IMAGE}:"


### PR DESCRIPTION
GNU "sort" is sensible to the current locale settings. The resulting
coreimage.lst content is unpredictable and causes a file loss during the
core update procedure.