### PR TITLE
Validate create-cluster join-cluster APIs

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/00validate_cluster
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/00validate_cluster
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import agent
+
+request = json.load(sys.stdin)
+
+rdb = agent.redis_connect()
+
+network = rdb.get('cluster/network')
+
+if network:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'network', 'parameter':'network','value': request['network'], 'error':'cluster_network_already_set'}], fp=sys.stdout)
+    sys.exit(2)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/00validate_cluster
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/00validate_cluster
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import agent
+
+request = json.load(sys.stdin)
+
+rdb = agent.redis_connect()
+
+network = rdb.get('cluster/network')
+
+if network:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'url', 'parameter':'url','value': request['url'], 'error':'cluster_network_already_set'}], fp=sys.stdout)
+    sys.exit(2)


### PR DESCRIPTION
Fail if the cluster is already configured.

This is just a safeguard measure against issuing create-cluster or join-cluster multiple times. It might be hard to recover in that case.