### PR TITLE
Listen for events on local Redis replica

### DIFF
--- a/core/agent/hevent.go
+++ b/core/agent/hevent.go
@@ -35,8 +35,13 @@ import (
 func listenEventsAsync(ctx context.Context, complete chan int) {
 	// Connect with default credentials to listen event channels with no
 	// restrictions.
-	redisAddress := os.Getenv("REDIS_ADDRESS")
+	redisAddress := os.Getenv("REDIS_REPLICA_ADDRESS")
 	if redisAddress == "" {
+		// Fallback to leader address
+		redisAddress = os.Getenv("REDIS_ADDRESS")
+	}
+	if redisAddress == "" {
+		// Fallback to local default
 		redisAddress = "127.0.0.1:6379"
 	}
 	rdb := redis.NewClient(&redis.Options{

--- a/core/imageroot/etc/nethserver/agent.env
+++ b/core/imageroot/etc/nethserver/agent.env
@@ -6,3 +6,4 @@ REGISTRY_AUTH_FILE=/etc/nethserver/registry.json
 AGENT_BASEACTIONS_DIR=/usr/local/agent/actions
 # An /etc/hosts record decides where to go:
 REDIS_ADDRESS=cluster-leader:6379
+REDIS_REPLICA_ADDRESS=127.0.0.1:6379

--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -47,11 +47,23 @@ SD_NOTICE  = "<5>"  # normal but significant condition
 SD_INFO    = "<6>"  # informational
 SD_DEBUG   = "<7>"  # debug-level messages
 
-def redis_connect(privileged=False, **kwargs):
-    """Connect to the Redis DB with the right credentials
+def redis_connect(privileged=False, use_replica=False, **kwargs):
+    """Connect to the Redis DB. If no arguments are given
+    the leader Redis instance with default read-only access rights
+    credentials is selected.
+    - Set `privileged=True` to modify Redis DB. Replica cannot be modified.
+    - Set `use_replica=True` to discover service startup configuration from
+      the local Redis replica.
+
+    Any other keyword argument is passed to redis.Redis() constructor.
     """
-    redis_host = os.getenv('REDIS_ADDRESS', '127.0.0.1:6379').split(':', 1)[0]
-    redis_port = os.getenv('REDIS_ADDRESS', '127.0.0.1:6379').split(':', 1)[1]
+    if use_replica:
+        redis_host = os.getenv('REDIS_REPLICA_ADDRESS', '127.0.0.1:6379').split(':', 1)[0]
+        redis_port = os.getenv('REDIS_REPLICA_ADDRESS', '127.0.0.1:6379').split(':', 1)[1]
+    else:
+        redis_host = os.getenv('REDIS_ADDRESS', '127.0.0.1:6379').split(':', 1)[0]
+        redis_port = os.getenv('REDIS_ADDRESS', '127.0.0.1:6379').split(':', 1)[1]
+
     if privileged:
         redis_username = os.environ['REDIS_USER'] # Fatal if missing!
         redis_password = os.environ['REDIS_PASSWORD'] # Fatal if missing!


### PR DESCRIPTION
This PR defines a new environment variable `REDIS_REPLICA_ADDRESS=127.0.0.1:6379` for agents. They listen to events on the local Redis replica.

Listening for events on the local Redis replica ensures events and data are consistent during service startup. Some startup scripts (e.g. defined as Systemd PreExecStart= commands), read configuration from Redis.
