### PR TITLE
Use Node v18 (enhancements)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "terminal.integrated.env.linux": {
+        "NODE_OPTIONS": "--openssl-legacy-provider"
+    }
+}

--- a/core/build-image.sh
+++ b/core/build-image.sh
@@ -38,7 +38,7 @@ buildah run gobuilder-core sh -c "cd /usr/src/core/api-server && go build -v -ld
 buildah run gobuilder-core sh -c "cd /usr/src/core/api-server && go build -v -ldflags=\"-extldflags=-static\" -tags sqlite_omit_load_extension api-server-logs.go"
 
 echo "Build static UI files with node..."
-buildah run nodebuilder-core sh -c "cd /usr/src/core/ui && yarn install && yarn build"
+buildah run --env="NODE_OPTIONS=--openssl-legacy-provider" nodebuilder-core sh -c "cd /usr/src/core/ui && yarn install && yarn build"
 
 echo "Install tidy..."
 buildah run nodebuilder-core sh -c "apt-get update && apt-get install -y tidy"

--- a/core/ui/.gitignore
+++ b/core/ui/.gitignore
@@ -15,7 +15,6 @@ pnpm-debug.log*
 
 # Editor directories and files
 .idea
-.vscode
 *.suo
 *.ntvs*
 *.njsproj

--- a/core/ui/Containerfile
+++ b/core/ui/Containerfile
@@ -1,4 +1,5 @@
 FROM node:18-slim
 WORKDIR /app
+ENV NODE_OPTIONS=--openssl-legacy-provider
 EXPOSE 8080
 ENTRYPOINT ["./container-entrypoint.sh"]

--- a/core/ui/README.md
+++ b/core/ui/README.md
@@ -58,7 +58,6 @@ podman exec -ti ns8-core yarn storybook
 - Open Command Palette (`CTRL+SHIFT+P`) and type `Reopen in Container`
 - Open VS Code integrated terminal: `View > Terminal`
 - Change directory to `core/ui`
-- Enter `export NODE_OPTIONS=--openssl-legacy-provider` (this is needed for Node v18)
 - Enter one of the commands listed in [Develop NS8 UI on your workstation](#develop-ns8-ui-on-your-workstation), e.g. `yarn serve`
 
 Container configuration is contained inside `.devcontainer/devcontainer.json`.

--- a/core/ui/README.md
+++ b/core/ui/README.md
@@ -56,6 +56,9 @@ podman exec -ti ns8-core yarn storybook
 - Dev Containers uses Docker by default but you can configure it to use Podman: go to `File > Preferences > Settings`, search `dev containers docker path` and type `podman` as `Docker path`
 - Open `ns8-core` directory (the repository root) in VS Code, if you haven't already
 - Open Command Palette (`CTRL+SHIFT+P`) and type `Reopen in Container`
-- Open VS Code integrated terminal, change directory to `core/ui` and then type one of the commands listed in [Develop NS8 UI on your workstation](#develop-ns8-ui-on-your-workstation), e.g. `yarn serve`
+- Open VS Code integrated terminal: `View > Terminal`
+- Change directory to `core/ui`
+- Enter `export NODE_OPTIONS=--openssl-legacy-provider` (this is needed for Node v18)
+- Enter one of the commands listed in [Develop NS8 UI on your workstation](#develop-ns8-ui-on-your-workstation), e.g. `yarn serve`
 
 Container configuration is contained inside `.devcontainer/devcontainer.json`.

--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -3,12 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service serve",
-    "build": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service build",
-    "lint": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service lint",
-    "watch": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service build --watch",
-    "storybook": "export NODE_OPTIONS=--openssl-legacy-provider && start-storybook -p 6006",
-    "build-storybook": "export NODE_OPTIONS=--openssl-legacy-provider && build-storybook"
+    "serve": "vue-cli-service serve",
+    "build": "vue-cli-service build",
+    "lint": "vue-cli-service lint",
+    "watch": "vue-cli-service build --watch",
+    "storybook": "start-storybook -p 6006",
+    "build-storybook": "build-storybook"
   },
   "dependencies": {
     "@carbon/grid": "^10.26.0",


### PR DESCRIPTION
Set `NODE_OPTIONS=--openssl-legacy-provider` in container as environment variable.

**About development inside VS Code container**
it looks like VS Code is ignoring the specified Node version inside `devcontainer.json` and always uses Node v16.
Since Node v16 doesn't accept `NODE_OPTIONS=--openssl-legacy-provider`, we need to set this environment variable inside VS Code integrated terminal before launching `yarn` commands. This has been configured inside `.vscode/settings.json`