### PR TITLE
function to retrieve FQDN of server

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -531,4 +531,4 @@ def get_hostname():
         hostname = subprocess.run(['hostname', '-f'], text=True, capture_output=True, check=True).stdout.strip()
     except ValueError:
         hostname = "myserver.example.org"
-    return {"hostname": hostname}
+    return hostname

--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -525,3 +525,10 @@ def tcp_port_in_use(port):
             raise
         # port is in use we have raise the error address in use
         return  True
+
+def get_hostname():
+    try:
+        hostname = subprocess.run(['hostname', '-f'], text=True, capture_output=True, check=True).stdout.strip()
+    except ValueError:
+        hostname = "myserver.example.org"
+    return {"hostname": hostname}

--- a/docs/core/hostname.md
+++ b/docs/core/hostname.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: hostname FQDN
+nav_order: 14
+parent: Core
+---
+
+# Hostname FQDN
+
+Retrieve the fully qualified domain name of the server by using a python library. In case of exception the function output a generic FQDN `myserver.example.com`
+
+Python example code:
+
+```python
+#!/usr/bin/env python3
+
+import sys
+import json
+import agent
+
+fqdn = agent.get_hostname()
+json.dump(fqdn, fp=sys.stdout)
+```
+
+output example:
+```json
+{"hostname": "foo.domain.com"}
+```

--- a/docs/modules/code_snippets.md
+++ b/docs/modules/code_snippets.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: hostname FQDN
+title: Code snippets
 nav_order: 14
-parent: Core
+parent: Modules
 ---
 
 # Hostname FQDN
@@ -14,15 +14,13 @@ Python example code:
 ```python
 #!/usr/bin/env python3
 
-import sys
-import json
 import agent
 
 fqdn = agent.get_hostname()
-json.dump(fqdn, fp=sys.stdout)
+print(fqdn)
 ```
 
 output example:
-```json
-{"hostname": "foo.domain.com"}
+```
+foo.domain.com
 ```

--- a/docs/modules/code_snippets.md
+++ b/docs/modules/code_snippets.md
@@ -5,7 +5,11 @@ nav_order: 14
 parent: Modules
 ---
 
-# Hostname FQDN
+# Code snippets
+
+Some code examples to ease the life of module developers
+
+## Hostname FQDN
 
 Retrieve the fully qualified domain name of the server by using a python library. In case of exception the function output a generic FQDN `myserver.example.com`
 
@@ -23,4 +27,67 @@ print(fqdn)
 output example:
 ```
 foo.domain.com
+```
+
+## Port validation
+
+we search if the TCP port is used or not by a service return true if the port is used, false is the port is not used.
+
+```python
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import agent
+
+port=80
+if agent.tcp_port_in_use(port):
+    sys.exit(1)
+```
+
+
+## Web route validation
+
+we search if the domain (foo.com) or the webpath (/foo) is used or not by a service return true if the route is used, false is the route is not used.
+
+### test if the domain is used (domain.com)
+```python
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import agent
+
+# Setup default values
+hostname = 'foo.com'
+
+if agent.http_route_in_use(domain=hostname):
+    sys.exit(2)
+```
+
+### test if the web path is not used (/path)
+```python
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import agent
+
+# Setup default values
+path ='/path'
+
+if agent.http_route_in_use(domain=none, path=path):
+    sys.exit(2)
 ```

--- a/docs/modules/code_snippets.md
+++ b/docs/modules/code_snippets.md
@@ -11,13 +11,11 @@ Some code examples to ease the life of module developers
 
 ## Hostname FQDN
 
-Retrieve the fully qualified domain name of the server by using a python library. In case of exception the function output a generic FQDN `myserver.example.com`
+Retrieve the fully qualified domain name of the server by using the `agent` Python library. In case of exception the function outputs the default FQDN `myserver.example.org`.
 
 Python example code:
 
 ```python
-#!/usr/bin/env python3
-
 import agent
 
 fqdn = agent.get_hostname()
@@ -31,16 +29,9 @@ foo.domain.com
 
 ## Port validation
 
-we search if the TCP port is used or not by a service return true if the port is used, false is the port is not used.
+Check if the TCP port is already used by a service. Exit with an error if the port is used.
 
 ```python
-#!/usr/bin/env python3
-
-#
-# Copyright (C) 2022 Nethesis S.r.l.
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-
 import sys
 import agent
 
@@ -52,42 +43,23 @@ if agent.tcp_port_in_use(port):
 
 ## Web route validation
 
-we search if the domain (foo.com) or the webpath (/foo) is used or not by a service return true if the route is used, false is the route is not used.
+Check if HTTP routes are handled by Traefik. The function issues an HTTP request to 127.0.0.1 port 80, setting the `Host` header in the HTTP request and/or the URL path. Any HTTP non-404 response assumes the HTTP route exists.
 
-### test if the domain is used (domain.com)
+### Test if a domain-based route is used (domain.com)
 ```python
-#!/usr/bin/env python3
-
-#
-# Copyright (C) 2022 Nethesis S.r.l.
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-
 import sys
 import agent
 
-# Setup default values
 hostname = 'foo.com'
-
 if agent.http_route_in_use(domain=hostname):
     sys.exit(2)
 ```
 
-### test if the web path is not used (/path)
+### Test if a path-based route is used (/path)
 ```python
-#!/usr/bin/env python3
-
-#
-# Copyright (C) 2022 Nethesis S.r.l.
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-
 import sys
 import agent
-
-# Setup default values
-path ='/path'
-
+path ='/path' # path fragment of the URL to check
 if agent.http_route_in_use(domain=none, path=path):
     sys.exit(2)
 ```


### PR DESCRIPTION
We could make a function to retrieve by the agent the FQDN of the server

The python library could fail even with socket.getfqdn, it is maybe better to use the bash command

to use it 

```
#!/usr/bin/env python3

import sys
import json
import agent

fqdn = agent.get_hostname()
json.dump(fqdn, fp=sys.stdout)
```

Add also the documentation of 
agent.tcp_port_in_use
agent.http_route_in_use