### PR TITLE
agent systemd unit: fix AGENT_ID

### DIFF
--- a/core/imageroot/etc/systemd/system/agent@.service
+++ b/core/imageroot/etc/systemd/system/agent@.service
@@ -3,7 +3,7 @@ Description=Rootfull %I agent
 
 [Service]
 Type=simple
-Environment=AGENT_ID=module/%I
+Environment=AGENT_ID=module/%i
 Environment=AGENT_INSTALL_DIR=/var/lib/nethserver/%i
 Environment=AGENT_STATE_DIR=/var/lib/nethserver/%i/state
 EnvironmentFile=/etc/nethserver/agent.env


### PR DESCRIPTION
If a module has the `-` char, the symbol is replaced with a `/`
generating an invalid agent_id