### PR TITLE
api: transfer-state, skip backup timers

### DIFF
--- a/core/imageroot/usr/local/agent/actions/transfer-state/10sendpayload
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/10sendpayload
@@ -29,7 +29,7 @@ with open('timers-target.clone-module', 'w') as fpout:
     proc = subprocess.run('systemctl --user show timers.target -p Wants --value'.split(), text=True, capture_output=True)
     if proc.returncode != 0:
         sysm.exit(3)
-    tlist = re.sub(r"backup.\.timer", '', proc.stdout) # remove backup timers
+    tlist = re.sub(r"\bbackup[0-9]+\.timer\b", '', proc.stdout) # remove backup timers
     fpout.write(tlist)
 
 

--- a/core/imageroot/usr/local/agent/actions/transfer-state/10sendpayload
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/10sendpayload
@@ -10,6 +10,7 @@ import sys
 import json
 import agent
 import os
+import re
 
 request = json.load(sys.stdin)
 address = request['address']
@@ -25,7 +26,12 @@ with open('default-target.clone-module', 'w') as fpout:
     agent.run_helper(*'systemctl --user show default.target -p Wants --value'.split(), stdout=fpout).check_returncode()
 
 with open('timers-target.clone-module', 'w') as fpout:
-    agent.run_helper(*'systemctl --user show timers.target -p Wants --value'.split(), stdout=fpout).check_returncode()
+    proc = subprocess.run('systemctl --user show timers.target -p Wants --value'.split(), text=True, capture_output=True)
+    if proc.returncode != 0:
+        sysm.exit(3)
+    tlist = re.sub(r"backup.\.timer", '', proc.stdout) # remove backup timers
+    fpout.write(tlist)
+
 
 errors = 0
 os.environ['RSYNC_PASSWORD'] = password


### PR DESCRIPTION
Backup timer can't be migrated.
Avoid errors like:
```
Failed to enable unit: Unit file backup1.timer does not exist.
```

See https://trello.com/c/UwVkhiRV/324-core-p2-clone-fails-if-a-backup-is-configured