### PR TITLE
Fix clone-module auth error

### DIFF
--- a/core/imageroot/usr/local/agent/actions/transfer-state/50sendstate
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/50sendstate
@@ -47,6 +47,7 @@ rsync_cmd = [
     # high-priority, harcoded filter rules: they cannot be overriden
     '--exclude=/state/agent.env',
     '--exclude=/state/environment',
+    '--exclude=/state/apitoken.cache',
 ]
 
 if os.path.isfile('state-filter-rules.rsync'):


### PR DESCRIPTION
The file apitoken.cache must be excluded from transfer-state (if it exists). Otherwise the destination module will use the source module credentials to authenticate itself.