### PR TITLE
Clean up old module and core images

### DIFF
--- a/core/build-image.sh
+++ b/core/build-image.sh
@@ -78,7 +78,7 @@ chmod -c 644 "${core_env_file}"
 source "${core_env_file}"
 buildah add "${container}" ${core_env_file} /etc/nethserver/core.env
 buildah config \
-    --label="org.nethserver.images=${REDIS_IMAGE} ${RCLONE_IMAGE}" \
+    --label="org.nethserver.images=${REDIS_IMAGE} ${RCLONE_IMAGE} ${RSYNC_IMAGE} ${RESTIC_IMAGE}" \
     --label="org.nethserver.flags=core_module" \
     --entrypoint=/ "${container}"
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/core/imageroot/usr/local/agent/actions/destroy-module/95cleanup_images
+++ b/core/imageroot/usr/local/agent/actions/destroy-module/95cleanup_images
@@ -12,5 +12,5 @@ if [[ $EUID == 0 ]]; then
     # Rootfull module, remove the module images
     podman inspect -f json "${IMAGE_ID:-none}" | \
         jq -r '.[0].Config.Labels."org.nethserver.images"' | \
-        xargs -t -- podman rmi --ignore "${IMAGE_ID:-none}" || :
+        xargs -t -- podman rmi "${IMAGE_ID:-none}" 2>/dev/null || :
 fi

--- a/core/imageroot/usr/local/agent/actions/update-module/95cleanup_images
+++ b/core/imageroot/usr/local/agent/actions/update-module/95cleanup_images
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+set -e
+
+# Clean up local images that are no longer required by the new module
+# version
+
+export LC_ALL=C # required by sort for portability
+
+# Find the images that are no longer required
+diff <(
+    echo "${IMAGE_ID}"
+    podman inspect -f json "${IMAGE_ID:-none}" | \
+            jq -r '.[0].Config.Labels."org.nethserver.images" | split(" ") | join("\n")' | \
+            sort -c
+) <(
+    echo "${PREV_IMAGE_ID}"
+    podman inspect -f json "${PREV_IMAGE_ID:-none}" | \
+            jq -r '.[0].Config.Labels."org.nethserver.images" | split(" ") | join("\n")' | \
+            sort -c
+) | sed -n '/< / s/< //p' | \
+    xargs -t -- podman rmi 2>/dev/null || :

--- a/core/imageroot/var/lib/nethserver/node/actions/update-core/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/update-core/50update
@@ -56,6 +56,10 @@ agent.run_helper('podman-pull-missing', core_url,
     progress_callback=agent.get_progress_callback(0,40)
 ).check_returncode()
 
+# Get the old Podman image Id
+with subprocess.Popen(['podman', 'image', 'inspect', '-f', '{{.Id}}', core_env['CORE_IMAGE']], stdout=subprocess.PIPE, stderr=sys.stderr) as proc:
+    agent.set_env('PREV_IMAGE_ID', proc.stdout.rstrip())
+
 # Parse the image labels
 with subprocess.Popen(['podman', 'image', 'inspect', core_url], stdout=subprocess.PIPE, stderr=sys.stderr) as proc:
     inspect = json.load(proc.stdout)
@@ -63,6 +67,7 @@ with subprocess.Popen(['podman', 'image', 'inspect', core_url], stdout=subproces
     inspect_image_id = inspect[0]['Id']
     inspect_image_digest = inspect[0]['Digest']
     inspect_image_repodigest = inspect[0]['RepoDigests'][0]
+    agent.set_env('IMAGE_ID', inspect_image_id)
 
 if 'org.nethserver.images' in inspect_labels:
     extra_images = inspect_labels['org.nethserver.images'].split()

--- a/core/imageroot/var/lib/nethserver/node/actions/update-core/95cleanup_images
+++ b/core/imageroot/var/lib/nethserver/node/actions/update-core/95cleanup_images
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+set -e
+
+# Clean up local images that are no longer required by the new core
+# version
+
+export LC_ALL=C # required by sort for portability
+
+source /etc/nethserver/core.env
+
+# Find the images that are no longer required
+diff <(
+    echo "${IMAGE_ID}"
+    podman inspect -f json "${IMAGE_ID:-none}" | \
+            jq -r '.[0].Config.Labels."org.nethserver.images" | split(" ") | join("\n")' | \
+            sort -c
+) <(
+    echo "${PREV_IMAGE_ID}"
+    podman inspect -f json "${PREV_IMAGE_ID:-none}" | \
+            jq -r '.[0].Config.Labels."org.nethserver.images" | split(" ") | join("\n")' | \
+            sort -c
+) | sed -n '/< / s/< //p' | \
+    xargs -t -- podman rmi 2>/dev/null || :

--- a/core/imageroot/var/lib/nethserver/node/install-core.sh
+++ b/core/imageroot/var/lib/nethserver/node/install-core.sh
@@ -87,7 +87,11 @@ cluster_pwhash=$(echo -n "${cluster_password}" | sha256sum | awk '{print $1}')
     printf "REDIS_PASSWORD=%s\n" "${cluster_password}"
     printf "REDIS_ADDRESS=127.0.0.1:6379\n" # Override the cluster-leader /etc/hosts record
 )
-printf "NODE_ID=1\n" > /var/lib/nethserver/cluster/state/environment
+echo "Write initial cluster environment state"
+(exec > /var/lib/nethserver/cluster/state/environment
+    printf "NODE_ID=1\n"
+    printf "IMAGE_ID=%s\n" $(podman image inspect -f '{{.Id}}' "${CORE_IMAGE}")
+)
 
 echo "Generating api-server password:"
 apiserver_password=$(podman exec redis redis-cli ACL GENPASS)

--- a/core/tests/10__cluster_sanity/60__clone_module.robot
+++ b/core/tests/10__cluster_sanity/60__clone_module.robot
@@ -72,7 +72,7 @@ Add a dummy instance
     Set Suite Variable    ${DUMMY_MODULE}    ${response['module_id']}
 
 Cleanup the dummy image
-    Execute Command    podman rmi --ignore localhost/dummy:latest
+    Execute Command    podman rmi localhost/dummy:latest
 
 Set the dummy instance name
     Run task    module/${DUMMY_MODULE}/set-name    {"name":"${DUMMY_NAME}"}    decode_json=${FALSE}

--- a/docs/modules/agent.md
+++ b/docs/modules/agent.md
@@ -22,8 +22,9 @@ The core provides a set of base actions defined in
 
 - `create-module`: executed upon installation, it automatically downloads the module image and all images
   listed inside `org.nethserver.images` label.
-- `remove-module`: executed on module removal, modules can add here scripts to remove configuration executed on
-  other modules, like Traefik routes
+- `destroy-module`: executed on module removal; modules can add here
+  scripts to clean up configuration, like Traefik routes, Firewalld,
+  system-wide Systemd units...
 - `get-status`: used by the UI, it returns the current module status, like the node where the application is running, used images and volumes, systemd units status.
   This action works correctly only for rootless modules.
 - `list-service-providers`: Look up provider information for a given


### PR DESCRIPTION
- When a module is updated, remove the old image from the Podman storage
- When the core is updated, remove the old core images from the Podman
storage

Removing the old images frees up disk space and forces the image
complete download, which is important during development to avoid
unexpected install of stale images, especially in worker nodes.