### PR TITLE
Remove unused images by the containers

### DIFF
--- a/core/imageroot/usr/local/agent/actions/update-module/95cleanup_images
+++ b/core/imageroot/usr/local/agent/actions/update-module/95cleanup_images
@@ -14,22 +14,12 @@ set -e
 export LC_ALL=C # required by sort for portability
 
 # Find the images that are no longer required:
-# 1. generate a sorted list starting with the old module image ID,
-#    followed by its additional images, as declared by the
-#    org.nethserver.images label
-# 2. similarly, generate the list for the new image ID
-# 3. compare (diff) the lists and extract the images that are no longer
-#    required
-# 4. pass them to `podman rmi`
-diff  <(
-    echo "${PREV_IMAGE_ID}"
-    podman inspect -f json "${PREV_IMAGE_ID:-none}" | \
-            jq -r '.[0].Config.Labels."org.nethserver.images" | split(" ") | join("\n")' | \
-            sort
-) <(
-    echo "${IMAGE_ID}"
-    podman inspect -f json "${IMAGE_ID:-none}" | \
-            jq -r '.[0].Config.Labels."org.nethserver.images" | split(" ") | join("\n")' | \
-            sort
-) | sed -n '/^< / s/^< //p' | \
-    xargs -t -- podman rmi 2>/dev/null || :
+# retrieve from env all variable with the prefix PREV_
+# remove not used images like PREV_*_IMAGE and PREV_IMAGE_URL
+# ignore errors and exit with successful exit status
+
+for varname in ${!PREV_*}; do 
+        if [[ $varname =~ _IMAGE$ || $varname =~ _URL$ ]]; then
+                podman image rm --ignore ${!varname} 2>/dev/null || :
+        fi
+done


### PR DESCRIPTION
List all PREV_* vars and remove the images not used anymore

for example

PREV_IMAGE_URL=ghcr.io/nethserver/mattermost:0.0.9 PREV_MATTERMOST_TEAM_EDITION_IMAGE=docker.io/mattermost/mattermost-team-edition:7.8.0 PREV_POSTGRES_IMAGE=docker.io/postgres:13.10-alpine

if an image is used we simply ignore the error message