### PR TITLE
Two-steps rsync in transfer-state action

### DIFF
--- a/core/imageroot/etc/nethserver/skel/.config/systemd/user/transfer-state.target.wants/agent.service
+++ b/core/imageroot/etc/nethserver/skel/.config/systemd/user/transfer-state.target.wants/agent.service
@@ -1,0 +1,1 @@
+../../../../../../etc/systemd/user/agent.service

--- a/core/imageroot/etc/systemd/user/agent.service
+++ b/core/imageroot/etc/systemd/user/agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Rootless module/%u agent
+Documentation=https://nethserver.github.io/ns8-core/modules/agent/
 
 [Service]
 Type=simple
@@ -18,4 +19,4 @@ Restart=always
 SyslogIdentifier=%u
 
 [Install]
-WantedBy=default.target
+WantedBy=default.target transfer-state.target

--- a/core/imageroot/etc/systemd/user/transfer-state.target
+++ b/core/imageroot/etc/systemd/user/transfer-state.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=Module State Integrity Target
+Documentation=https://nethserver.github.io/ns8-core/core/clone_module/#implementation-of-transfer-state
+AllowIsolate=true

--- a/core/imageroot/usr/local/agent/actions/transfer-state/01set_weight
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/01set_weight
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import os
+import agent
+
+agent.set_weight(os.path.basename(__file__), 0)
+agent.set_weight('10sendpayload', 5)

--- a/core/imageroot/usr/local/agent/actions/transfer-state/10sendpayload
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/10sendpayload
@@ -1,23 +1,8 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
-# http://www.nethesis.it - nethserver@nethesis.it
-#
-# This script is part of NethServer.
-#
-# NethServer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License,
-# or any later version.
-#
-# NethServer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with NethServer.  If not, see COPYING.
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import subprocess
@@ -32,16 +17,11 @@ port = int(request['port'])
 replace = bool(request['replace'])
 username, password = request['credentials']
 
-# Only for rootless modules, sorry:
-if os.geteuid() != 0:
-    # Stop services for state consistency:
-    agent.run_helper('systemctl', '--user', 'isolate', 'transfer-state.target')
-
 errors = 0
 os.environ['RSYNC_PASSWORD'] = password
 podman_cmd = [
     'podman', 'run', '-i', '--workdir=/srv', '--rm', '--network=host', '--privileged',
-    '--name=transfer-state-send',
+    '--name=transfer-state-payload',
     '--env=RSYNC_PASSWORD',
 ]
 
@@ -49,7 +29,6 @@ rsync_cmd = [
     'rsync',
     '-a',
     '--info=progress2',
-    '--delete-after',
 
     # high-priority, harcoded filter rules: they cannot be overriden
     '--exclude=/state/agent.env',
@@ -92,20 +71,4 @@ with subprocess.Popen(transfer_cmd, stdin=subprocess.DEVNULL, stdout=subprocess.
         else:
             buf += ch
 
-if pclient.returncode != 0:
-    print(agent.SD_ERR + "[ERROR] rsync transfer error " + str(pclient.returncode), file=sys.stderr)
-    errors += 1 # non-fatal: cleanup required!
-
-# Send a termination request to the server
-pterminate = agent.run_helper(*podman_cmd, core_env['RSYNC_IMAGE'], *f'rsync -q rsync://{username}@{address}:{port}/terminate'.split())
-if pterminate.returncode != 0:
-    print(agent.SD_ERR + "[ERROR] cannot send termination message to the rsync server. Exit code " + str(pterminate.returncode), file=sys.stderr)
-    errors += 1 # non-fatal: cleanup required!
-
-# Only for rootless modules, sorry:
-if os.geteuid() != 0 and (replace == False or errors > 0):
-    # Start the services again if we are cloning to produce a copy, or if any error occurred:
-    agent.run_helper('systemctl', '--user', 'isolate', 'default.target')
-
-if errors > 0:
-    sys.exit(1)
+sys.exit(pclient.returncode)

--- a/docs/core/clone_module.md
+++ b/docs/core/clone_module.md
@@ -15,7 +15,7 @@ For example to create a clone of instance `dokuwiki1` on node 1, run
 
     api-cli run clone-module --data '{"module":"dokuwiki1","replace":false,"node":1}'
 
-The `replace` boolean specifies if the source instance can is removed when
+The `replace` boolean specifies if the source instance should be removed when
 `clone-module` completes with success.
 
 - With `"replace":false` the cloning action makes a copy of the source


### PR DESCRIPTION
First step to transfer the heavy data, second step to ensure data
integrity.

During the last rsync transfer, services are stopped by isolating the
`transfer-state.target` Systemd unit.

Rsync filter rules are moved from `state/` to `etc/` directory
(`etc/state-filter-rules.rsync`).
