### PR TITLE
UI: Fix add Samba provider validation

### DIFF
--- a/core/ui/src/components/domains/AddInternalProviderModal.vue
+++ b/core/ui/src/components/domains/AddInternalProviderModal.vue
@@ -689,16 +689,6 @@ export default {
         }
       }
 
-      // samba ip address
-
-      if (!this.samba.ipaddress) {
-        this.error.samba.ipaddress = "common.required";
-
-        if (isValidationOk) {
-          isValidationOk = false;
-        }
-      }
-
       // samba hostname
 
       if (!this.samba.hostname) {
@@ -706,6 +696,16 @@ export default {
 
         if (isValidationOk) {
           this.focusElement("hostname");
+          isValidationOk = false;
+        }
+      }
+
+      // samba ip address
+
+      if (this.samba.enableFileServer && !this.samba.ipaddress) {
+        this.error.samba.ipaddress = "common.required";
+
+        if (isValidationOk) {
           isValidationOk = false;
         }
       }

--- a/core/ui/src/components/error/TaskErrorInfo.vue
+++ b/core/ui/src/components/error/TaskErrorInfo.vue
@@ -27,7 +27,10 @@
         </cv-link></cv-tooltip
       >
     </div>
-    <div v-if="task.result && task.result.error" class="mg-top-sm">
+    <div
+      v-if="task.result && task.result.error && task.result.exit_code != 0"
+      class="mg-top-sm"
+    >
       <NsCodeSnippet
         :copyTooltip="$t('common.copy_to_clipboard')"
         :copy-feedback="$t('common.copied_to_clipboard')"


### PR DESCRIPTION
Validate Samba IP address only if "Provide file shares and authentication to Windows clients" toggle is enabled

Trello card: https://trello.com/c/W5vw07Tl/410-core-p1-adding-samba-provider-dialog-unresponsive

Other changes:
- Improve task error visualization