### PR TITLE
Fix hardcoded home directory path

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
@@ -68,7 +68,7 @@ if is_rootfull:
 else: # rootless
     # Create the module dirs structure
     agent.run_helper('useradd', '-m', '-k', '/etc/nethserver/skel', '-s', '/bin/bash', module_id).check_returncode()
-    os.chdir(f'/home/{module_id}/.config')
+    os.chdir(os.path.expanduser("~" + module_id) + '/.config')
     save_environment(module_environment)
     redis_sha256 = save_agent_env(module_id)
     # Extract the module imageroot and fix CWD permissions recursively

--- a/core/imageroot/var/lib/nethserver/node/uninstall.sh
+++ b/core/imageroot/var/lib/nethserver/node/uninstall.sh
@@ -35,12 +35,13 @@ cat /var/lib/nethserver/node/state/coreimage.lst > ${tmp_srclist}
 
 trap "rm -f ${tmp_dirlist} ${tmp_srclist}" EXIT
 
-for userhome in /home/*[0-9]; do
-    moduleid=$(basename $userhome)
+# Assuming user names ending with digits and with some homedir correspond
+# to rootless modules:
+for moduleid in $(awk -F: '$1 ~ /^.+[0-9]+$/ && $2 ~ /.+/ { print $1 }' </etc/passwd); do
     echo "Deleting rootless module ${moduleid}..."
     loginctl disable-linger "${moduleid}"
     systemctl stop user@$(id -u $moduleid)
-    loginctl terminate-user "${moduleid}"
+    loginctl terminate-user "${moduleid}" &>/dev/null
     userdel -r "${moduleid}"
 done
 


### PR DESCRIPTION
Retrieve the path of user's home directory from passwd DB.

Even if /home is widely adopted, the local system setup can use a different base path for home directories.

Ref https://community.nethserver.org/t/ns8-growing-data-directories-path/21065