### PR TITLE
tests: fix cluster UI / uninstall app test

### DIFF
--- a/core/tests/20__cluster_ui/40__software_center.robot
+++ b/core/tests/20__cluster_ui/40__software_center.robot
@@ -40,5 +40,14 @@ Uninstall App
     ${old_mode} =    Set Strict Mode    False
     Click    .bx--overflow-menu-options >> text="Uninstall"
     Set Strict Mode    ${old_mode}
-    Click    button >> text="Uninstall instance"
+    # get module ID from modal title
+    ${modalTitle}=    Get Text    .bx--modal-header__heading >> text=Uninstall
+    ${regexpMatch}=    Evaluate    re.search("Uninstall (.+)", "${modalTitle}"), re
+    # enter module ID in danger modal input
+    Fill Text    .cv-modal .bx--text-input    ${regexpMatch[0].group(1)}
+    Click    button >> text="I understand, delete"
+    ${old_browser_timeout} =    Set Browser Timeout    60 seconds
+    ${old_retry_assertions} =    Set Retry Assertions For    60 seconds
     Get Text    .bx--toast-notification--success >> text="Completed"
+    Set Browser Timeout    ${old_browser_timeout}
+    Set Retry Assertions For    ${old_retry_assertions}


### PR DESCRIPTION
App uninstallation now shows a danger modal: need to type module ID in an input field to confirm uninstallation