### PR TITLE
api. Return task ID for import-module

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/import-module/50import
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/import-module/50import
@@ -63,4 +63,5 @@ import_task_result = agent.tasks.run_nowait("module/" + dmid, "import-module",
 
 # Return connection details
 data['address'] = rsyncd_addr
+data['task'] = import_task_result
 json.dump(data, fp=sys.stdout)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/import-module/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/import-module/validate-output.json
@@ -7,7 +7,8 @@
         {
             "credentials": ["dokuwiki1", "16541c262d4c8-b1e8-4e95-a31b-8c3ed239203f"],
             "port": 20031,
-            "address": "10.5.4.1"
+            "address": "10.5.4.1",
+            "task": "module/dokuwiki1/b75964f0-766c-4869-bacd-941171753487"
         }
     ],
     "type": "object"


### PR DESCRIPTION
Return the waiting task ID to the caller, so it can synchronize with the worker module.