### PR TITLE
Fix UI endless load state in retrieveNodesStatus()

### DIFF
--- a/core/ui/src/views/Nodes.vue
+++ b/core/ui/src/views/Nodes.vue
@@ -490,7 +490,7 @@ export default {
       for (const node of this.nodes) {
         if (!node.online) {
           // node is offline
-          return;
+          continue;
         }
 
         const nodeId = node.id;


### PR DESCRIPTION
The first time the function hits an offline node, further nodes are left behind by the return statement.

References 
- https://trello.com/c/DjnNsuX9/384-core-p1-fix-node-details
- https://community.nethserver.org/t/node-3-details-loading-forever-when-node-2-is-offline/21702/3