### PR TITLE
clone-module. Safe environment transfer

### DIFF
--- a/core/imageroot/usr/local/agent/actions/clone-module/05replace
+++ b/core/imageroot/usr/local/agent/actions/clone-module/05replace
@@ -1,1 +1,0 @@
-../restore-module/05replace

--- a/core/imageroot/usr/local/agent/actions/clone-module/10recvstate
+++ b/core/imageroot/usr/local/agent/actions/clone-module/10recvstate
@@ -46,3 +46,24 @@ podman_cmd = ['podman', 'run', '--rm', '--privileged', '--network=host', '--work
 core_env = agent.read_envfile('/etc/nethserver/core.env') # Import URLs of core images
 
 agent.run_helper(*podman_cmd, core_env['RSYNC_IMAGE']).check_returncode()
+
+#
+# Replace the MODULE_UUID, if needed
+#
+env_clone = agent.read_envfile('environment.clone-module')
+env_local = agent.read_envfile('environment')
+uuid = env_clone.get('MODULE_UUID', '')
+replace = request.get('replace', False)
+
+# Restore old MODULE_UUID
+if replace == True and len(uuid) > 0:
+    print("Preserving original MODULE_UUID", file=sys.stderr)
+    agent.set_env("MODULE_UUID", uuid)
+
+#
+# Copy environment from the source module. Only missing variables are copied!
+#
+for evar in env_clone:
+    if not evar in env_local:
+        print(f"Importing {evar} from source instance", file=sys.stderr)
+        agent.set_env(evar, env_clone[evar])

--- a/core/imageroot/usr/local/agent/actions/clone-module/90finalize
+++ b/core/imageroot/usr/local/agent/actions/clone-module/90finalize
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+exec 1>&2 # Redirect any output to the journal (stderr)
+
+# Rootfull modules must implement this step on their own!
+if [[ $EUID != 0 ]]; then
+    if [[ -s timers-target.clone-module ]]; then
+        read -ra targs < timers-target.clone-module
+        systemctl --user enable "${targs[@]}"
+    fi
+    if [[ -s default-target.clone-module ]]; then
+        read -ra dargs < default-target.clone-module
+        systemctl --user enable "${dargs[@]}"
+        systemctl --user isolate default.target
+    fi
+fi
+
+# Clean up clone-module state files
+rm -vf ./*.clone-module

--- a/core/imageroot/usr/local/agent/actions/clone-module/validate-input.json
+++ b/core/imageroot/usr/local/agent/actions/clone-module/validate-input.json
@@ -9,21 +9,6 @@
                 "dokuwiki1",
                 "s3cr3t"
             ],
-            "environment": {
-                "IMAGE_URL": "ghcr.io/nethserver/dokuwiki:latest",
-                "MODULE_UUID": "f5d24fcd-819c-4b1d-98ad-a1b2ebcee8cf",
-                "DOKUWIKI_IMAGE": "docker.io/bitnami/dokuwiki:20200729.0.0-debian-10-r299",
-                "DOKUWIKI_WIKI_NAME": "mywiki",
-                "DOKUWIKI_USERNAME": "admin",
-                "DOKUWIKI_PASSWORD": "pass",
-                "DOKUWIKI_EMAIL": "davidep@nethesis.it",
-                "DOKUWIKI_FULL_NAME": "Wiki Admin",
-                "PHP_ENABLE_OPCACHE": "1",
-                "PHP_MEMORY_LIMIT": "512M",
-                "TRAEFIK_HOST": "mywiki.dp.nethserver.net",
-                "TRAEFIK_HTTP2HTTPS": "False",
-                "TRAEFIK_LETS_ENCRYPT": "False"
-            },
             "port": 20027,
             "volumes": [
                 "dokuwiki-data"
@@ -35,7 +20,6 @@
     "required": [
         "credentials",
         "replace",
-        "environment",
         "volumes",
         "port"
     ],
@@ -52,27 +36,6 @@
             "title": "Rsyncd TCP port number",
             "type": "integer",
             "minimum": 1
-        },
-        "environment": {
-            "type": "object",
-            "title": "Environment backup",
-            "description": "Copy of the environment of the original module",
-            "properties": {
-                "IMAGE_URL": {
-                    "type": "string",
-                    "description": "URL of the module root image",
-                    "examples": [
-                        "ghcr.io/nethserver/mymodule:v2.3.2"
-                    ],
-                    "minLength": 1
-                }
-            },
-            "patternProperties": {
-                "^[^=]+$": {
-                    "type": "string"
-                }
-            },
-            "additionalProperties": false
         },
         "credentials": {
             "title": "Rsyncd service credentials",

--- a/core/imageroot/usr/local/agent/actions/transfer-state/10sendpayload
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/10sendpayload
@@ -17,6 +17,16 @@ port = int(request['port'])
 replace = bool(request['replace'])
 username, password = request['credentials']
 
+# Prepare a copy of the source module environment that can be transfered
+agent.run_helper('cp', '-v', 'environment', 'environment.clone-module').check_returncode()
+
+# Dump the Systemd enabled services list
+with open('default-target.clone-module', 'w') as fpout:
+    agent.run_helper(*'systemctl --user show default.target -p Wants --value'.split(), stdout=fpout).check_returncode()
+
+with open('timers-target.clone-module', 'w') as fpout:
+    agent.run_helper(*'systemctl --user show timers.target -p Wants --value'.split(), stdout=fpout).check_returncode()
+
 errors = 0
 os.environ['RSYNC_PASSWORD'] = password
 podman_cmd = [

--- a/core/imageroot/var/lib/nethserver/cluster/actions/clone-module/50clone_module
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/clone-module/50clone_module
@@ -38,7 +38,8 @@ node_id = int(request['node'])
 rdb = agent.redis_connect(privileged=True)
 
 secret = str(os.getpid()) + os.getenv('AGENT_TASK_ID')
-original_environment = rdb.hgetall(f'module/{smid}/environment')
+source_image_url = rdb.hget(f'module/{smid}/environment', 'IMAGE_URL')
+agent.assert_exp(source_image_url)
 rsyncd_addr = rdb.hget(f'node/{node_id}/vpn', 'ip_address')
 agent.assert_exp(rsyncd_addr)
 
@@ -53,7 +54,7 @@ svolumes = list_volumes_result['output']
 # Create the destination  module
 add_module_result = agent.tasks.run("cluster", "add-module",
     data={
-        "image": original_environment['IMAGE_URL'],
+        "image": source_image_url,
         "node": node_id,
     }, 
     endpoint="redis://cluster-leader",
@@ -82,7 +83,6 @@ server_task = {
     "data": {
         "replace": replace,
         "credentials": [smid, secret],
-        "environment": original_environment,
         "port": rsyncd_port,
         "volumes": dvolumes,
     },


### PR DESCRIPTION
The Redis environment copy may be stale. It is safer to transfer it with rsync.

Also, the destination environment is merged with the source environment automatically. Only missing variables are merged.

Finally, for rootless modules the services are automatically enabled and started as set by the source module.