### PR TITLE
Hide the overlayFs partition in get-node-status

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/get-node-status/20read
+++ b/core/imageroot/var/lib/nethserver/node/actions/get-node-status/20read
@@ -74,7 +74,8 @@ ret['swap']['free'] = swap[2]
 ret['swap']['used'] = swap[1]
 for p in psutil.disk_partitions():
     usage = psutil.disk_usage(p[1])
-    ret['disks'].append({'device': p[0], 'mountpoint': p[1], 'fstype': p[2], 'total': usage[0], 'used': usage[1], 'free': usage[2]})
+    if not re.search(r'/var/lib/containers/storage/overlay', p[1]):
+        ret['disks'].append({'device': p[0], 'mountpoint': p[1], 'fstype': p[2], 'total': usage[0], 'used': usage[1], 'free': usage[2]})
 
 # Dump the result
 json.dump(ret, fp=sys.stdout)


### PR DESCRIPTION
the psutil.disk_partitions gives back the overlayFs partition mounted to `var/lib/containers/storage/overlay`, this could mislead the user because for him it got one less partition 

see https://trello.com/c/KqN3iegZ/386-core-p3-repeated-disk-info

```
[root@R1-pve state]# cat /etc/fstab 

#
# /etc/fstab
# Created by anaconda on Thu Jan  5 07:34:42 2023
#
# Accessible filesystems, by reference, are maintained under '/dev/disk/'.
# See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info.
#
# After editing this file, run 'systemctl daemon-reload' to update systemd
# units generated from this file.
#
/dev/mapper/rl-root     /                       xfs     defaults        0 0
UUID=2376ce48-2235-45e3-9300-aa231a73b165 /boot                   xfs     defaults        0 0
/dev/mapper/rl-home     /home                   xfs     defaults        0 0
/dev/mapper/rl-swap     none                    swap    defaults        0 0
```

```
[root@R1-pve state]# df -h
Filesystem           Size  Used Avail Use% Mounted on
devtmpfs             4.0M     0  4.0M   0% /dev
tmpfs                3.8G  504K  3.8G   1% /dev/shm
tmpfs                1.6G   30M  1.5G   2% /run
/dev/mapper/rl-root   39G  3.3G   35G   9% /
/dev/sda1           1014M  378M  637M  38% /boot
/dev/mapper/rl-home   19G  4.7G   14G  26% /home
tmpfs                769M   76K  769M   1% /run/user/1001
tmpfs                769M   76K  769M   1% /run/user/1000
tmpfs                769M  160K  769M   1% /run/user/1002
shm                   63M     0   63M   0% /var/lib/containers/storage/overlay-containers/c79c72c2957b23f602f12b945c9815447caddd5b76632619e48a9de40e2f32a9/userdata/shm
overlay               39G  3.3G   35G   9% /var/lib/containers/storage/overlay/29e098b305e6d1159fbeda07bc834f5910ae1cefa0f596f4e1942959d3b420f6/merged
shm                   63M     0   63M   0% /var/lib/containers/storage/overlay-containers/f7e0c4a1c11cbd5386fbf354d299a3c02bf9ac73c726bdd99a1826b204bd12e7/userdata/shm
overlay               39G  3.3G   35G   9% /var/lib/containers/storage/overlay/b6fd67c2360d9dc9ede868aaf6f2c671aa255cc4bf7851a50a5f62015f07bec6/merged
tmpfs                769M  324K  769M   1% /run/user/1003
tmpfs                769M  308K  769M   1% /run/user/1004
tmpfs                769M     0  769M   0% /run/user/0
```

```
[root@R1-pve ~]# runagent python
Python 3.9.16 (main, Dec  8 2022, 00:00:00) 
[GCC 11.3.1 20221121 (Red Hat 11.3.1-4)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import psutil
>>> psutil.disk_partitions()
[sdiskpart(device='/dev/mapper/rl-root', mountpoint='/', fstype='xfs', opts='rw,seclabel,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota', maxfile=255, maxpath=4096), sdiskpart(device='/dev/sda1', mountpoint='/boot', fstype='xfs', opts='rw,seclabel,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota', maxfile=255, maxpath=4096), sdiskpart(device='/dev/mapper/rl-home', mountpoint='/home', fstype='xfs', opts='rw,seclabel,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota', maxfile=255, maxpath=4096), sdiskpart(device='/dev/mapper/rl-root', mountpoint='/var/lib/containers/storage/overlay', fstype='xfs', opts='rw,seclabel,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota', maxfile=255, maxpath=4096)]
```

The UI and the backend get right, we need to hide the overlaysFs partition mounted here on the physical  
`/dev/mapper/rl-root`