### PR TITLE
lddaproxy lib: handle external domains

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/ldapproxy.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/ldapproxy.py
@@ -20,6 +20,7 @@
 
 import redis
 import os
+import cluster.userdomains
 
 class Ldapproxy:
 
@@ -71,13 +72,13 @@ class Ldapproxy:
             pass
 
         domains = {}
-        for ksrv in rdb.scan_iter('*/srv/tcp/ldap'):
-            dhx = rdb.hgetall(ksrv)
-            if 'domain' in dhx:
-                domains.setdefault(dhx['domain'], dhx)
+        configured_domains = cluster.userdomains.list_domains(rdb)
+        for domain in configured_domains:
+            dhx = configured_domains[domain]
+            domains.setdefault(domain, dhx)
 
-            if dhx['domain'] in domain_port:
-                domains[dhx['domain']].setdefault('listen_port', domain_port[dhx['domain']])
+            if domain in domain_port:
+                domains[domain].setdefault('listen_port', domain_port[domain])
 
         rdb.close()
         return domains

--- a/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
@@ -22,6 +22,7 @@ import redis
 import ldap3
 import ssl
 import sys
+import agent
 
 def probe_ldap_basedn(config, ldapconn=None):
     if ldapconn is None:
@@ -200,3 +201,25 @@ def get_external_domains(rdb):
             del domains[domain_id]
 
     return domains
+
+def list_domains(rdb = None):
+    domains = {}
+    if not rdb:
+        rdb = agent.redis_connect()
+
+    domains = get_internal_domains(rdb)
+    domains.update(get_external_domains(rdb))
+    return domains
+
+def get_domain(domain):
+    rdb = agent.redis_connect()
+    internal_domains = get_internal_domains(rdb)
+    for dom in internal_domains:
+        if dom == domain:
+            return internal_domains[dom]
+    external_domains = get_external_domains(rdb)
+    for dom in external_domains:
+        if dom == domain:
+            return external_domains[dom]
+
+    return None

--- a/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
@@ -210,16 +210,3 @@ def list_domains(rdb = None):
     domains = get_internal_domains(rdb)
     domains.update(get_external_domains(rdb))
     return domains
-
-def get_domain(domain):
-    rdb = agent.redis_connect()
-    internal_domains = get_internal_domains(rdb)
-    for dom in internal_domains:
-        if dom == domain:
-            return internal_domains[dom]
-    external_domains = get_external_domains(rdb)
-    for dom in external_domains:
-        if dom == domain:
-            return external_domains[dom]
-
-    return None


### PR DESCRIPTION
Ldapproxy can now handle domains connected to remote account providers.

See also NethServer/ns8-ldapproxy#3