### PR TITLE
Find the rootfull volumes and remove them

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
@@ -38,6 +38,7 @@ if [[ -z $uid ]]; then # Rootfull module
     systemctl disable --now agent@"${mid}"
     if [[ ${preserve} == "no" ]]; then
         rm -rf "/var/lib/nethserver/${mid}"
+        podman volume rm $(podman volume ls | grep -o "${mid}-\w*")
     fi
 else # Rootless module
     loginctl disable-linger "${mid}"

--- a/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
@@ -38,7 +38,7 @@ if [[ -z $uid ]]; then # Rootfull module
     systemctl disable --now agent@"${mid}"
     if [[ ${preserve} == "no" ]]; then
         rm -rf "/var/lib/nethserver/${mid}"
-        podman volume rm $(podman volume ls | grep -o "${mid}-\w*")
+        podman volume ls | grep -o "${mid}-\w*" | xargs -r -- podman volume rm || :
     fi
 else # Rootless module
     loginctl disable-linger "${mid}"


### PR DESCRIPTION
When we remove a rootfull container, the volumes are not destroyed even if asked

We cannot inspect the containers because at this point the container has been probably removed by the destroy-module action of the container. 

The possibility I see is to state that the documentation asks the volume must be named by  "module_id-something", therefore we could find the volumes and remove them.

 