### PR TITLE
podman-catatonit conflicts catatonit

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -31,7 +31,7 @@ source /etc/os-release
 echo "Install dependencies:"
 if [[ ${ID} == "centos" && "${PLATFORM_ID}" == "platform:el9" ]]; then
     dnf update -y # Fix SELinux issues with basic packages
-    dnf install -y wireguard-tools podman jq openssl firewalld catatonit
+    dnf install -y wireguard-tools podman jq openssl firewalld
     systemctl enable --now firewalld
 elif [[ "${ID}" == "debian" && "${VERSION_ID}" == "11" ]]; then
     apt-get update


### PR DESCRIPTION




```
[root@ns8loc ~]# curl https://raw.githubusercontent.com/NethServer/ns8-core/main/core/install.sh | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2559  100  2559    0     0   7849      0 --:--:-- --:--:-- --:--:--  7849
Restart journald:
Install dependencies:
CentOS Stream 9 - BaseOS                                                                              19 kB/s |  10 kB     00:00    
CentOS Stream 9 - BaseOS                                                                             2.2 MB/s | 5.9 MB     00:02    
CentOS Stream 9 - AppStream                                                                           17 kB/s |  11 kB     00:00    
CentOS Stream 9 - AppStream                                                                           11 MB/s |  15 MB     00:01    
CentOS Stream 9 - CRB                                                                                 17 kB/s |  10 kB     00:00    
CentOS Stream 9 - CRB                                                                                5.0 MB/s | 4.7 MB     00:00    
CentOS Stream 9 - Extras packages                                                                     23 kB/s |  12 kB     00:00    
Error: 
 Problem: package podman-2:4.2.0-3.el9.x86_64 conflicts with catatonit provided by catatonit-3:0.1.7-7.el9.x86_64
  - cannot install the best update candidate for package podman-2:4.1.1-6.el9.x86_64
  - cannot install the best update candidate for package catatonit-3:0.1.7-7.el9.x86_64
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```


```
[root@ns8loc ~]# dnf install catatonit
Last metadata expiration check: 0:03:58 ago on Thu 01 Sep 2022 04:26:36 PM CEST.
Error: 
 Problem: problem with installed package podman-catatonit-2:4.2.0-3.el9.x86_64
  - package podman-catatonit-2:4.2.0-3.el9.x86_64 requires podman = 2:4.2.0-3.el9, but none of the providers can be installed
  - package podman-2:4.2.0-3.el9.x86_64 conflicts with catatonit provided by catatonit-3:0.1.7-7.el9.x86_64
  - package catatonit-3:0.1.7-7.el9.x86_64 obsoletes podman-catatonit <= 2:4.1.2 provided by podman-catatonit-2:4.1.0-4.el9.x86_64
  - package catatonit-3:0.1.7-7.el9.x86_64 obsoletes podman-catatonit <= 2:4.1.2 provided by podman-catatonit-2:4.1.1-1.el9.x86_64
  - package catatonit-3:0.1.7-7.el9.x86_64 obsoletes podman-catatonit <= 2:4.1.2 provided by podman-catatonit-2:4.1.1-3.el9.x86_64
  - cannot install the best candidate for the job
  - nothing provides podman = 2:4.0.3-1.el9 needed by podman-catatonit-2:4.0.3-1.el9.x86_64
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)

```