### PR TITLE
create-cluster: set VPN network for traefik

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/50update
@@ -29,6 +29,7 @@ import agent.tasks
 import cluster.grants
 import cluster.vpn
 import uuid
+import pwd
 
 request = json.load(sys.stdin)
 
@@ -67,7 +68,9 @@ rdb.hset(f'node/{NODE_ID}/vpn', mapping={
 })
 
 # Our first Traefik instance is missing the VPN network: fix it here.
-rdb.set('module/traefik1/kv/http/middlewares/ApiServerMw1/ipWhiteList/sourceRange/1', network)
+agent.run_helper('sed', '-i',
+                f'/- 127.0.0.1$/a\ \ \ \ \ \ \ \ - {network}',
+                f'{pwd.getpwnam("traefik1").pw_dir}/.config/state/configs/_api.yml').check_returncode()
 
 # Update the cluster-localnode record in /etc/hosts
 agent.run_helper('sed', '-i',


### PR DESCRIPTION
Change implementation to file backend

See also: https://github.com/NethServer/ns8-traefik/pull/38

Card: https://trello.com/c/Zc20ffWx/416-core-p1-traefik-dirs-backend-migration