### PR TITLE
Terminate the user session before to remove the module

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
@@ -42,6 +42,9 @@ if [[ -z $uid ]]; then # Rootfull module
 else # Rootless module
     loginctl disable-linger "${mid}"
     systemctl stop "user@${uid}.service"
+    if pgrep -u "${mid}"; then
+        loginctl terminate-user "${mid}"
+    fi
 
     if [[ ${preserve} == "yes" ]]; then
         userdel "${mid}"

--- a/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
@@ -42,9 +42,7 @@ if [[ -z $uid ]]; then # Rootfull module
 else # Rootless module
     loginctl disable-linger "${mid}"
     systemctl stop "user@${uid}.service"
-    if pgrep -u "${mid}"; then
-        loginctl terminate-user "${mid}"
-    fi
+    loginctl terminate-user "${mid}" &>/dev/null || :
 
     if [[ ${preserve} == "yes" ]]; then
         userdel "${mid}"


### PR DESCRIPTION
When you remove a rootless module, we have to terminate (kill)  all sessions relevant to the user before to remove the module with its associated user.