### PR TITLE
Create events module-added and module-removed

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
@@ -230,6 +230,15 @@ if is_rootfull:
 else:
     rdb.sadd(f'module/{module_id}/flags', 'rootless')
 
+# trigger an event to advertize other modules that a new module has been addded
+agent_id = os.environ['AGENT_ID']
+trx = rdb.pipeline()
+trx.publish(agent_id + '/event/module-added', json.dumps({
+    'module': module_id,
+    'node': node_id,
+}))
+trx.execute()
+
 json.dump({
     "module_id": module_id,
     "image_name": image_id,

--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-module/50update
@@ -24,6 +24,7 @@ import sys
 import json
 import agent
 import agent.tasks
+import os
 
 request = json.load(sys.stdin)
 module_id = request['module_id']
@@ -98,5 +99,15 @@ agent.assert_exp(rdb.execute_command('ACL', 'SAVE') == 'OK')
 # Clean up the local Podman image copy, if still present
 if podman_image_id:
     agent.run_helper("podman", "rmi", "--ignore", podman_image_id)
+
+# trigger an event to advertize other modules that a module has been removed
+agent_id = os.environ['AGENT_ID']
+trx = rdb.pipeline()
+trx.publish(agent_id + '/event/module-removed', json.dumps({
+    'module': module_id,
+    'node': node_id,
+}))
+
+trx.execute()
 
 json.dump({}, fp=sys.stdout)

--- a/docs/core/events.md
+++ b/docs/core/events.md
@@ -22,6 +22,8 @@ Well known events:
 - `account-provider-changed`: the event should be fired by account providers to inform about configuration changes
 - `account-provider-credentials-updated`: the event can be fired by account providers or LDAP proxies,
   it notifies the change of LDAP credentials (eg. `ldapservice` user) to applications
+
+Events fired by the `cluster` agent (i.e. channel is `cluster/event/<event name>`):
 - `module-added`: the event is fired at the end of the add-module process to inform other modules that a new module has been installed on the cluster
 - `module-removed`: the event is fired at the end of the remove-module process to inform other modules that a module has been removed on the cluster
 

--- a/docs/core/events.md
+++ b/docs/core/events.md
@@ -22,6 +22,8 @@ Well known events:
 - `account-provider-changed`: the event should be fired by account providers to inform about configuration changes
 - `account-provider-credentials-updated`: the event can be fired by account providers or LDAP proxies,
   it notifies the change of LDAP credentials (eg. `ldapservice` user) to applications
+- `module-added`: the event is fired at the end of the add-module process to inform other modules that a new module has been installed on the cluster
+- `module-removed`: the event is fired at the end of the remove-module process to inform other modules that a module has been removed on the cluster
 
 ## Signaling events
 


### PR DESCRIPTION
We could need for some modules like fail2ban or crowdsec to be advertized when a module is installed or removed. At the end of the installation or the removal the event is triggered, only module which have subscribed to the event will use them