### PR TITLE
Docs update: service_providers.md

### DIFF
--- a/docs/modules/service_providers.md
+++ b/docs/modules/service_providers.md
@@ -100,6 +100,6 @@ startup more robust.
 
 ```python
 import agent
-rdb = agent.redis_connect(host='127.0.0.1') # connect the local Redis replica
+rdb = agent.redis_connect(use_replica=True) # connect the local Redis replica
 print(agent.list_service_providers(rdb, 'imap', 'tcp'))
 ```


### PR DESCRIPTION
Reword the example with the new `use_replica=True` argument for redis_connect() function.

The effect of the call is the same of `host=127.0.0.1`, but the purpose is more clear.