### PR TITLE
Tests: fix "Uninstall app" UI test

### DIFF
--- a/core/tests/20__cluster_ui/20__login.robot
+++ b/core/tests/20__cluster_ui/20__login.robot
@@ -8,11 +8,11 @@ Test Teardown     Close the context
 
 *** Test Cases ***
 Login Page Is Reachable
-    New Page    https://${NODE_ADDR}/cluster-admin/
+    Open login page
     Get Title    should be    Log in
 
 Invalid Login Credentials
-    New Page    https://${NODE_ADDR}/cluster-admin/
+    Open login page
     Fill Text    text="Username"    Baaad
     Click    button >> text="Continue"
     Fill Text    text="Password"    S3cret!

--- a/core/tests/20__cluster_ui/40__software_center.robot
+++ b/core/tests/20__cluster_ui/40__software_center.robot
@@ -41,10 +41,10 @@ Uninstall App
     Click    .bx--overflow-menu-options >> text="Uninstall"
     Set Strict Mode    ${old_mode}
     # get module ID from modal title
-    ${modalTitle}=    Get Text    .bx--modal-header__heading >> text=Uninstall
-    ${regexpMatch}=    Evaluate    re.search("Uninstall (.+)", "${modalTitle}"), re
+    ${modal_title}=    Get Text    .bx--modal-header__heading >> text=Uninstall
+    ${regexp_match}=    Evaluate    re.search("Uninstall (.+)", "${modal_title}"), re
     # enter module ID in danger modal input
-    Fill Text    .cv-modal .bx--text-input    ${regexpMatch[0].group(1)}
+    Fill Text    .cv-modal .bx--text-input    ${regexp_match[0].group(1)}
     Click    button >> text="I understand, delete"
     ${old_browser_timeout} =    Set Browser Timeout    60 seconds
     ${old_retry_assertions} =    Set Retry Assertions For    60 seconds

--- a/core/tests/20__cluster_ui/40__software_center.robot
+++ b/core/tests/20__cluster_ui/40__software_center.robot
@@ -36,10 +36,7 @@ Uninstall App
     Click    .app-list .bx--row > div:first-child button >> text="Instances"
     # click overflow menu
     Click    .bx--row > div:first-child .cv-overflow-menu button
-    # temporarily disable strict mode (query can return more than one element)
-    ${old_mode} =    Set Strict Mode    False
-    Click    .bx--overflow-menu-options >> text="Uninstall"
-    Set Strict Mode    ${old_mode}
+    Click    .bx--overflow-menu-options [data-test-id="first"] >> text="Uninstall"
     # get module ID from modal title
     ${modal_title}=    Get Text    .bx--modal-header__heading >> text=Uninstall
     ${regexp_match}=    Evaluate    re.search("Uninstall (.+)", "${modal_title}"), re

--- a/core/tests/keywords.resource
+++ b/core/tests/keywords.resource
@@ -60,8 +60,18 @@ Close the browser
 
 UI login
     [Arguments]    ${username}    ${password}
-    New Page    https://${NODE_ADDR}/cluster-admin/
+    Open login page
     Fill Text    text="Username"    ${username}
     Click    button >> text="Continue"
     Fill Text    text="Password"    ${password}
     Click    button >> text="Log in"
+
+Open login page
+    # support for localhost:PORT as NODE_ADDR
+    ${is_localhost}=    Evaluate    "${NODE_ADDR}".startswith("localhost")
+    IF    ${is_localhost} == True
+        ${url}=    Set Variable    http://${NODE_ADDR}
+    ELSE
+        ${url}=    Set Variable    https://${NODE_ADDR}/cluster-admin
+    END
+    New Page    ${url}

--- a/core/tests/keywords.resource
+++ b/core/tests/keywords.resource
@@ -68,8 +68,7 @@ UI login
 
 Open login page
     # support for localhost:PORT as NODE_ADDR
-    ${is_localhost}=    Evaluate    "${NODE_ADDR}".startswith("localhost")
-    IF    ${is_localhost} == True
+    IF    $NODE_ADDR.startswith("localhost")
         ${url}=    Set Variable    http://${NODE_ADDR}
     ELSE
         ${url}=    Set Variable    https://${NODE_ADDR}/cluster-admin

--- a/core/ui/src/views/SoftwareCenterAppInstances.vue
+++ b/core/ui/src/views/SoftwareCenterAppInstances.vue
@@ -176,6 +176,7 @@
                   <NsMenuItem
                     :icon="TrashCan20"
                     :label="$t('software_center.uninstall')"
+                    :data-test-id="index == 0 ? 'first' : ''"
                   />
                 </cv-overflow-menu-item>
               </cv-overflow-menu>


### PR DESCRIPTION
- If robotframework-browser `Strict Mode` variable is disabled and a UI selector that matches more than one HTML element is used, there is a chance that the wrong element is selected. Let's keep `Strict Mode` enabled and fix the selector in order to select exactly one element
- Support for running UI tests on `localhost`
- Fix variable names case