### PR TITLE
Fix api-cli auto completion

### DIFF
--- a/core/imageroot/etc/profile.d/api-cli.sh
+++ b/core/imageroot/etc/profile.d/api-cli.sh
@@ -20,6 +20,10 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+if [ $SHELL != '/bin/bash' ]; then
+    return
+fi
+
 _apicli_wastyped()
 {
     local xword checkword="$1"

--- a/core/imageroot/etc/profile.d/api-cli.sh
+++ b/core/imageroot/etc/profile.d/api-cli.sh
@@ -41,7 +41,7 @@ _apicli_completions()
     local actions=()
 
     if _apicli_wastyped "run"; then
-        actions+=($(api-cli list-actions))
+        actions+=($(api-cli list-actions "${cword}"))
         COMPREPLY+=($(compgen -W "${actions[*]}" -- "${cword}"))
     elif _apicli_wastyped "login"; then
         COMPREPLY+=($(compgen -W "--username --password --output --help" -- "${cword}"))

--- a/core/imageroot/usr/local/bin/api-cli
+++ b/core/imageroot/usr/local/bin/api-cli
@@ -29,6 +29,7 @@ import sys
 import getpass
 import agent
 import signal
+import fnmatch
 
 # Handled exceptions:
 from aiohttp import ClientError
@@ -153,10 +154,40 @@ def run_command(args):
 
 def list_actions_command(args):
     rdb = agent.redis_connect()
-    for krole in rdb.scan_iter('*/roles/owner'):
+
+    action_list = None
+
+    def run_list_actions(agent_id):
+        return agent.tasks.run(agent_id, 'list-actions', {}, endpoint='redis://cluster-leader')['output']
+
+    def print_matches(action_list, agent_id, paction):
+        for naction in action_list:
+            if fnmatch.fnmatch(naction, paction):
+                print(agent_id + '/' + naction)
+
+    if '*' in args.prefix: # assume a complete action pattern
+        agent_id, paction = args.prefix.rsplit('/', 1)
+        print_matches(run_list_actions(), agent_id, paction)
+        return 0
+
+    if args.prefix not in ['module/', 'node/', ''] and args.prefix[-1] == '/':
+        scanpat = args.prefix + 'roles/owner'
+    else:
+        scanpat = args.prefix + '*/roles/owner'
+
+    rolekeys = list(rdb.scan_iter(scanpat))
+
+    if len(rolekeys) == 1: # exact role match: dig it more
+        krole = rolekeys.pop()
         agent_id = krole.removesuffix('/roles/owner')
-        for action in rdb.smembers(krole):
-            print(f"{agent_id}/{action}")
+        action_list = run_list_actions(agent_id)
+        for paction in rdb.smembers(krole):
+            print_matches(action_list, agent_id, paction)
+    else: # just print out entries for agent_id completion
+        for krole in rolekeys:
+            agent_id = krole.removesuffix('roles/owner')
+            print(agent_id)
+
     return 0
 
 root_parser = argparse.ArgumentParser(description='Invoke cluster APIs from the command line')
@@ -187,6 +218,7 @@ submit_parser.add_argument('--nowait', help='do not wait for task completion. Re
 submit_parser.add_argument('--raw', help='convert output with print() instead dumping it in JSON format', action='store_true')
 
 list_actions_parser = subparsers.add_parser('list-actions', help='list actions granted to role "owner"')
+list_actions_parser.add_argument('prefix', default='', nargs='?', help='expand and filter with the given prefix')
 
 args = root_parser.parse_args()
 

--- a/core/imageroot/usr/local/bin/api-cli
+++ b/core/imageroot/usr/local/bin/api-cli
@@ -160,20 +160,28 @@ def list_actions_command(args):
     def run_list_actions(agent_id):
         return agent.tasks.run(agent_id, 'list-actions', {}, endpoint='redis://cluster-leader')['output']
 
-    def print_matches(action_list, agent_id, paction):
+    def print_matches(action_list, agent_id, paction, action_name):
+        if not action_name:
+            action_name = '*'
         for naction in action_list:
-            if fnmatch.fnmatch(naction, paction):
+            if fnmatch.fnmatch(naction, paction) and fnmatch.fnmatch(naction, action_name):
                 print(agent_id + '/' + naction)
 
-    if '*' in args.prefix: # assume a complete action pattern
-        agent_id, paction = args.prefix.rsplit('/', 1)
-        print_matches(run_list_actions(), agent_id, paction)
-        return 0
+    prefix = args.prefix
+    if not '*' in prefix:
+        prefix += '*' # append trailing slash
 
-    if args.prefix not in ['module/', 'node/', ''] and args.prefix[-1] == '/':
-        scanpat = args.prefix + 'roles/owner'
+    agent_type, agent_name, action_name = (prefix.split('/', 2) + [None, None, None])[0:3]
+
+    if agent_type == 'cluster': # shift positions
+        action_name = agent_name
+        agent_name = None
+        scanpat = 'cluster/roles/owner'
     else:
-        scanpat = args.prefix + '*/roles/owner'
+        scanpat = agent_type
+        if agent_name:
+            scanpat += '/' + agent_name
+        scanpat += '/roles/owner'
 
     rolekeys = list(rdb.scan_iter(scanpat))
 
@@ -181,8 +189,8 @@ def list_actions_command(args):
         krole = rolekeys.pop()
         agent_id = krole.removesuffix('/roles/owner')
         action_list = run_list_actions(agent_id)
-        for paction in rdb.smembers(krole):
-            print_matches(action_list, agent_id, paction)
+        for pataction in rdb.smembers(krole):
+            print_matches(action_list, agent_id, pataction, action_name)
     else: # just print out entries for agent_id completion
         for krole in rolekeys:
             agent_id = krole.removesuffix('roles/owner')


### PR DESCRIPTION
Since #186 the `api-cli` Bash auto completion is broken. This PR aims to fix it. Refs fb1e605e8f6a440aa03fecbc761f8dbbe4ba2625

The completion token is passed by the Bash function to `api-cli list-actions [prefix]`, as the search `prefix`.

The prefix is used to generate the correct completion list. Only when a full AGENT_ID is completed, the full action list is retrieved with a `list-actions` action call.