### PR TITLE
Import volumes for rootfull modules

### DIFF
--- a/core/imageroot/usr/local/agent/actions/import-module/05create_volumes
+++ b/core/imageroot/usr/local/agent/actions/import-module/05create_volumes
@@ -24,10 +24,17 @@ import sys
 import agent
 import json
 import subprocess
+import os
 
 request = json.load(sys.stdin)
+is_rootfull = (os.geteuid() == 0)
+module_id = os.environ['MODULE_ID']
 
-create_volumes = set(request['volumes'])
+if is_rootfull:
+    create_volumes = set([f'{module_id}-{xvol}' for xvol in request['volumes']])
+else:
+    create_volumes = set(request['volumes'])
+
 with subprocess.Popen(['podman', 'volume', 'ls', '--format=json'], stdout=subprocess.PIPE) as vproc:
     for vobj in json.load(vproc.stdout):
         create_volumes.discard(vobj['Name']) # Discard volume if already exists

--- a/core/imageroot/usr/local/agent/actions/import-module/10recvstate
+++ b/core/imageroot/usr/local/agent/actions/import-module/10recvstate
@@ -43,7 +43,7 @@ podman_cmd = ['podman', 'run', '--rm', '--privileged', '--network=host', '--work
         '--env=RSYNCD_PASSWORD=' + password,
         '--env=RSYNCD_SYSLOG_TAG=' + os.environ['MODULE_ID'],
         '--volume=/dev/log:/dev/log',
-        '--name=rsync',
+        '--name=rsync-' + os.environ['MODULE_ID'],
     ] + agent.get_existing_volume_args()
 
 core_env = agent.read_envfile('/etc/nethserver/core.env') # Import URLs of core images

--- a/core/imageroot/usr/local/agent/actions/import-module/validate-input.json
+++ b/core/imageroot/usr/local/agent/actions/import-module/validate-input.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "import-module input",
     "$id": "http://schema.nethserver.org/module/import-module-input.json",
-    "description": "Clone the module state received from rsync",
+    "description": "Import the module state from an external procedure with rsync",
     "examples": [
         {
             "credentials": [
@@ -12,6 +12,17 @@
             "port": 20027,
             "volumes": [
                 "dokuwiki-data"
+            ]
+        },
+        {
+            "credentials": [
+                "samba3",
+                "s3cr3t"
+            ],
+            "port": 20028,
+            "volumes": [
+                "data",
+                "config"
             ]
         }
     ],
@@ -27,7 +38,8 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "title": "Name of the volume element"
+                "name": "Volume name",
+                "description": "For rootfull modules, the given volume name is prefixed automatically with the module ID"
             }
         },
         "port": {


### PR DESCRIPTION
Volume names convention for rootfull modules wants the module ID as volume name prefix.

It is not possible to predict the module ID and use it to build correct volume names for rootfull modules.

This commit automatically adds the prefix for rootfull module volumes during the import-module action.