### PR TITLE
Build NS8 images 

### DIFF
--- a/.github/workflows/build-disk-images.yml
+++ b/.github/workflows/build-disk-images.yml
@@ -16,7 +16,14 @@ jobs:
       - id: check
         run: |
           pip install semver
-          python3 -c 'import semver, sys; sys.exit(1) if semver.VersionInfo.parse("${{ github.event.workflow_run.head_branch }}").prerelease else sys.exit(0)'
+          check_core_version=$(cat <<EOF
+          import semver, sys
+          try:
+            sys.exit(1) if semver.VersionInfo.parse("${{ github.event.workflow_run.head_branch }}").prerelease else sys.exit(0)
+          except ValueError: sys.exit(2)
+          EOF
+          )
+          python3 -c "$check_core_version"
   build-imges-digitalocean:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build-disk-images.yml
+++ b/.github/workflows/build-disk-images.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   core-version:
     runs-on: ubuntu-latest
+    outputs:
+      is_stable: ${{ steps.check.outputs.is_stable }}
     steps:
       - id: python-dep
         uses: actions/setup-python@v3
@@ -19,11 +21,11 @@ jobs:
           check_core_version=$(cat <<EOF
           import semver, sys
           try:
-            sys.exit(1) if semver.VersionInfo.parse("${{ github.event.workflow_run.head_branch }}").prerelease else sys.exit(0)
-          except ValueError: sys.exit(2)
+            print("false") if semver.VersionInfo.parse("${{ github.event.workflow_run.head_branch }}").prerelease else print ("true")
+          except ValueError: print("false")
           EOF
           )
-          python3 -c "$check_core_version"
+          echo is_stable=$(python3 -c "$check_core_version") >> $GITHUB_OUTPUT
   build-imges-digitalocean:
     runs-on: ubuntu-latest
     strategy:
@@ -35,6 +37,7 @@ jobs:
           - digitalocean.al
     needs:
       - core-version
+    if: needs.core-version.outputs.is_stable == 'true'
     steps:
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main
@@ -63,6 +66,7 @@ jobs:
           - qemu.al
     needs:
       - core-version
+    if: needs.core-version.outputs.is_stable == 'true'
     steps:
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main

--- a/.github/workflows/build-disk-images.yml
+++ b/.github/workflows/build-disk-images.yml
@@ -39,7 +39,7 @@ jobs:
         run: packer init .
       - name: Run `packer build`
         id: validate
-        run: packer build --only=${{ matrix.source }} .
+        run: packer build --only=${{ matrix.source }} --var "core_version=${{ github.event.workflow_run.head_branch }}" .
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.do_token }}
   build-imges-qemu:
@@ -67,7 +67,7 @@ jobs:
         run: packer init .
       - name: Run `packer build`
         id: validate
-        run: packer build --only=${{ matrix.source }} .
+        run: packer build --only=${{ matrix.source }} --var "core_version=${{ github.event.workflow_run.head_branch }}" .
       - id: image
         run: |
           IMAGE_PATH=$(cat packer-manifest.json | jq -r .builds[0].files[0].name)

--- a/.github/workflows/build-disk-images.yml
+++ b/.github/workflows/build-disk-images.yml
@@ -1,0 +1,82 @@
+name: Build NS8 disk images
+on:
+  workflow_run:
+    workflows: [core]
+    types:
+      - completed
+
+jobs:
+  core-version:
+    runs-on: ubuntu-latest
+    steps:
+      - id: python-dep
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+      - id: check
+        run: |
+          pip install semver
+          python3 -c 'import semver, sys; sys.exit(1) if semver.VersionInfo.parse("${{ github.event.workflow_run.head_branch }}").prerelease else sys.exit(0)'
+  build-imges-digitalocean:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        source:
+          - digitalocean.cs
+          - digitalocean.rl
+          - digitalocean.al
+    needs:
+      - core-version
+    steps:
+      - name: Setup `packer`
+        uses: hashicorp/setup-packer@main
+      - uses: actions/checkout@v3
+        with:
+          repository: NethServer/ns8-images
+      - name: Run `packer init`
+        id: init
+        run: packer init .
+      - name: Run `packer build`
+        id: validate
+        run: packer build --only=${{ matrix.source }} .
+        env:
+          DIGITALOCEAN_TOKEN: ${{ secrets.do_token }}
+  build-imges-qemu:
+    runs-on: [self-hosted]
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        source:
+          - qemu.dn
+          - qemu.cs
+          - qemu.rl
+          - qemu.al
+    needs:
+      - core-version
+    steps:
+      - name: Setup `packer`
+        uses: hashicorp/setup-packer@main
+      - uses: actions/checkout@v3
+        with:
+          repository: NethServer/ns8-images
+      - name: Run `packer init`
+        id: init
+        run: packer init .
+      - name: Run `packer build`
+        id: validate
+        run: packer build --only=${{ matrix.source }} .
+      - id: image
+        run: |
+          IMAGE_PATH=$(cat packer-manifest.json | jq -r .builds[0].files[0].name)
+          NAME=$(basename "${IMAGE_PATH}")
+          echo "path=${IMAGE_PATH}" >> "$GITHUB_OUTPUT"
+          echo "name=${NAME}" >> "$GITHUB_OUTPUT"
+      - name: Upload NS8 image
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ github.event.workflow_run.head_branch }}
+          tag_name: ${{ github.event.workflow_run.head_branch }}
+          files:  ${{ steps.image.outputs.path }}

--- a/.github/workflows/build-disk-images.yml
+++ b/.github/workflows/build-disk-images.yml
@@ -68,15 +68,21 @@ jobs:
       - name: Run `packer build`
         id: validate
         run: packer build --only=${{ matrix.source }} --var "core_version=${{ github.event.workflow_run.head_branch }}" .
-      - id: image
+      - id: qcow2
         run: |
           IMAGE_PATH=$(cat packer-manifest.json | jq -r .builds[0].files[0].name)
-          NAME=$(basename "${IMAGE_PATH}")
           echo "path=${IMAGE_PATH}" >> "$GITHUB_OUTPUT"
-          echo "name=${NAME}" >> "$GITHUB_OUTPUT"
+      - id: vmdk
+        name: Convert to VMDK
+        run: |
+          VMDK_PATH=$(echo ${{ steps.qcow2.outputs.path }} | sed -e 's/\.qcow2$/\.vmdk/')
+          qemu-img convert -f qcow2 -O vmdk -o subformat=streamOptimized ${{ steps.qcow2.outputs.path }} $VMDK_PATH
+          echo "path=${VMDK_PATH}" >> "$GITHUB_OUTPUT"
       - name: Upload NS8 image
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ github.event.workflow_run.head_branch }}
           tag_name: ${{ github.event.workflow_run.head_branch }}
-          files:  ${{ steps.image.outputs.path }}
+          files: |
+            ${{ steps.qcow2.outputs.path }}
+            ${{ steps.vmdk.outputs.path }}

--- a/.github/workflows/build-disk-images.yml
+++ b/.github/workflows/build-disk-images.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   core-version:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     outputs:
       is_stable: ${{ steps.check.outputs.is_stable }}


### PR DESCRIPTION
This PR will create disk images, that can be used to quickly create a new instance of an NS8 node, on every stable release of the core module.
The images are based on all the supported distros:
* Debian 11
* Centos Stream 9
* Rocky Linux 9
* Alma Linux 9

Images  formats:
* QCOW2: compacted and compressed.
* VMDK: subformat `streamOptimized`.

The default root password is Nethesis,1234, and will be asked to change it on the first login.

The process use [packer](https://www.packer.io/) for the build, the configuration can be found in the repo https://github.com/NethServer/ns8-images/.

### Setup the builder
To ease the build process a self-hosted runner is used. To setup the environment on Ubuntu:

1. Install the required packages:
```
sudo apt install  qemu-system qemu-utils unzip jq --no-install-recommend
```
2. Create the runner user, eg: 
```
useradd -m -G kvm ns8-images-runner-1
```
Create many users as many parallel build as you want.
The above command will add the runner user to the `kvm` group, needed to use 'host` as `cpu_type` on qemu,  this is required for the new distros based on Red Hat.

3. For every runner user, install the GitHub Actions Runner:  https://github.com/NethServer/ns8-core/settings/actions/runners/new
