### PR TITLE
Add "file_server" to `list-user-domains` action

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/userdomains.py
@@ -136,10 +136,16 @@ def get_internal_domains(rdb):
                 "providers": []
             }
 
+        # Check if the provider can be used also as a SMB file server by
+        # LAN clients. This is possible only with Samba providers but the
+        # attribute is always set despite of that.
+        has_file_server_flag = rdb.sismember(f'module/{module_id}/flags', 'file_server')
+
         domains[conf['domain']]['providers'].append({
             "id": module_id,
             "ui_name": rdb.get(f'module/{module_id}/ui_name') or "",
             "node": int(conf['node']),
+            "file_server": has_file_server_flag,
             "host": conf['host'],
             "port": int(conf['port']),
         })
@@ -160,6 +166,7 @@ def get_internal_domains(rdb):
             "node": int(node_id),
             "host": None,
             "port": None,
+            "file_server": False, # An unconfigured internal provider cannot be a file server
         })
 
     return domains
@@ -192,6 +199,7 @@ def get_external_domains(rdb):
                 "host": host,
                 "port": int(port),
                 "id": host,
+                "file_server": False, # An external provider cannot be a file server
                 "node": None,
                 "ui_name": rdb.hget(f"cluster/user_domain/ldap/{domain_id}/ui_names", epaddr) or "",
             })

--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-user-domains/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-user-domains/validate-output.json
@@ -32,6 +32,7 @@
                             "id": "openldap1",
                             "ui_name": "",
                             "node": 1,
+                            "file_server": false,
                             "host": "10.110.32.2",
                             "port": 20003
                         },
@@ -39,6 +40,7 @@
                             "id": "openldap2",
                             "ui_name": "",
                             "node": 2,
+                            "file_server": false,
                             "host": "10.110.32.3",
                             "port": 20002
                         }
@@ -63,6 +65,7 @@
                             "id": "ldap-primary.company.org",
                             "ui_name": "Company LDAP primary",
                             "node": null,
+                            "file_server": false,
                             "host": "ldap-master.company.org",
                             "port": 636
                         },
@@ -70,6 +73,7 @@
                             "id": "ldap-replica.company.org",
                             "ui_name": "Company LDAP replica",
                             "node": null,
+                            "file_server": false,
                             "host": "ldap-replica.company.org",
                             "port": 636
                         }
@@ -268,6 +272,7 @@
                 "id",
                 "ui_name",
                 "node",
+                "file_server",
                 "host",
                 "port"
             ],
@@ -285,6 +290,10 @@
                         "null"
                     ],
                     "minimum": 1
+                },
+                "file_server": {
+                    "title": "The provider can be used as SMB file server too",
+                    "type": "boolean"
                 },
                 "host": {
                     "title": "Host name or IP address",


### PR DESCRIPTION
The user domain provider object has a new attribute: "file_server". It is a boolean flag that reflects the existence and the value of a "file_server" flag in the Redis SET key `module/{mid}/flags`.