### PR TITLE
Samba file server UI

### DIFF
--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -15,7 +15,7 @@
     "@carbon/icons-vue": "^10.37.0",
     "@carbon/themes": "^10.34.0",
     "@carbon/vue": "^2.40.0",
-    "@nethserver/ns8-ui-lib": "^0.1.22",
+    "@nethserver/ns8-ui-lib": "^0.1.23",
     "await-to-js": "^3.0.0",
     "axios": "^0.21.2",
     "carbon-components": "^10.41.0",

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -921,6 +921,9 @@
   "samba": {
     "adminuser": "Samba admin username",
     "choose_samba_admin_username": "Choose Samba admin username",
+    "samba_admin_username_tooltip_1": "If you choose a username other than <strong>administrator</strong>:",
+    "samba_admin_username_tooltip_2": "The specified user will be added to <strong>Domain Admins</strong> group",
+    "samba_admin_username_tooltip_3": "<strong>administrator</strong> user will be disabled and a random password will be set to it",
     "adminpass": "Samba admin password",
     "adminpass_confirm": "Re-enter Samba admin password",
     "choose_samba_admin_password": "Choose a password for Samba admin user",

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -770,7 +770,8 @@
       "storage": "Storage",
       "monitoring": "Monitoring",
       "web": "Web",
-      "communication": "Communication"
+      "communication": "Communication",
+      "security": "Security"
     }
   },
   "system_logs": {
@@ -925,11 +926,19 @@
     "choose_samba_admin_password": "Choose a password for Samba admin user",
     "realm": "Domain",
     "ipaddress": "IP address",
+    "provider_ipaddress": "Provider IP address",
     "hostname": "Hostname",
     "nbdomain": "NetBIOS domain",
     "enter_samba_admin_username": "Login as Samba admin",
     "enter_samba_admin_password": "Enter Samba admin password",
-    "samba_configuration": "Samba configuration"
+    "samba_configuration": "Samba configuration",
+    "enable_file_server_label": "Provide file shares and authentication to Windows clients",
+    "enable_file_server_tooltip": "Enable this switch and select the desired IP address to provide Active Directory services to clients in the local private network",
+    "enable_file_server_disabled_info": "File shares and authentication to Windows clients cannot be enabled because they are already configured on another provider of this domain",
+    "provider_on_vpn_address_message": "The new provider will be configured on the VPN IP address <strong>{vpnIpAddress}</strong>",
+    "choose_ip_address_warning": "Make sure to select an IP address reachable by Windows clients. This choice is <strong>NOT</strong> reversible",
+    "file_server": "File server",
+    "open_file_server": "Open file server"
   },
   "openldap": {
     "domain": "Domain",

--- a/core/ui/src/components/shell/AppDrawer.vue
+++ b/core/ui/src/components/shell/AppDrawer.vue
@@ -461,10 +461,13 @@ export default {
 
       for (let instanceList of Object.values(taskResult.output)) {
         for (let instance of instanceList) {
-          // skip instance if it's an account provider app or a core app
+          // show app instance if:
+          // - it's not a core app, OR
+          // - it's a samba file server instance
           if (
-            !instance.flags.includes("account_provider") &&
-            !instance.flags.includes("core_module")
+            !instance.flags.includes("core_module") ||
+            (instance.flags.includes("account_provider") &&
+              instance.flags.includes("file_server"))
           ) {
             apps.push(instance);
           }

--- a/core/ui/src/views/DomainConfiguration.vue
+++ b/core/ui/src/views/DomainConfiguration.vue
@@ -398,6 +398,14 @@
                     <span>{{ provider.host }}</span>
                     <span v-if="provider.port">:{{ provider.port }}</span>
                   </div>
+                  <div v-if="provider.file_server" class="row actions">
+                    <NsButton
+                      kind="ghost"
+                      :icon="Application20"
+                      @click="goToFileServer(provider)"
+                      >{{ $t("samba.open_file_server") }}</NsButton
+                    >
+                  </div>
                 </div>
               </template>
             </NsInfoCard>
@@ -967,6 +975,9 @@ export default {
         }
       }
       return this.$t("common.node") + " " + nodeId;
+    },
+    goToFileServer(provider) {
+      this.$router.push(`/apps/${provider.id}`);
     },
   },
 };

--- a/core/ui/src/views/DomainUsersAndGroups.vue
+++ b/core/ui/src/views/DomainUsersAndGroups.vue
@@ -222,10 +222,6 @@ export default {
     listUserDomainsCompleted(taskContext, taskResult) {
       let domains = taskResult.output.domains;
       this.domain = domains.find((domain) => domain.name === this.domainName);
-
-      //// remove mock
-      // this.domain.location = "external";
-
       this.loading.listUserDomains = false;
     },
     onUsersLoaded(users) {

--- a/core/ui/src/views/Domains.vue
+++ b/core/ui/src/views/Domains.vue
@@ -74,7 +74,8 @@
           <cv-tile light>
             <cv-skeleton-text
               :paragraph="true"
-              :line-count="8"
+              :line-count="6"
+              heading
             ></cv-skeleton-text>
           </cv-tile>
         </cv-column>
@@ -314,6 +315,14 @@
                         {{ domain.providers.length }}
                         {{ $tc("domains.providers", domain.providers.length) }}
                       </cv-link>
+                      <template v-if="domain.fileServerProvider">
+                        <span class="bullet-separator">&bull;</span>
+                        <cv-link
+                          @click="goToFileServer(domain.fileServerProvider)"
+                        >
+                          <span>{{ $t("samba.file_server") }}</span>
+                        </cv-link>
+                      </template>
                     </div>
                     <div class="row actions">
                       <NsButton
@@ -480,8 +489,9 @@ export default {
         domains.sort(this.sortByProperty("name"));
       }
 
-      // check for unconfigured providers
       for (const domain of domains) {
+        // check for unconfigured providers
+
         const unconfiguredProvidersFound = domain.providers.find(
           (p) => !p.host
         );
@@ -491,8 +501,17 @@ export default {
         } else {
           domain.hasUnconfiguredProviders = false;
         }
-      }
 
+        // check samba file server
+
+        const fileServerProviderFound = domain.providers.find(
+          (p) => p.file_server
+        );
+
+        if (fileServerProviderFound) {
+          domain.fileServerProvider = fileServerProviderFound;
+        }
+      }
       this.domains = domains;
 
       let unconfiguredDomains = taskResult.output.unconfigured_domains;
@@ -676,6 +695,9 @@ export default {
         params: { domainName: domain.name },
         hash: anchor ? "#" + anchor : "",
       });
+    },
+    goToFileServer(fileServerProvider) {
+      this.$router.push(`/apps/${fileServerProvider.id}`);
     },
   },
 };

--- a/core/ui/src/views/Nodes.vue
+++ b/core/ui/src/views/Nodes.vue
@@ -428,9 +428,6 @@ export default {
         const endpoint =
           window.location.protocol + "//" + window.location.hostname;
 
-        console.log("endpoint", endpoint); ////
-        console.log("leaderListenPort", this.leaderListenPort); ////
-
         // join code is obtained by concatenating endpoint, leader VPN port and auth token with pipe character
         this.joinCode = btoa(
           endpoint + "|" + this.leaderListenPort + "|" + loginInfo.token

--- a/core/ui/yarn.lock
+++ b/core/ui/yarn.lock
@@ -2002,9 +2002,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nethserver/ns8-ui-lib@npm:^0.1.22":
-  version: 0.1.22
-  resolution: "@nethserver/ns8-ui-lib@npm:0.1.22"
+"@nethserver/ns8-ui-lib@npm:^0.1.23":
+  version: 0.1.23
+  resolution: "@nethserver/ns8-ui-lib@npm:0.1.23"
   dependencies:
     "@rollup/plugin-json": ^4.1.0
     core-js: ^3.15.2
@@ -2013,7 +2013,7 @@ __metadata:
     vue-date-fns: ^2.0.1
   peerDependencies:
     vue: ^2.6.12
-  checksum: a1020ab6ba158ac8a34d0c980d582d71c4b037484825bceb45f553a8136838e9b5d7cb5508f0e69b163629253d2167e96490c9f5da13f2b83f8c4b24efbcaaee
+  checksum: 62d05562c62aafc3bc31f943224a0d1aa4667c1f7513bdf3694b5653b1e10fd606514b216ac629d4c1792d3afeb3dbaae838a896a3ee91d18e0f16d7e1690ad1
   languageName: node
   linkType: hard
 
@@ -13076,7 +13076,7 @@ __metadata:
     "@carbon/icons-vue": ^10.37.0
     "@carbon/themes": ^10.34.0
     "@carbon/vue": ^2.40.0
-    "@nethserver/ns8-ui-lib": ^0.1.22
+    "@nethserver/ns8-ui-lib": ^0.1.23
     "@storybook/addon-actions": ^6.2.9
     "@storybook/addon-essentials": ^6.2.9
     "@storybook/addon-links": ^6.2.9


### PR DESCRIPTION
- Optionally enable file server capabilities when configuring a Samba account provider
- Show Samba file server instances inside the App drawer

Other changes:
- Add app category **Security**
- Update `@nethserver/ns8-ui-lib`
- Clean up code
