### PR TITLE
Drop agent package dependency in cluster.userdomains

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
@@ -22,7 +22,6 @@ import redis
 import ldap3
 import ssl
 import sys
-import agent
 
 def probe_ldap_basedn(config, ldapconn=None):
     if ldapconn is None:
@@ -202,11 +201,7 @@ def get_external_domains(rdb):
 
     return domains
 
-def list_domains(rdb = None):
-    domains = {}
-    if not rdb:
-        rdb = agent.redis_connect()
-
+def list_domains(rdb):
     domains = get_internal_domains(rdb)
     domains.update(get_external_domains(rdb))
     return domains


### PR DESCRIPTION
Existing similar functions receive a Redis opened connection handle
as mandatory argument. The package should not open new connections by
itself.