### PR TITLE
ui: fix add/remove app from favorites

### DIFF
--- a/core/ui/src/components/shell/AppDrawer.vue
+++ b/core/ui/src/components/shell/AppDrawer.vue
@@ -95,8 +95,9 @@
                     <cv-toggle
                       value="favorite"
                       small
-                      v-model="app.isFavorite"
+                      :checked="app.isFavorite"
                       class="toggle-app-favorite"
+                      @click="toggleFavorite(app)"
                     >
                       <template slot="text-left">{{
                         $t("app_drawer.favorite")
@@ -850,6 +851,10 @@ export default {
 .app-drawer
   .cv-structured-list-data.bx--structured-list-td.app-list-element:hover {
   background-color: #353535 !important;
+}
+
+.app-drawer .toggle-app-favorite .bx--toggle-input__label {
+  color: $text-03;
 }
 
 .app-drawer .toggle-app-favorite .bx--toggle-input__label .bx--toggle__switch {


### PR DESCRIPTION
Before this fix, adding or removing an app from favorites was not working if the user clicked the **Favorite** toggle below app icon (it was working only by clicking app icon or app name).

Other changes: make **Favorite** toggle label more legible

See also https://trello.com/c/VE4iiDnI/255-core-p1-ui-favorites-are-not-saved