### PR TITLE
Log match for module subcomponents

### DIFF
--- a/core/api-server/socket/action.go
+++ b/core/api-server/socket/action.go
@@ -117,7 +117,7 @@ func Action(socketAction models.SocketAction, s *melody.Session, wg *sync.WaitGr
 
 		// check filter
 		if len(logsAction.Filter) > 0 {
-			filter = "json | line_format \"{{.SYSLOG_TIMESTAMP}} {{.SYSLOG_IDENTIFIER}} {{.nodename}} {{.MESSAGE}}\" |= `" + logsAction.Filter + "`"
+			filter = "json | line_format \"{{.SYSLOG_IDENTIFIER}} {{.nodename}} {{.MESSAGE}}\" |= `" + logsAction.Filter + "`"
 		} else {
 			filter = "json"
 		}

--- a/core/api-server/socket/action.go
+++ b/core/api-server/socket/action.go
@@ -128,7 +128,7 @@ func Action(socketAction models.SocketAction, s *melody.Session, wg *sync.WaitGr
 			entity = "{job=\"systemd-journal\"} | " + filter + " | line_format \"{{.nodename}} {{.MESSAGE}}\""
 
 		case "node":
-			entity = "{nodename=\"" + logsAction.EntityName + "\"} | " + filter + " | line_format \"{{.nodename}} {{.MESSAGE}}\""
+			entity = "{nodename=\"" + logsAction.EntityName + "\"} | " + filter + " | line_format \"{{.MESSAGE}}\""
 
 		case "module":
 			entity = "{job=\"systemd-journal\"} | " + filter + " | SYSLOG_IDENTIFIER=~\"" + logsAction.EntityName + "(/.+)?\" | line_format \"{{.SYSLOG_IDENTIFIER}} {{.MESSAGE}}\""

--- a/core/api-server/socket/action.go
+++ b/core/api-server/socket/action.go
@@ -117,7 +117,7 @@ func Action(socketAction models.SocketAction, s *melody.Session, wg *sync.WaitGr
 
 		// check filter
 		if len(logsAction.Filter) > 0 {
-			filter = "json |  line_format \"{{.SYSLOG_TIMESTAMP}} {{.nodename}} {{.MESSAGE}}\" |= `" + logsAction.Filter + "`"
+			filter = "json | line_format \"{{.SYSLOG_TIMESTAMP}} {{.SYSLOG_IDENTIFIER}} {{.nodename}} {{.MESSAGE}}\" |= `" + logsAction.Filter + "`"
 		} else {
 			filter = "json"
 		}
@@ -131,7 +131,7 @@ func Action(socketAction models.SocketAction, s *melody.Session, wg *sync.WaitGr
 			entity = "{nodename=\"" + logsAction.EntityName + "\"} | " + filter + " | line_format \"{{.nodename}} {{.MESSAGE}}\""
 
 		case "module":
-			entity = "{job=\"systemd-journal\"} | " + filter + " | SYSLOG_IDENTIFIER=\"" + logsAction.EntityName + "\" | line_format \"{{.nodename}} {{.MESSAGE}}\""
+			entity = "{job=\"systemd-journal\"} | " + filter + " | SYSLOG_IDENTIFIER=~\"" + logsAction.EntityName + "(/.+)?\" | line_format \"{{.SYSLOG_IDENTIFIER}} {{.MESSAGE}}\""
 
 		}
 		args = append(args, entity)


### PR DESCRIPTION
Some modules provide multiple log sources (subcomponents). E.g. Mail has distinct Postfix components with a "/suffix" qualifier:

- mail1
- mail1/anvil
- mail1/master
- mail1/submission/smtpd

This PR changes the Log page filter/match logic to include the "/suffix" notation for such modules.

See individual commit for details.