### PR TITLE
import-module. Run import-module one time

### DIFF
--- a/core/imageroot/usr/local/agent/actions/import-module/00validate_import
+++ b/core/imageroot/usr/local/agent/actions/import-module/00validate_import
@@ -10,6 +10,8 @@ import agent
 import os
 import json
 
+agent.set_weight(os.path.basename(__file__), 0) # Validation step, no task progress at all
+
 if os.getenv('IMPORT_IMAGE_URL'):
     agent.set_status('validation-failed')
     json.dump([{'field':'none', 'parameter':'none','value': '', 'error':'module_already_imported'}], fp=sys.stdout)

--- a/core/imageroot/usr/local/agent/actions/import-module/00validate_import
+++ b/core/imageroot/usr/local/agent/actions/import-module/00validate_import
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import agent
+import os
+import json
+
+if os.getenv('IMPORT_IMAGE_URL'):
+    agent.set_status('validation-failed')
+    json.dump([{'field':'none', 'parameter':'none','value': '', 'error':'module_already_imported'}], fp=sys.stdout)
+    sys.exit(2)

--- a/core/imageroot/usr/local/agent/actions/import-module/99mark_completed
+++ b/core/imageroot/usr/local/agent/actions/import-module/99mark_completed
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import agent
+import os
+
+agent.set_env('IMPORT_IMAGE_URL', os.getenv('IMAGE_URL'))
+agent.set_env('IMPORT_TASK_ID', os.getenv('AGENT_TASK_ID'))


### PR DESCRIPTION
After import-module completes, do not allow a new run of it. Fail with a validation error if this happens.

This should prevent errors from the ns7 migration tool to destroy a running module.