### PR TITLE
Fix core workflow build

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -2,7 +2,8 @@ name: core
 on:
   push:
     paths:
-      - 'core/**'
+      - '!docs/**'
+      - '!infra/**'
       - '!core/tests/**'
       - '!core/test-module.sh'
 
@@ -12,7 +13,7 @@ jobs:
       REPONAME: ${{ github.workflow }}
       IMAGETAG: ${{ github.ref_name }}
     name: 'Build ${{ github.workflow }}'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - id: info
         name: "Retrieve runtime information"

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -10,7 +10,7 @@ jobs:
   push_image:
     env:
       REPONAME: ${{ github.workflow }}
-      IMAGETAG: ${{ github.head_ref }}
+      IMAGETAG: ${{ github.ref_name }}
     name: 'Build ${{ github.workflow }}'
     runs-on: ubuntu-20.04
     steps:
@@ -39,7 +39,6 @@ jobs:
         name: "Push the images"
         run: |
           # Push the images
-          set -e
           trap 'buildah logout ghcr.io' EXIT
           buildah login -u ${{ github.actor }} --password-stdin ghcr.io <<<"${{ secrets.GITHUB_TOKEN }}"
-          for image in ${{ steps.build.outputs.images }} ; do buildah push $image docker://${image}:${IMAGETAG:-latest} ; done
+          for image in ${{ steps.build.outputs.images }} ; do buildah push $image docker://${image}:${IMAGETAG:?is missing} ; done

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,11 +1,11 @@
 name: core
 on:
   push:
-    paths:
-      - '!docs/**'
-      - '!infra/**'
-      - '!core/tests/**'
-      - '!core/test-module.sh'
+    paths-ignore:
+      - 'docs/**'
+      - 'infra/**'
+      - 'core/tests/**'
+      - 'core/test-module.sh'
 
 jobs:
   push_image:


### PR DESCRIPTION
- Read the branch/tag name from `github.ref_name` context variable
- Do not fall back to "latest". Fail the `buildah push` if IMAGETAG is not properly defined
