### PR TITLE
Add docs note for images in Podman local storage

### DIFF
--- a/docs/modules/updates.md
+++ b/docs/modules/updates.md
@@ -35,3 +35,16 @@ Make sure the `imageroot/update-module.d/20restart` is executable.
 To update an instance from command line, use:
 
      api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/mymodule:latest","instances":["mymodule1"]}'
+
+If the given `module_url` is already present in the local Podman storage,
+no remote download occurs and the local image is used instead. During
+development this might be unwanted and to work around this behavior
+execute the following command in every cluster node, before running
+`update-module`:
+
+    podman rmi ghcr.io/nethserver/mymodule:latest
+
+Depending on the module implementation, the module Podman local storage
+might store auxiliary module images that must be removed as well. E.g.
+
+    ssh mymodule1@localhost podman rmi docker.io/library/postgres:13-alpine

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -103,6 +103,13 @@ Example to install Dokuwiki directly from the image registry:
 add-module ghcr.io/nethserver/dokuwiki:mydev 1
 ```
 
+If the given image is already present in the local Podman storage, no
+remote download occurs and the local image is used instead. During
+development this might be unwanted and to work around this behavior
+execute the following command in every cluster node, before `add-module`:
+
+    podman rmi ghcr.io/nethserver/dokuwiki:mydev
+
 Many applications need a configuration step after install, for more info, 
 please refer to the README of each application.
 


### PR DESCRIPTION
During development, some local Podman images might override remote ones, producing unexpected behavior.

The typical case is when a `:latest` image tag is used to install/update a module instance that was already downloaded.