### PR TITLE
Fix internal/external user domains priority

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
@@ -203,4 +203,6 @@ def get_external_domains(rdb):
 
 def list_domains(rdb):
     # Internal domains have higher precedence and override external ones:
-    return get_external_domains(rdb) | get_internal_domains(rdb)
+    domains = get_external_domains()
+    domains.update(get_internal_domains())
+    return domains

--- a/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
@@ -202,6 +202,5 @@ def get_external_domains(rdb):
     return domains
 
 def list_domains(rdb):
-    domains = get_internal_domains(rdb)
-    domains.update(get_external_domains(rdb))
-    return domains
+    # Internal domains have higher precedence and override external ones:
+    return get_external_domains(rdb) | get_internal_domains(rdb)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-user-domains/50read
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-user-domains/50read
@@ -29,10 +29,7 @@ unconfigured_domains = []
 
 rdb = agent.redis_connect()
 
-internal_domains = cluster.userdomains.get_internal_domains(rdb) 
-external_domains = cluster.userdomains.get_external_domains(rdb)
-
-domains = external_domains | internal_domains
+domains = cluster.userdomains.list_domains(rdb)
 
 for kdom in domains:
     try:


### PR DESCRIPTION
Honor the same priority of domain records in both API (list-user-domains) and Ldapproxy output.

Domain names must be unique. This rule is enforced by the API validators.

However if validators are bypassed by modules there can be domains with the same name. This commit ensures the internal has higher priority over external.