### PR TITLE
list-installed-modules: get icon from local disk

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
@@ -158,7 +158,6 @@ def list_installed(rdb, skip_core_modules = False):
         vars = rdb.hgetall(m)
         module_ui_name = rdb.get(m.removesuffix('/environment') + '/ui_name') or ""
         url, sep, tag = vars['IMAGE_URL'].partition(":")
-        image = url[url.rindex('/')+1:]
         logo = logos.get(vars["MODULE_ID"]) or ''
         flags = list(rdb.smembers(f'module/{vars["MODULE_ID"]}/flags')) or []
         if skip_core_modules and 'core_module' in flags:


### PR DESCRIPTION
If metadata repository are not accessible, the logo must be always available

Card: https://trello.com/c/Kwu5FnOl/361-core-p2-app-drawer-icons-and-metadata