### PR TITLE
install.sh: install podman => 3.4.2

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -49,6 +49,9 @@ if [[ ${ID} == "centos" && "${PLATFORM_ID}" == "platform:el9" ]]; then
     dnf install -y wireguard-tools podman jq openssl
     systemctl disable --now firewalld || :
 elif [[ "${ID}" == "debian" && "${VERSION_ID}" == "11" ]]; then
+    # Add repo for podman => 3.4.2
+    echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+    wget -O - https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/Release.key | apt-key add -
     apt-get update
     apt-get -y install gnupg2 python3-venv podman wireguard uuid-runtime jq openssl psmisc
 elif [[ "${ID}" == "ubuntu" && "${VERSION_ID}" == "20.04" && "${CI}" == "true" && "${GITHUB_ACTIONS}" == "true" ]]; then

--- a/core/tests/10__cluster_sanity/_dummy/build-images.sh
+++ b/core/tests/10__cluster_sanity/_dummy/build-images.sh
@@ -7,7 +7,7 @@ if ! command -v buildah; then
     # Pick up the first one that is available
     if command -v apt; then
         apt install buildah
-        trap "apt remove buildah" EXIT
+        trap "apt remove -y buildah" EXIT
     elif command -v dnf; then
         dnf install -q -y buildah
         trap "dnf remove -q -y buildah" EXIT


### PR DESCRIPTION
The version provided by Debian 11 of the `containers-common` package,
provided as dependence by `podman`, don't have the support for `log-tag`
an option that is needed by the logs system collector.

See: https://github.com/containers/common/commit/6a2f926c6498ce9f76304933354f297dd52302b5
