### PR TITLE
add-module. Define the `selfadm` role implicitly

### DIFF
--- a/core/imageroot/usr/local/agent/actions/create-module/10selfadm_role
+++ b/core/imageroot/usr/local/agent/actions/create-module/10selfadm_role
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+set -e
+
+# If action "configure-module" exists, grant it to selfadm role:
+if [[ -d "${AGENT_INSTALL_DIR}"/actions/configure-module ]]; then
+    redis-exec SADD "${AGENT_ID}/roles/selfadm" "configure-module"
+fi

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
@@ -179,6 +179,12 @@ agent.assert_exp(rdb.execute_command('ACL', 'SAVE') == 'OK')
 
 agent.save_acls(rdb)
 
+# Every module is authorized for self-administration. The core implicitly
+# permits to run configure-module with the selfadm role, but the role can
+# be extended to permit more actions.
+if not 'self:selfadm' in authorizations:
+    authorizations.append('self:selfadm')
+
 # Save the node_id and persist authorizations, to enforce labels on future modules
 rdb.hset(f'cluster/module_node', module_id, node_id)
 if authorizations:

--- a/docs/core/agents.md
+++ b/docs/core/agents.md
@@ -176,13 +176,13 @@ with the `actionsreader` role to run `list-actions` on `AGENT_ID` (e.g.
 `module/mymod1`).
 
 ```sh
-    redis-exec SADD "${AGENT_ID}/roles/actionsreader" "list-actions"
+redis-exec SADD "${AGENT_ID}/roles/actionsreader" "list-actions"
 ```
 
 Same as above, but to allow also any other action with name prefix `list-`:
 
 ```sh
-    redis-exec SADD "${AGENT_ID}/roles/actionsreader" "list-*"
+redis-exec SADD "${AGENT_ID}/roles/actionsreader" "list-*"
 ```
 
 Now it is possible to grant the role `actionsreader` on `module/mymod1` to
@@ -190,10 +190,22 @@ another agent (e.g. `module/authmod2`). This is the corresponding Redis command:
 
     HSET roles/module/authmod2 module/mymod1 actionsreader
 
-Roles are always granted by the `cluster` agent.
+If the module instance needs to run its own actions, extend the builtin
+role `selfadm`. A basic role definition is set up by the builtin step
+`10selfadm_role`. It adds `configure-module` to the `selfadm` role during
+the module instance creation. If this is undesirable, override the builtin
+step.
 
-Users with the `owner` role can use the following actions to manage users
-and their roles:
+For instance add the following command in a Bash step of
+`configure-module`:
+
+```sh
+redis-exec SADD "${AGENT_ID}/roles/selfadm" "get-configuration"
+```
+
+Roles are always granted by the `cluster` agent.  Users with the `owner`
+role on `cluster` (cluster administrators) can use the following cluster
+actions to manage users and their roles:
 
 - `add-user`
 - `remove-user`
@@ -226,7 +238,8 @@ the following way:
 
 Other possible *agent selector* values:
 
-- `self` - selects the module itself
+- `self` - selects the module itself. Note that the module instance is
+  implicitly granted the role `selfadm` on itself.
 - `cluster` - selects the cluster agent
 - `node` - selects the node agent where the module is running
 


### PR DESCRIPTION
Every module is authorized to run configure-module on itself. If this is undesirable, or if more actions are needed it is possible to modify the Redis SET key that defines the `selfadm` role:

    module/{module_id}/roles/selfadm
    
See also the attached documentation.