### PR TITLE
Reduce task expire duration to 8 hours

### DIFF
--- a/core/agent/agent.go
+++ b/core/agent/agent.go
@@ -51,7 +51,7 @@ var actionPaths flagStringSlice
 var eventPaths flagStringSlice
 
 var pollingDuration = 5000 * time.Millisecond
-var taskExpireDuration = 24 * time.Hour
+var taskExpireDuration = 8 * time.Hour
 
 // Command arguments --actionsdir and --eventsdir can be repeated multiple
 // times. Each item is inserted into a []string.


### PR DESCRIPTION
- 8 hours is a work day duration. It should be enough for debugging purposes
- Every day the */task/* keyspace is clean