### PR TITLE
Fix userdel home locking

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
@@ -48,6 +48,9 @@ else # Rootless module
     if [[ ${preserve} == "yes" ]]; then
         userdel "${mid}"
     else
+        # Avoid /etc/passwd locking by erasing home directory separately:
+        # it is a long operation!
+        eval rm -rf ~"${mid}"
         userdel -r "${mid}"
     fi
 fi

--- a/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
@@ -50,7 +50,7 @@ else # Rootless module
     else
         # Avoid /etc/passwd locking by erasing home directory separately:
         # it is a long operation!
-        eval rm -rf ~"${mid}"
+        rm -rf "$(getent passwd "${mid}" | awk -F : '{ print $6 }')"
         userdel -r "${mid}"
     fi
 fi


### PR DESCRIPTION
The command holds the lock on /etc/passwd and prevents other processes to modify it. Removing a big home directory holds the lock for a long time, blocking the removal of other modules.