### PR TITLE
install: fix gnupg2 dependency

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -30,11 +30,13 @@ if [[ ${ID} == "centos" && "${PLATFORM_ID}" == "platform:el9" ]]; then
     dnf install -y wireguard-tools podman jq openssl
     systemctl disable --now firewalld || :
 elif [[ "${ID}" == "debian" && "${VERSION_ID}" == "11" ]]; then
+    apt-get update
+    apt-get -y install gnupg2
     # Add repo for podman => 3.4.2
     echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
     wget -O - https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/Release.key | apt-key add -
     apt-get update
-    apt-get -y install gnupg2 python3-venv podman wireguard uuid-runtime jq openssl psmisc
+    apt-get -y install python3-venv podman wireguard uuid-runtime jq openssl psmisc
 elif [[ "${ID}" == "ubuntu" && "${VERSION_ID}" == "20.04" && "${CI}" == "true" && "${GITHUB_ACTIONS}" == "true" ]]; then
     apt-get update
     apt-get -y install wireguard


### PR DESCRIPTION
On a fresh-installed Debian gnupg is not installed, this will cause a
failure when calling "apt-key add"

Regression from #220 