### PR TITLE
Override replace flag for restore-module

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/restore-module/50restore_module
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/restore-module/50restore_module
@@ -33,7 +33,7 @@ request = json.load(sys.stdin)
 repository = request['repository']
 path = request['path']
 snapshot = request['snapshot'] or "latest"
-replace = request.get('replace', False)
+replace_requested = request.get('replace', False)
 
 # destination
 node_id = int(request['node'])
@@ -62,38 +62,43 @@ omodule = add_module_result['output']
 
 module_id = add_module_result['output']['module_id']
 
+remove_tasks = []
+
+# Search for existing node with the same MODULE_UUID:
+for mod in rdb.scan_iter('module/*/environment'):
+    if rdb.hget(mod, 'MODULE_UUID') == original_environment['MODULE_UUID']:
+        # Prepare a task that removes the old module:
+        remove_tasks.append({
+            "agent_id": "cluster",
+            "action": "remove-module",
+            "data": {
+                "module_id": rdb.hget(mod, 'MODULE_ID'),
+                "preserve_data": False
+            },
+        })
+
 restore_task_result = agent.tasks.run("module/" + module_id, "restore-module",
     data={
         "repository": repository,
         "path": path,
         "snapshot": snapshot,
         "environment": original_environment,
-        "replace": replace
+        # MODULE_UUID is always preserved if there is no module to be replaced
+        "replace": replace_requested or len(remove_tasks) == 0
     },
     endpoint="redis://cluster-leader",
-    progress_callback=agent.get_progress_callback(51, 95)
+    progress_callback=agent.get_progress_callback(51, 85),
 )
 
 agent.assert_exp(restore_task_result['exit_code'] == 0)
 
-# Remove existing modules with the same MODULE_UUID
-if replace:
-    for mod in rdb.scan_iter('module/*/environment'):
-
-        # Do not remove freshly restored module
-        if rdb.hget(mod, 'MODULE_ID') == add_module_result['output']['module_id']:
-            continue
-
-        # Remove old module
-        if rdb.hget(mod, 'MODULE_UUID') == original_environment['MODULE_UUID']:
-           remove_module_result = agent.tasks.run("cluster", "remove-module",
-               data={
-                   "module_id": rdb.hget(mod, 'MODULE_ID'),
-                   "preserve_data": False
-               },
-               endpoint="redis://cluster-leader",
-               progress_callback=agent.get_progress_callback(95, 98)
-           )
-           agent.assert_exp(remove_module_result['exit_code'] == 0)
+if len(remove_tasks) > 0 and replace_requested:
+    # Remove existing modules with the same MODULE_UUID:
+    remove_modules_errors = agent.tasks.runp_brief(
+        remove_tasks,
+        endpoint="redis://cluster-leader",
+        progress_callback=agent.get_progress_callback(86, 98)
+    )
+    agent.assert_exp(remove_modules_errors == 0)
 
 json.dump(add_module_result['output'], fp=sys.stdout)


### PR DESCRIPTION
**Bug description**

In a disaster recovery, if I restore a module backup in a new cluster I expect the MODULE_UUID from the backup is applied, because the module UUID can be used by other modules to identify the right module instance and restore the relation between modules (e.g. Webtop - Mail).

**With the PR**

If a module backup is restored in a cluster with no instances of that module, or if there is not an instance with the same MODULE_UUID, the restore-module action is invoked with "replace=true", to preserve the original MODULE_UUID from backup.

The UI actually disables the Replace checkbox under the same conditions, preventing MODULE_UUID to be preserved.

**Effects of this change to other expectations**

If I want to use backup-restore as a path to migrate a module instance to a new cluster, or if I use a backup repo as a module template repository, the proposed change might break my expectations. In this case the backup repository should be removed after the restore, and future module backups must be sent to a new backup repo to avoid overwriting the module template.

---

Current UI. The checkbox is active if MODULE_UUID is found among existing modules.

![image](https://user-images.githubusercontent.com/2920838/207656686-0f8d6d16-c569-4b71-9a9e-c139e5582b03.png)
