### PR TITLE
Allow addition of pip packages

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/install-core.sh
+++ b/core/imageroot/var/lib/nethserver/node/install-core.sh
@@ -49,7 +49,7 @@ fi
 
 echo "Setup Python virtual environment for agents:"
 core_dir=/usr/local/agent/pyenv
-python3 -mvenv ${core_dir} --upgrade-deps
+python3 -mvenv ${core_dir} --upgrade-deps --system-site-packages
 ${core_dir}/bin/pip3 install -r /etc/nethserver/pythonreq.txt
 echo "/usr/local/agent/pypkg" >$(${core_dir}/bin/python3 -c "import sys; print(sys.path[-1] + '/pypkg.pth')")
 


### PR DESCRIPTION
This PR allows rootless modules to add more Python packages to the base  `pyenv` agent environment: they are installed under the module home directory, with `pip install --user ...` 

References:

https://peps.python.org/pep-0405/#isolation-from-system-site-packages

> [PEP 370](https://peps.python.org/pep-0370) user-level site-packages are considered part of the system site-packages for venv purposes: they are not available from an isolated venv, but are available from an include-system-site-packages = true venv.