### PR TITLE
Add counters to list-user-domains API

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-domain-groups/50list_groups
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-domain-groups/50list_groups
@@ -24,6 +24,7 @@ import sys
 import json
 from agent.ldapproxy import Ldapproxy
 from agent.ldapclient import Ldapclient
+import agent
 
 request = json.load(sys.stdin)
 
@@ -33,3 +34,6 @@ groups = Ldapclient.factory(**domain).list_groups()
 
 groups = sorted(groups, key=lambda rec: rec['group'].lower())
 json.dump({"groups":groups}, fp=sys.stdout)
+
+with agent.redis_connect(privileged=True) as rdb:
+    rdb.set(f"cluster/counters_cache/groups/{request['domain']}", len(groups))

--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-domain-users/50list_users
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-domain-users/50list_users
@@ -24,6 +24,7 @@ import sys
 import json
 from agent.ldapproxy import Ldapproxy
 from agent.ldapclient import Ldapclient
+import agent
 
 request = json.load(sys.stdin)
 
@@ -33,3 +34,6 @@ users = Ldapclient.factory(**domain).list_users()
 
 users = sorted(users, key=lambda rec: rec['user'])
 json.dump({"users":users}, fp=sys.stdout)
+
+with agent.redis_connect(privileged=True) as rdb:
+    rdb.set(f"cluster/counters_cache/users/{request['domain']}", len(users))

--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-user-domains/50read
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-user-domains/50read
@@ -34,6 +34,24 @@ external_domains = cluster.userdomains.get_external_domains(rdb)
 
 domains = external_domains | internal_domains
 
+# Add default counters object
+for kdom in domains:
+    
+    try:
+        users_count = int(rdb.get(f"cluster/counters_cache/users/{kdom}"))
+    except TypeError: 
+        users_count = None
+
+    try:
+        groups_count = int(rdb.get(f"cluster/counters_cache/groups/{kdom}"))
+    except TypeError:
+        groups_count = None
+
+    domains[kdom]['counters'] = {
+        "users": users_count,
+        "groups": groups_count,
+    }
+
 for kdom in rdb.scan_iter("module/*/user_domain"):
     module_id = kdom.split('/', 2)[1]
     user_domain = rdb.get(kdom)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-user-domains/50read
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-user-domains/50read
@@ -34,9 +34,7 @@ external_domains = cluster.userdomains.get_external_domains(rdb)
 
 domains = external_domains | internal_domains
 
-# Add default counters object
 for kdom in domains:
-    
     try:
         users_count = int(rdb.get(f"cluster/counters_cache/users/{kdom}"))
     except TypeError: 

--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-user-domains/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-user-domains/validate-output.json
@@ -23,6 +23,10 @@
                     "bind_password": "S3cr3t!",
                     "tls": false,
                     "tls_verify": false,
+                    "counters": {
+                        "users": null,
+                        "groups": null
+                    },
                     "providers": [
                         {
                             "id": "openldap1",
@@ -50,6 +54,10 @@
                     "bind_password": "OtherS3cr3t!",
                     "tls": true,
                     "tls_verify": true,
+                    "counters": {
+                        "users": 15,
+                        "groups": 3
+                    },
                     "providers": [
                         {
                             "id": "ldap-primary.company.org",
@@ -99,6 +107,7 @@
                 "name",
                 "location",
                 "protocol",
+                "counters",
                 "providers"
             ],
             "properties": {
@@ -114,6 +123,31 @@
                         "internal",
                         "external"
                     ]
+                },
+                "counters": {
+                    "type": "object",
+                    "title": "Counters",
+                    "description": "The cached number of users and groups returned by their respective last API calls",
+                    "required": [
+                        "users",
+                        "groups"
+                    ],
+                    "properties": {
+                        "users": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "title": "User counter"
+                        },
+                        "groups": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "title": "Group counter"
+                        }
+                    }
                 },
                 "protocol": {
                     "type": "string",

--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-external-domain/50remove_domain
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-external-domain/50remove_domain
@@ -46,6 +46,8 @@ if not domain in domains:
     json.dump([{'field':'domain', 'parameter':'domain','value': domain, 'error':'domain_not_found'}], fp=sys.stdout)
     sys.exit(2)
 
+rdb.delete(f"cluster/counters_cache/users/{domain}", f"cluster/counters_cache/groups/{domain}")
+
 protocol = domains[domain]['protocol']
 
 removed_keys = rdb.delete(*list(rdb.scan_iter(f"cluster/user_domain/{protocol}/{domain}/*")))

--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-domain/50remove_domain
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-domain/50remove_domain
@@ -64,3 +64,6 @@ errors = agent.tasks.runp_brief(remove_tasks,
 if errors > 0:
     print(agent.SD_ERR + f"There were errors during user domain {domk} removal. Check the subtasks for details.", file=sys.stderr)
     sys.exit(1)
+
+with agent.redis_connect(privileged=True) as rdb:
+    rdb.delete(f"cluster/counters_cache/users/{kdom}", f"cluster/counters_cache/groups/{kdom}")

--- a/docs/core/database.md
+++ b/docs/core/database.md
@@ -182,6 +182,8 @@ Legend:
 |cluster/user_domain/ldap/{domain}/conf tls_verify      |STRING |Can be `on` or `off`|
 |cluster/user_domain/ldap/{domain}/providers            |LIST   |List of domain provider hosts|
 |cluster/user_domain/ldap/{domain}/ui_names             |HASH   |UI labels for domain providers. The key is the provider name, eg `ldap.ns.test:389` => `mylabel`|
+|cluster/counters_cache/users/{domain}                  |INT    |Cached number of users in the domain, updated by list APIs|
+|cluster/counters_cache/groups/{domain}                 |INT    |Cached number of groups in the domain, updated by list APIs|
 
 ### node
 


### PR DESCRIPTION
Return the number of users and groups in the domain as cached from the last run of list-domain-groups/users.