### PR TITLE
Fix for Rocky Linux 9.1

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -30,7 +30,7 @@ source /etc/os-release
 
 echo "Install dependencies:"
 if [[ "${PLATFORM_ID}" == "platform:el9" ]]; then
-    [[ "${ID}" == "centos" ]] && dnf update -y # Fix SELinux issues with basic packages on CentOS Stream
+    dnf update -y # Fix SELinux issues with basic packages
     dnf install -y wireguard-tools podman jq openssl firewalld
     systemctl enable --now firewalld
 elif [[ "${ID}" == "debian" && "${VERSION_ID}" == "11" ]]; then


### PR DESCRIPTION
Since release 9.1, Podman rootfull containers stopped to work on Rocky Linux due to SELinux issues. Even the install scripts hangs on Redis startup.

The installation succeedes on CentOS Stream though: https://github.com/NethServer/ns8-core/actions/runs/3567385345/jobs/5995025566