### PR TITLE
Set container name of restic and rclone-wrapper

### DIFF
--- a/core/imageroot/usr/local/agent/bin/rclone-wrapper
+++ b/core/imageroot/usr/local/agent/bin/rclone-wrapper
@@ -81,10 +81,12 @@ else:
     raise Exception(f"Scheme {uscheme} not supported")
 
 # Build the Podman+Rclone command line
+container_name = "rclone-wrapper-" + os.environ.get('MODULE_ID', os.environ["AGENT_ID"]) + "-" + str(os.getpid())
 exec_args = [
     "podman", "run",
     "-i", "--attach=stdin", "--attach=stdout", "--attach=stderr",
     "--env=RCLONE*", "--network=host", "--rm",
+    "--name=" + container_name,
     rclone_image,
     ] + sys.argv[2:]
 

--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -211,7 +211,8 @@ def run_restic(rdb, repository, repo_path, podman_args, restic_args, **kwargs):
         raise Exception(f"Schema {uschema} not supported")
 
     # Build the Podman command line to run Restic
-    podman_cmd = ['podman', 'run', '-i', '--rm', '--privileged', '--network=host', '--volume=restic-cache:/var/cache/restic']
+    container_name = "restic-" + os.environ.get('MODULE_ID', os.environ["AGENT_ID"]) + "-" + str(os.getpid())
+    podman_cmd = ['podman', 'run', '-i', '--rm', f'--name={container_name}', '--privileged', '--network=host', '--volume=restic-cache:/var/cache/restic']
 
     for envvar in restic_env:
         podman_cmd.extend(['-e', envvar]) # Import Restic environment variables


### PR DESCRIPTION
Setting the container name conveys more information in the log. If the name is not specified the container assumes a random one and that is useless.