### PR TITLE
api: fix acquire-fsmo in remove-internal-provider

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-provider/50remove_provider
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-internal-provider/50remove_provider
@@ -72,7 +72,7 @@ if leave_is_required:
         acquire_retval = agent.tasks.run(
             agent_id=f"module/{designated_survivor}",
             action="acquire-fsmo",
-            data=None,
+            data={"adminuser": request.get("adminuser", ""), "adminpass": request.get("adminpass", "")},
             endpoint="redis://cluster-leader",
             progress_callback=agent.get_progress_callback(2, 50),
         )


### PR DESCRIPTION
acquire-fsmo requires admin credentials

Samba PR: https://github.com/NethServer/ns8-samba/pull/12

See also https://trello.com/c/f6u0mII7/327-core-p1-ui-for-samba-domain-removal