### PR TITLE
Added default cluster name on core installation

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/install-core.sh
+++ b/core/imageroot/var/lib/nethserver/node/install-core.sh
@@ -138,6 +138,11 @@ ACL SAVE
 SAVE
 EOF
 
+    # Set default UI name
+    cat <<EOF
+SET cluster/ui_name ${CLUSTER_NAME:-''}
+EOF
+
 ) | redis-cli
 
 echo "Start API server and core agents:"

--- a/core/install.sh
+++ b/core/install.sh
@@ -64,6 +64,8 @@ echo "Extracting core sources from ${core_url}:"
 mkdir -pv /var/lib/nethserver/node/state
 cid=$(podman create "${core_url}")
 podman export ${cid} | tar --totals -C / --no-overwrite-dir --no-same-owner -x -v -f - | LC_ALL=C sort | tee /var/lib/nethserver/node/state/coreimage.lst
+export CLUSTER_NAME
+CLUSTER_NAME=$(podman ps -a -f id="$cid" --format "{{.Names}}")
 podman rm -f ${cid}
 
 /var/lib/nethserver/node/install-core.sh "${modules[@]}"

--- a/core/tests/10__cluster_sanity/21__default_name.robot
+++ b/core/tests/10__cluster_sanity/21__default_name.robot
@@ -1,0 +1,9 @@
+*** Settings ***
+Library     SSHLibrary
+Resource    api.resource
+
+
+*** Test Cases ***
+Check if ui_name is generated
+    ${response} =    Run task    cluster/get-name    null
+    Should Not Be Empty    ${response['name']}


### PR DESCRIPTION
Edited the install.sh script to export in environment the random name of the container used to unpack the core.
Setting the name for the node just created before the cluster creation / node join.
