### PR TITLE
api: remove-internal-provider, support samba leave

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-provider/50remove_provider
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-provider/50remove_provider
@@ -41,6 +41,7 @@ module_id = request['module_id']
 # Check if module_id is in an internal domain among multiple providers.
 # If so, run the leave-domain action before actually remove the provider.
 leave_is_required = False
+target_domain = None
 designated_survivor = ''
 for odomain in cluster.userdomains.get_internal_domains(agent.redis_connect()).values():
     # Filter out unconfigured providers: they surely do not need leave-domain
@@ -55,29 +56,37 @@ for odomain in cluster.userdomains.get_internal_domains(agent.redis_connect()).v
     for provider in providers:
         if provider['id'] == module_id:
             leave_is_required = True
+            target_domain = odomain
         else:
             designated_survivor = provider['id']
 
+    # Do not look for other domains, we already have all required info
+    if target_domain:
+        break
+
 remove_progress_start = 2
 if leave_is_required:
-    remove_progress_start = 40
-    acquire_retval = agent.tasks.run(
-        agent_id=f"module/{designated_survivor}",
-        action="acquire-fsmo",
-        data=None,
-        endpoint="redis://cluster-leader",
-        progress_callback=agent.get_progress_callback(2, 50),
-    )
-    if acquire_retval['exit_code'] != 0:
-        print(agent.SD_ERR + f"There was an error in module/{designated_survivor}/acquire-fsmo. Check the subtask for details.", file=sys.stderr)
-        sys.exit(3)
+    # If the domain is an Active Directory, make sure the designated survivor can retain all FSMO roles
+    if target_domain.get('schema', '') == 'ad':
+        remove_progress_start = 40
+        acquire_retval = agent.tasks.run(
+            agent_id=f"module/{designated_survivor}",
+            action="acquire-fsmo",
+            data=None,
+            endpoint="redis://cluster-leader",
+            progress_callback=agent.get_progress_callback(2, 50),
+        )
+        if acquire_retval['exit_code'] != 0:
+            print(agent.SD_ERR + f"There was an error in module/{designated_survivor}/acquire-fsmo. Check the subtask for details.", file=sys.stderr)
+            sys.exit(3)
 
-
+    rdb = agent.redis_connect()
+    ds_host = rdb.hget(f"module/{designated_survivor}/environment", "HOSTNAME")
     remove_progress_start = 51
     leave_retval = agent.tasks.run(
         agent_id=f"module/{module_id}",
         action="leave-domain",
-        data={"adminuser": request.get("adminuser", ""), "adminpass": request.get("adminpass", "")},
+        data={"adminuser": request.get("adminuser", ""), "adminpass": request.get("adminpass", ""), "designated_survivor": ds_host},
         endpoint="redis://cluster-leader",
         progress_callback=agent.get_progress_callback(2, 50),
     )
@@ -99,8 +108,3 @@ remove_retval = agent.tasks.run(
 if remove_retval['exit_code'] != 0:
     print(agent.SD_ERR + f"There was an error during {module_id} removal. Check the subtask for details.", file=sys.stderr)
     sys.exit(4)
-
-
-
-
-

--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-provider/50remove_provider
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-provider/50remove_provider
@@ -41,6 +41,7 @@ module_id = request['module_id']
 # Check if module_id is in an internal domain among multiple providers.
 # If so, run the leave-domain action before actually remove the provider.
 leave_is_required = False
+designated_survivor = ''
 for odomain in cluster.userdomains.get_internal_domains(agent.redis_connect()).values():
     # Filter out unconfigured providers: they surely do not need leave-domain
     providers = [xprov for xprov in odomain['providers'] if xprov['host'] and xprov['port']]
@@ -51,17 +52,32 @@ for odomain in cluster.userdomains.get_internal_domains(agent.redis_connect()).v
         sys.exit(2)
 
     # Check if module_id is among configured providers:
-    if [xprov for xprov in providers if xprov['id'] == module_id]:
-        leave_is_required = True
-        break
+    for provider in providers:
+        if provider['id'] == module_id:
+            leave_is_required = True
+        else:
+            designated_survivor = provider['id']
 
 remove_progress_start = 2
 if leave_is_required:
+    remove_progress_start = 40
+    acquire_retval = agent.tasks.run(
+        agent_id=f"module/{designated_survivor}",
+        action="acquire-fsmo",
+        data=None,
+        endpoint="redis://cluster-leader",
+        progress_callback=agent.get_progress_callback(2, 50),
+    )
+    if acquire_retval['exit_code'] != 0:
+        print(agent.SD_ERR + f"There was an error in module/{designated_survivor}/acquire-fsmo. Check the subtask for details.", file=sys.stderr)
+        sys.exit(3)
+
+
     remove_progress_start = 51
     leave_retval = agent.tasks.run(
         agent_id=f"module/{module_id}",
         action="leave-domain",
-        data=None,
+        data={"adminuser": request.get("adminuser", ""), "adminpass": request.get("adminpass", "")},
         endpoint="redis://cluster-leader",
         progress_callback=agent.get_progress_callback(2, 50),
     )

--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-provider/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-provider/validate-input.json
@@ -5,7 +5,12 @@
     "description": "Safely remove a user domain provider.",
     "examples": [
         {
-            "module_id": "samba1"
+            "module_id": "openldap1"
+        },
+        {
+            "module_id": "samba1",
+            "adminuser": "administrator",
+            "adminpass": "Nethesis,1234"
         }
     ],
     "type": "object",
@@ -15,6 +20,14 @@
     "properties": {
         "module_id": {
             "title": "Module identifier",
+            "type": "string",
+            "minLength": 1
+        },
+        "adminuser": {
+            "type": "string",
+            "minLength": 1
+        },
+        "adminpass": {
             "type": "string",
             "minLength": 1
         }

--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-provider/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-provider/validate-input.json
@@ -10,7 +10,8 @@
         {
             "module_id": "samba1",
             "adminuser": "administrator",
-            "adminpass": "Nethesis,1234"
+            "adminpass": "Nethesis,1234",
+	    "designated_survivor": "dc1.mydomain.org"
         }
     ],
     "type": "object",
@@ -28,6 +29,10 @@
             "minLength": 1
         },
         "adminpass": {
+            "type": "string",
+            "minLength": 1
+        },
+        "designated_survivor": {
             "type": "string",
             "minLength": 1
         }


### PR DESCRIPTION
When removing a Samba DC, first also select an existing instance as designated survivor.
Transfer to the survivor all [FSMO roles](https://wiki.samba.org/index.php/Transferring_and_Seizing_FSMO_Roles#Displaying_the_Current_FSMO_Role_Owners), then execute the `leave-domain`.

While not strictly needed, the address of the designates survivor is used by the demote action to make sure to find the right server.

https://trello.com/c/cuKDUqag/187-core-p1-samba-join-dc-admin-password-validator

Example:
```
api-cli run cluster/remove-internal-provider --data '{"module_id": "samba5", "adminuser": "Administrator", "adminpass": "Nethesis,1234", "designated_survivor": "dc2.domain2.it"}'
```