### PR TITLE
ui: reload app drawer when adding/removing samba

### DIFF
--- a/core/ui/src/components/domains/AddInternalProviderModal.vue
+++ b/core/ui/src/components/domains/AddInternalProviderModal.vue
@@ -832,6 +832,9 @@ export default {
 
       // reload domains
       this.$emit("reloadDomains");
+
+      // reload app drawer (samba file server might have appeared)
+      this.$root.$emit("reloadAppDrawer");
     },
     configureSambaModuleAborted(taskResult, taskContext) {
       console.error(`${taskContext.action} aborted`, taskResult);

--- a/core/ui/src/components/domains/CreateDomainModal.vue
+++ b/core/ui/src/components/domains/CreateDomainModal.vue
@@ -1187,6 +1187,9 @@ export default {
 
       // reload domains
       this.$emit("reloadDomains");
+
+      // reload app drawer (samba file server might have appeared)
+      this.$root.$emit("reloadAppDrawer");
     },
     configureSambaModuleAborted(taskResult, taskContext) {
       console.error(`${taskContext.action} aborted`, taskResult);

--- a/core/ui/src/components/domains/DeleteSambaProviderModal.vue
+++ b/core/ui/src/components/domains/DeleteSambaProviderModal.vue
@@ -228,6 +228,9 @@ export default {
 
       // reload domains
       this.$emit("reloadDomains");
+
+      // reload app drawer (samba file server might have disappeared)
+      this.$root.$emit("reloadAppDrawer");
     },
   },
 };

--- a/core/ui/src/views/Domains.vue
+++ b/core/ui/src/views/Domains.vue
@@ -588,6 +588,9 @@ export default {
     },
     removeInternalDomainCompleted() {
       this.listUserDomains();
+
+      // reload app drawer (samba file server might have disappeared)
+      this.$root.$emit("reloadAppDrawer");
     },
     async removeExternalDomain(domain) {
       this.error.removeExternalDomain = "";


### PR DESCRIPTION
Samba file server app might appear/disappear in the app drawer when installing/uninstalling a domain/provider