### PR TITLE
install.sh. Test if FQDN is resolvable

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -26,7 +26,9 @@ echo "Checking machine hostname"
 fqdn=$(hostname -f)
 if [[ -z "${fqdn}" || "${fqdn}" == *localhost* ]]; then
     echo "Current hostname '$fqdn' is not valid. The hostname must not contain 'localhost'."
-    echo "Please set a valid FQDN like 'myserver.nethserver.org'."
+    echo "Please set a FQDN like"
+    echo "- myserver.nethserver.org (real public DNS domain suffix for production)"
+    echo "- myserver.dom.test (RFC-6761 .test DNS suffix for testing and development)"
     exit 2
 fi
 


### PR DESCRIPTION
The /etc/hosts record existence check might fail but the address is
still resolvable: for instance, RHEL-derived distros resolve the
hostname locally with the NSS "myhostname" module.