### PR TITLE
Suppress repeated Agent BRPOP errors

### DIFF
--- a/core/agent/htask.go
+++ b/core/agent/htask.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -339,7 +340,12 @@ func listenActionsAsync(brpopCtx context.Context, complete chan int) {
 		OnConnect: setClientNameCallback,
 	})
 
-	var lastPopErr error = nil // Clear the last error buffer
+	// Ignore the credential error on agent startup
+	//
+	// Initialize to a well-known error condition, to avoid log pollution
+	// and false alarms. When an agent is created its credentials might be
+	// still not stored in the leader node Redis instance:
+	var lastPopErr error = errors.New("WRONGPASS invalid username-password pair or user is disabled.")
 
 	for { // Action listen loop
 		var task models.Task


### PR DESCRIPTION
The main agent task loop watches the task queue and produces repeated error log lines (one every 5 seconds) if credentials are wrong or connection is down. This commit adds a comparison of the error log message with the previous loop run and prints the message only if they differ.

For instance, in a multi-node cluster the `cluster` agent of worker nodes typically produces lines like this one:

    Task queue pop error: READONLY You can't write against a read only replica.

They can be silenced with this PR.

Another example: if the leader is unreachable every agent starts complaining, flooding the log with repeated entries.

Refs https://trello.com/c/9EG8GJia/326-core-p2-multi-node-ui


----

Fixes also the WRONGPASS error

Refs https://trello.com/c/8tjQ5S7Y/90-core-p3-wrongpass-invalid-username-password-pair