### PR TITLE
Restrict additional VPN routes to IP addresses

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-routes/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-routes/50update
@@ -33,24 +33,24 @@ rdb = agent.redis_connect(privileged=True)
 destinations = {}
 
 for reqitem in request.get('add', []):
-    network = reqitem['network']
+    ip_address = requitem['ip_address']
     node_id = reqitem['node_id']
 
     if not node_id in destinations:
         destinations[node_id] = {*rdb.hget(f'node/{node_id}/vpn', 'destinations').split()}
 
     # merge the new destination with existing values
-    destinations[node_id] |= {network}
+    destinations[node_id] |= {ip_address}
 
 for reqitem in request.get('remove', []):
-    network = reqitem['network']
+    ip_address = requitem['ip_address']
     node_id = reqitem['node_id']
 
     if not node_id in destinations:
         destinations[node_id] = {*rdb.hget(f'node/{node_id}/vpn', 'destinations').split()}
 
     # remove the destination from existing values
-    destinations[node_id] -= {network}
+    destinations[node_id] -= {ip_address}
 
 pipe = rdb.pipeline()
 

--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-routes/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-routes/validate-input.json
@@ -2,16 +2,16 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "update-routes input",
     "$id": "http://schema.nethserver.org/cluster/update-routes-input.json",
-    "description": "Route traffic to the given networks through VPN nodes",
+    "description": "Route traffic to the given IP addresses through the cluster VPN",
     "examples": [
         {
             "add": [
                 {
-                    "network": "192.168.2.0/24",
+                    "ip_address": "192.168.2.12",
                     "node_id": 3
                 },
                 {
-                    "network": "192.168.3.0/24",
+                    "ip_address": "192.168.3.8",
                     "node_id": 4
                 }
             ],
@@ -45,12 +45,16 @@
             "items": {
                 "type": "object",
                 "required": [
-                    "network",
-                    "node_id"
+                    "node_id",
+                    "ip_address"
                 ],
                 "properties": {
-                    "network": {
-                        "$ref": "http://schema.nethserver.org/cluster.json#/definitions/ipv4-cidr"
+                    "ip_address": {
+                        "title": "IP address",
+                        "description": "IP address to add or remove. It should be local to the node.",
+                        "type": "string",
+                        "format": "ipv4",
+                        "minLength": 1
                     },
                     "node_id": {
                         "type": "integer",

--- a/docs/core/database.md
+++ b/docs/core/database.md
@@ -242,7 +242,7 @@ follow this notation:
 |node/{id}/vpn                      |HASH||
 |node/{id}/vpn ip_address           |STRING     |IP address in cluster/network|
 |node/{id}/vpn public_key           |STRING     |Public WireGuard VPN key|
-|node/{id}/vpn destinations         |STRING     |List of networks in CIDR notation, routed through the VPN|
+|node/{id}/vpn destinations         |STRING     |List of IP addresses routed through the VPN|
 |node/{id}/vpn endpoint             |STRING     |Public IP or host name of the VPN endpoint with :port suffix|
 |node/{id}/vpn listen_port          |INTEGER    |Public UDP port of the VPN endpoint, default: `55820`|
 |node/{id}/flags                    |SET        |FlagS to mark a node. Supported flags: `nomodules`, the node can't run any module|


### PR DESCRIPTION
As the only legitimate use case is adding the IP address of some cluster node to obtain Samba DC replication through the cluster VPN, the update-routes action do not accept CIDR network parameters any more.