### PR TITLE
Avoid ldap3 library error against NS7 OpenLDAP

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/ldapclient/base.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/ldapclient/base.py
@@ -92,3 +92,8 @@ class LdapclientBase:
             filter_clause += f"({uattr}={user})"
 
         return f"(!(|{filter_clause}))"
+
+    def filter_schema_attributes(self, attr_list):
+        """Reduce the given attr_list by filtering out attribute names not
+           declared in the server schema."""
+        return [aname for aname in attr_list if aname in self.ldapsrv.schema.attribute_types]

--- a/core/imageroot/usr/local/agent/pypkg/agent/ldapclient/rfc2307.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/ldapclient/rfc2307.py
@@ -67,7 +67,7 @@ class LdapclientRfc2307(LdapclientBase):
 
     def get_user(self, user):
         response = self.ldapconn.search(self.base_dn, f'(&(objectClass=posixAccount)(objectClass=inetOrgPerson)(uid={user}){self._get_users_search_filter_clause()})',
-            attributes=['displayName', 'uid', 'pwdAccountLockedTime'],
+            attributes=['displayName', 'uid'] + self.filter_schema_attributes(['pwdAccountLockedTime']),
         )[2]
 
         def get_memberof(user):
@@ -91,7 +91,7 @@ class LdapclientRfc2307(LdapclientBase):
                 "user": entry['attributes']['uid'][0],
                 "display_name": entry['attributes'].get('displayName') or "",
                 "groups": get_memberof(user),
-                "locked": entry['attributes']['pwdAccountLockedTime'] != [],
+                "locked": entry['attributes'].get('pwdAccountLockedTime', []) != [],
             }
 
         raise LdapclientEntryNotFound()
@@ -99,7 +99,7 @@ class LdapclientRfc2307(LdapclientBase):
 
     def list_users(self):
         response = self.ldapconn.search(self.base_dn, f'(&(objectClass=posixAccount)(objectClass=inetOrgPerson){self._get_users_search_filter_clause()})',
-            attributes=['displayName', 'uid', 'pwdAccountLockedTime'],
+            attributes=['displayName', 'uid'] + self.filter_schema_attributes(['pwdAccountLockedTime']),
         )[2]
 
         users = []
@@ -109,6 +109,6 @@ class LdapclientRfc2307(LdapclientBase):
             users.append({
                 "user": entry['attributes']['uid'][0],
                 "display_name": entry['attributes'].get('displayName') or "",
-                "locked": entry['attributes']['pwdAccountLockedTime'] != [],
+                "locked": entry['attributes'].get('pwdAccountLockedTime', []) != [],
             })
         return users


### PR DESCRIPTION
The ldap3 Python library uses the server provided schema to check search query attributes. If the attribute name is unknown in the schema it raises a LDAPAttributeError exception.

As disabing the schema would impact the library return value format, check if the query attributes are in the schema and filter out unknown attributes to avoid the error.

Alternative fix to #359 to fix regression introduced by 601190a6ec66461bf7fc989269df6e72064ce24d