### PR TITLE
Hide builtin users and groups

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/ldapclient/ad.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/ldapclient/ad.py
@@ -57,7 +57,7 @@ class LdapclientAd(LdapclientBase):
         raise LdapclientEntryNotFound()
 
     def list_groups(self):
-        response = self.ldapconn.search(self.base_dn, '(&(objectClass=group))',
+        response = self.ldapconn.search(self.base_dn, '(&(objectClass=group)(groupType:1.2.840.113556.1.4.803:=2))',
             attributes=['cn','member','description', 'sAMAccountName'],
         )[2]
 


### PR DESCRIPTION
Some users and groups are specific to the account provider implementation. The UI cannot manipulate them correctly. In ns7 we implemented an hide-list of well known items. We should implement something similar in ns8...

For instance
- (openldap) "locals"
- (samba) "Domain Controllers", "krbtgt", "guest"


See https://trello.com/c/a2a9oYn2/210-hide-builtin-users-and-groups