### PR TITLE
Fix Python 3.11 regression in HTTP route validator

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -500,7 +500,14 @@ def http_route_in_use(domain=None, path=''):
         req = urllib.request.Request('http://127.0.0.1'+path, method="HEAD")
         if domain:
             req.add_header('Host', domain)
-        urllib.request.urlopen(req)
+        # Build a OpenerDirector instance without 30x handlers, to avoid
+        # chasing https:// redirects. A 30x response is enough for us to
+        # infer the route exists.
+        odirector = urllib.request.OpenerDirector()
+        odirector.add_handler(urllib.request.HTTPHandler())
+        odirector.add_handler(urllib.request.HTTPDefaultErrorHandler())
+        odirector.add_handler(urllib.request.HTTPErrorProcessor())
+        odirector.open(req, timeout=5)
     except urllib.error.HTTPError as e:
         if e.code == 404:
             # Assume no path exists


### PR DESCRIPTION
Avoid silent chasing of the HTTP 30x (redirect) responses. By chasing HTTP redirects to HTTPS (common in app-defined routes, like `/rspamd`) the following error arises:

    ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate

The PR fix has been tested with both Python 3.9 and 3.11.

See https://trello.com/c/i2KOMSx1/419-core-p0-agenthttprouteinuse-fails-the-check for more details.

----
Test environment for Python 3.9 (EL-only):

install and configure a Mail instance. Then run:

```
python3.9 -mvenv /usr/local/agent/pyenv3.9 --upgrade-deps --system-site-packages
/usr/local/agent/pyenv3.9/bin/pip3 install -r /etc/nethserver/pythonreq.txt
echo "/usr/local/agent/pypkg" >$(/usr/local/agent/pyenv3.9/bin/python3 -c "import sys; print(sys.path[-1] + '/pypkg.pth')")
/usr/local/agent/pyenv3.9/bin/python3 -c "import agent; print(agent.http_route_in_use(None, '/rspamd'), agent.http_route_in_use(None, '/rspamd2'))"
```

Compare the last command output with Python 3.11:

```
/usr/local/agent/pyenv/bin/python3 -c "import agent; print(agent.http_route_in_use(None, '/rspamd'), agent.http_route_in_use(None, '/rspamd2'))"
```
