### PR TITLE
Update install-finalize.sh

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/install-finalize.sh
+++ b/core/imageroot/var/lib/nethserver/node/install-finalize.sh
@@ -160,7 +160,7 @@ Finally, access the administration UI at:
 
    https://<hostname_or_IP>/cluster-admin/
 
-For instance, if $(hostname -f) is resolveable 
+For instance, if $(hostname -f) is resolvable 
 
    https://$(hostname -f)/cluster-admin/
 


### PR DESCRIPTION
Clarify the use of FQDN to reach the node is just an example. We cannot set as installation pre-requirement that FQDN is resolvable by DNS.

https://github.com/NethServer/ns8-docs/pull/25