### PR TITLE
Fix CentOS Stream 9 installation

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -30,6 +30,7 @@ source /etc/os-release
 
 echo "Install dependencies:"
 if [[ ${ID} == "centos" && "${PLATFORM_ID}" == "platform:el9" ]]; then
+    dnf update -y # Fix SELinux issues with basic packages
     dnf install -y wireguard-tools podman jq openssl firewalld
     systemctl enable --now firewalld
 elif [[ "${ID}" == "debian" && "${VERSION_ID}" == "11" ]]; then


### PR DESCRIPTION
Additional packages are incompatible with base installation. An update is
required to fix SELinux policies.