### PR TITLE
Catatonit must be installed to create pod

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -31,7 +31,7 @@ source /etc/os-release
 echo "Install dependencies:"
 if [[ ${ID} == "centos" && "${PLATFORM_ID}" == "platform:el9" ]]; then
     dnf update -y # Fix SELinux issues with basic packages
-    dnf install -y wireguard-tools podman jq openssl firewalld
+    dnf install -y wireguard-tools podman jq openssl firewalld catatonit
     systemctl enable --now firewalld
 elif [[ "${ID}" == "debian" && "${VERSION_ID}" == "11" ]]; then
     apt-get update


### PR DESCRIPTION
Catatonit could not be installed on a minimal installation (find in digital ocean), when we try to start a pod we have an error

```
systemd[58561]: Starting Loki pod service...
Aug 10 11:24:54 mattermost.nethserver.fr podman[58943]: Error: building local pause image: finding pause binary: exec: "catatonit": executable file not found in $PATH
```

we need to install catatonit to fix the issue

```
[root@mattermost ~]# rpm -qa catatonit podman
podman-4.1.1-6.el9.x86_64
catatonit-0.1.7-7.el9.x86_64
```