### PR TITLE
Drop agent dump-env command

### DIFF
--- a/core/agent/README.md
+++ b/core/agent/README.md
@@ -132,7 +132,6 @@ When all steps are executed successfully the action is considered `completed`. T
 - `<agent-id>/environment`, copy of additional environment variables passed
   to the action steps. The values are stored in the local module
   filesystem and copied to Redis if the action has completed successfully
-  or the `dump-env` command was called.
 
 The `validation-failed` status must be set manually with the `set-status` command, described below. When the `validation-failed`
 status is set, no more steps are invoked and the action exit code is set to 10 unless another non-zero exit code is returned by
@@ -187,7 +186,7 @@ like `01validation`. If the validation fails, the step must execute the
 A running action step receives the **current working directory** value and its operating system process environment from the agent. This environment consists of
 
 - variables inherited from the agent environment (e.g. PATH, PYTHONPATH...)
-- variables loaded from the local filesystem (file `./environment`) and
+- variables loaded from the local filesystem (state file `./environment`) and
   copied to the Redis DB, under the hash key `<AGENT_ID>/environment`
   (e.g. MODULE_ID, IMAGE_URL...)
 - runtime agent vars:
@@ -211,7 +210,6 @@ Available commands are:
 
 - `set-env`
 - `unset-env`
-- `dump-env`
 - `set-status`
 - `set-progress`
 - `set-weight`
@@ -229,35 +227,24 @@ The same command in Python 3
 ### set-env
 
 The `set-env` command modifies an environment variable for subsequent
-steps. If the action is successful, it persists the value in the local
-filesystem `./environment` file for future action invocations. For example
+steps. If the step where the command is invoked is successful, the agent
+persists the variable value in the local filesystem `./environment` state
+file and the next step picks it up. For example
 
     set-env FULLNAME "First User"
 
 The environment vars are also copied to the Redis DB under the
-`{agent_id}/environment` hash key.
+`{agent_id}/environment` hash key, if the whole action completes
+successfully.
 
 ### unset-env
 
-The `unset-env` command remove an environment variable for subsequent
-steps. If the action is successful, it persists the value in the local
-filesystem `./environment` file for future action invocations.
-For example
+The `unset-env` command removes an environment variable for subsequent
+steps. If the step where the command is invoked is successful, the change
+is persisted in the local filesystem `./environment` state file and is
+picked up by the next step. For example
 
     unset-env FULLNAME
-
-### dump-env
-
-The `dump-env` command writes to a special file all variables set using
-`set-env`. The file can be used for subsequent steps. The `dump-env`
-command is automatically called when the action is `completed`. The
-generated file is written to the agent current working directory as
-`./environment`, and it is also copied to the Redis DB under the
-`{agent_id}/environment` hash key.
-
-For example
-
-    dump-env
 
 ### set-status
 

--- a/core/agent/README.md
+++ b/core/agent/README.md
@@ -131,7 +131,7 @@ When all steps are executed successfully the action is considered `completed`. T
 - `<agent-id>/task/<task-id>/exit_code`, 0 if all steps were successful, otherwise the exit code of the failing step
 - `<agent-id>/environment`, copy of additional environment variables passed
   to the action steps. The values are stored in the local module
-  filesystem and copied to Redis if the action has completed successfully
+  filesystem and copied to Redis if the action has completed successfully.
 
 The `validation-failed` status must be set manually with the `set-status` command, described below. When the `validation-failed`
 status is set, no more steps are invoked and the action exit code is set to 10 unless another non-zero exit code is returned by
@@ -229,7 +229,7 @@ The same command in Python 3
 The `set-env` command modifies an environment variable for subsequent
 steps. If the step where the command is invoked is successful, the agent
 persists the variable value in the local filesystem `./environment` state
-file and the next step picks it up. For example
+file and the next step will pick it up. For example
 
     set-env FULLNAME "First User"
 
@@ -241,7 +241,7 @@ successfully.
 
 The `unset-env` command removes an environment variable for subsequent
 steps. If the step where the command is invoked is successful, the change
-is persisted in the local filesystem `./environment` state file and is
+is persisted in the local filesystem `./environment` state file and will be
 picked up by the next step. For example
 
     unset-env FULLNAME

--- a/core/agent/agent.go
+++ b/core/agent/agent.go
@@ -26,7 +26,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -66,25 +65,6 @@ func (v *flagStringSlice) Set(raw string) error {
 		*v = append(*v, raw)
 	}
 	return nil
-}
-
-func readEnvironmentFile() []string {
-	env := make([]string, 0)
-	content, err := os.ReadFile("./environment")
-	if err != nil {
-		log.Printf(SD_ERR+"Cannot read ./environment file: %s", err)
-		return env
-	}
-	for _, line := range strings.Split(string(content), "\n") {
-		if line == "" {
-			continue
-		}
-		if strings.Contains(line, "=") == false {
-			continue
-		}
-		env = append(env, line)
-	}
-	return env
 }
 
 func setClientNameCallback(ctx context.Context, cn *redis.Conn) error {

--- a/core/agent/envstate.go
+++ b/core/agent/envstate.go
@@ -6,10 +6,10 @@
 package main
 
 import (
+	"log"
 	"os"
 	"strings"
 	"sync"
-	"log"
 )
 
 var muxEnvironment sync.Mutex

--- a/core/agent/envstate.go
+++ b/core/agent/envstate.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 Nethesis S.r.l.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package main
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"log"
+)
+
+var muxEnvironment sync.Mutex
+
+// Read the environment state file from the current working directory.
+func readStateFile() []string {
+	muxEnvironment.Lock()
+	defer func() { muxEnvironment.Unlock() }()
+	env := make([]string, 0)
+	content, err := os.ReadFile("./environment")
+	if err != nil {
+		log.Printf(SD_ERR+"Cannot read ./environment file: %s", err)
+		return env
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		if line == "" {
+			continue
+		}
+		if strings.Contains(line, "=") == false {
+			continue
+		}
+		env = append(env, line)
+	}
+	return env
+}
+
+// Persist the environment state file to the current working directory
+// Systemd unit file can pickup it with EnvironmentFile option
+func writeStateFile(env []string) {
+	muxEnvironment.Lock()
+	defer func() { muxEnvironment.Unlock() }()
+	path, _ := os.Getwd()
+	env = dedupEnv(env)
+	f, err := os.Create("./environment")
+	if err != nil {
+		log.Printf(SD_ERR+"Can't write %s/environment file: %s", path, err)
+		return
+	}
+	for _, line := range env {
+		f.WriteString(line + "\n")
+	}
+	f.Close()
+	log.Printf("Wrote %s/environment file", path)
+}
+
+// NOTE: This function is a copy of dedupEnvCase in go/exec module
+func dedupEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	saw := make(map[string]int, len(env)) // key => index into out
+	for _, kv := range env {
+		eq := strings.Index(kv, "=")
+		if eq < 0 {
+			out = append(out, kv)
+			continue
+		}
+		k := kv[:eq]
+		if dupIdx, isDup := saw[k]; isDup {
+			out[dupIdx] = kv
+			continue
+		}
+		saw[k] = len(out)
+		out = append(out, kv)
+	}
+	return out
+}

--- a/core/agent/hevent.go
+++ b/core/agent/hevent.go
@@ -84,7 +84,7 @@ func runEvent(wg *sync.WaitGroup, event *models.Event) {
 	}
 
 	// Get additional environment variables from the filesystem
-	environment := readEnvironmentFile()
+	environment := readStateFile()
 	for stepIndex, step := range handler.Steps {
 		lastStep = step.Name
 

--- a/core/agent/hevent.go
+++ b/core/agent/hevent.go
@@ -100,11 +100,11 @@ func runEvent(wg *sync.WaitGroup, event *models.Event) {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
-		log.Printf(SD_DEBUG + "Handler of %s/event/%s is starting step %s", event.Source, event.Name, step.Name)
+		log.Printf(SD_DEBUG+"Handler of %s/event/%s is starting step %s", event.Source, event.Name, step.Name)
 		if err := cmd.Start(); err != nil {
 			exitCode = 9
 			handler.Status = "aborted"
-			log.Printf(SD_ERR + "Handler of %s/event/%s failed at step %s: %v", event.Source, event.Name, step, err)
+			log.Printf(SD_ERR+"Handler of %s/event/%s failed at step %s: %v", event.Source, event.Name, step, err)
 			break
 		}
 

--- a/core/agent/test/actions/dump-environment/10setenv
+++ b/core/agent/test/actions/dump-environment/10setenv
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-value=$(cat)
-
-# Store the input value in VAR1
-echo 'set-env VAR1 '$value >&${AGENT_COMFD}

--- a/core/agent/test/actions/dump-environment/20dumpenv
+++ b/core/agent/test/actions/dump-environment/20dumpenv
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-echo -n $VAR1 #First time output: echo of the input
-
-# Create the environment file at the end
-# of this step. 
-echo 'dump-env' >&${AGENT_COMFD} 

--- a/core/agent/test/actions/dump-environment/30failure
+++ b/core/agent/test/actions/dump-environment/30failure
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Try to store XXX but...
-echo 'set-env VAR1 XXX' >&${AGENT_COMFD}
-
-# Abort action. The agent does not write the environment file in this case and
-# the value set by step 10setenv wins.
-exit 1

--- a/core/agent/test/suite/20__environment.robot
+++ b/core/agent/test/suite/20__environment.robot
@@ -6,17 +6,6 @@ Test Setup       Start command monitoring
 Test Teardown    Stop command monitoring
 
 *** Test Cases ***
-Test the dump-env command
-    Given The task is submitted    dump-environment    "ABC"
-
-    When The command is received    hset    VAR1    ABC
-    Then The agent environment contains    VAR1\=ABC
-
-    When The command is received    set    /exit_code    1
-    Then The task output should be equal to    ABC
-    And The agent environment does not contain    XXX
-    And The agent environment contains    ABC
-
 Set a variable
     Given The task is submitted    set-environment
 

--- a/core/agent/test/suite/60__shutdown.robot
+++ b/core/agent/test/suite/60__shutdown.robot
@@ -28,7 +28,7 @@ Start the command monitoring and the agent
     Start the agent
 
 The agent completes successfully
-    ${res} =    Wait For Process    timeout=1200ms
+    ${res} =    Wait For Process    timeout=2000ms
     Process Should Be Stopped
     Should Be Equal As Integers    ${res.rc}    ${0}
 

--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -258,7 +258,7 @@ def unset_env(name):
     __action("unset-env", name)
 
 def dump_env():
-    print(SD_DEBUG+"dump_env() is deprecated. The environment is automatically persisted to the agent state/ directory at the end of each action step.")
+    print(SD_DEBUG + "dump_env() is deprecated. The environment is now automatically persisted to the agent state/ directory at the end of each action step. See also NethServer/core#324.", file=sys.stderr)
 
 def set_status(value):
     __action("set-status", value)

--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -258,7 +258,7 @@ def unset_env(name):
     __action("unset-env", name)
 
 def dump_env():
-    __action("dump-env")
+    print(SD_DEBUG+"dump_env() is deprecated. The environment is automatically persisted to the agent state/ directory at the end of each action step.")
 
 def set_status(value):
     __action("set-status", value)

--- a/docs/modules/agent.md
+++ b/docs/modules/agent.md
@@ -85,8 +85,9 @@ this command prints the agent environment of the rootfull module `promtail1`.
 
 ## Agent commands
 
-During the action execution, action steps can talk to the agent using a simple protocol.
-It is possible to set/unset environment variables, dump the environment to a well known file, etc.
+During the action execution, action steps can talk to the agent using a
+simple protocol. For instance, it is possible to set/unset environment
+variables that are persisted under the `AGENT_STATE_DIR`.
 
 See all [available action commands](https://github.com/NethServer/ns8-core/blob/main/core/agent/README.md#action-commands).
 
@@ -97,7 +98,6 @@ Python example:
 import agent
 
 agent.set_env('MYVAR', 'value')
-agent.dump_env()
 ```
 
 ## Validation


### PR DESCRIPTION
This PR changes the behavior of the module `agent`  service. The changes purpose is to allow a parent action to start a child action and share the module state as much as possible, controlling the `./environment` file contents with  `set-env` and `unset-env` commands.

1. The `environment` state file is saved in a backup copy at the beginning of the action. If the action aborts, the backup contents are written to the state file again.
1. The `environment` state file is read at the beginning of each step and is written at the end of each step, if this is successful.
1. The dump-env command is removed.

This change of behavior is expected to be **backward compatible**. Existing code now prints deprecation/warning messages but still produces equivalent results.
