### PR TITLE
rsyncd. Keep symlinks in module state transfers

### DIFF
--- a/core/rsync/entrypoint.sh
+++ b/core/rsync/entrypoint.sh
@@ -45,6 +45,7 @@ use chroot = no
 path = /srv
 read only = no
 numeric ids = yes
+munge symlinks = no
 hosts allow = 127.0.0.1 ::1 ${RSYNCD_NETWORK:-0.0.0.0/0}
 
 [terminate]


### PR DESCRIPTION
For security reasons, the default behavior of rsyncd is adding an absolute and non-existing path to relative symlinks.

Switching off this behavior preserves the original symlink value. It is required by .dovecot.sieve symlinks in Mail module migration.