### PR TITLE
UI: fix default vpn endpoint address on node promotion

### DIFF
--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -15,7 +15,7 @@
     "@carbon/icons-vue": "^10.37.0",
     "@carbon/themes": "^10.34.0",
     "@carbon/vue": "^2.40.0",
-    "@nethserver/ns8-ui-lib": "^0.1.26",
+    "@nethserver/ns8-ui-lib": "^0.1.27",
     "await-to-js": "^3.0.0",
     "axios": "^0.21.2",
     "carbon-components": "^10.41.0",

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -354,7 +354,8 @@
     "list-users": "List cluster administrators",
     "get-user-info": "Get user info",
     "remove-node": "Remove node",
-    "promote-node": "Promote node"
+    "promote-node": "Promote node",
+    "get-info": "Get node info"
   },
   "network": {
     "title": "Network"
@@ -1094,7 +1095,8 @@
     "validation_endpoint_port_invalid_type": "Invalid format",
     "go_to_cluster_admin": "Go to cluster administration",
     "promotion_completed": "Promotion completed",
-    "shutdown_node_after_removal": "Shut down {node} after node removal to stop the apps running on it"
+    "shutdown_node_after_removal": "Shut down {node} after node removal to stop the apps running on it",
+    "cannot_retrieve_node_info": "Cannot retrieve node info"
   },
   "node_detail": {
     "title": "Node detail",

--- a/core/ui/src/components/shell/AppDrawer.vue
+++ b/core/ui/src/components/shell/AppDrawer.vue
@@ -89,7 +89,7 @@
                               ? app.logo
                               : require('@/assets/module_default_logo.png')
                           "
-                          :alt="app.name + ' logo'"
+                          :alt="app.id + ' logo'"
                         />
                       </div>
                       <div>
@@ -171,7 +171,7 @@
                                 ? app.logo
                                 : require('@/assets/module_default_logo.png')
                             "
-                            :alt="app.name + ' logo'"
+                            :alt="app.id + ' logo'"
                           />
                         </div>
                         {{ app.ui_name ? app.ui_name : app.id }}
@@ -207,7 +207,7 @@
                               ? app.logo
                               : require('@/assets/module_default_logo.png')
                           "
-                          :alt="app.name + ' logo'"
+                          :alt="app.id + ' logo'"
                         />
                       </div>
                       {{ app.ui_name ? app.ui_name : app.id }}
@@ -235,7 +235,7 @@
                                     ? app.logo
                                     : require('@/assets/module_default_logo.png')
                                 "
-                                :alt="app.name + ' logo'"
+                                :alt="app.id + ' logo'"
                               />
                             </div>
                             <span>{{
@@ -268,7 +268,7 @@
                                   ? app.logo
                                   : require('@/assets/module_default_logo.png')
                               "
-                              :alt="app.name + ' logo'"
+                              :alt="app.id + ' logo'"
                             />
                           </div>
                           <span>{{ app.ui_name ? app.ui_name : app.id }}</span>

--- a/core/ui/src/views/Nodes.vue
+++ b/core/ui/src/views/Nodes.vue
@@ -291,7 +291,6 @@
     <PromoteNodeModal
       :isShown="isShownPromoteNodeModal"
       :node="nodeToPromote"
-      :vpnEndpointAddress="nodeToPromoteHostname"
       @hide="hidePromoteNodeModal"
       @nodePromoted="onNodePromoted"
     />
@@ -374,19 +373,6 @@ export default {
     },
     nodesOffline() {
       return this.nodes.filter((n) => n.online == false);
-    },
-    nodeToPromoteHostname() {
-      if (!this.nodeToPromote) {
-        return "";
-      }
-      const nodeFound = this.nodes.find(
-        (node) => node.id === this.nodeToPromote.id
-      );
-
-      if (nodeFound) {
-        return nodeFound.hostname;
-      }
-      return "";
     },
   },
   watch: {

--- a/core/ui/yarn.lock
+++ b/core/ui/yarn.lock
@@ -2002,9 +2002,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nethserver/ns8-ui-lib@npm:^0.1.26":
-  version: 0.1.26
-  resolution: "@nethserver/ns8-ui-lib@npm:0.1.26"
+"@nethserver/ns8-ui-lib@npm:^0.1.27":
+  version: 0.1.27
+  resolution: "@nethserver/ns8-ui-lib@npm:0.1.27"
   dependencies:
     "@rollup/plugin-json": ^4.1.0
     core-js: ^3.15.2
@@ -2013,7 +2013,7 @@ __metadata:
     vue-date-fns: ^2.0.1
   peerDependencies:
     vue: ^2.6.12
-  checksum: b02f133111450add7830d3d3fb895ff321dfa7155dcdf23f24bcb99d754861ee09f59a68d940382631b960356d2f0d5be9b6bcacd7ec4192080884bc02d5b19f
+  checksum: 7de037966b7790a894ac012ae16a99fedb4b3390ed25d0f728219e44e5d2f83c07ce750ee67c7a58f3a567c7846f84f9d67fafe9b6d6ce5f1641029ce53571ea
   languageName: node
   linkType: hard
 
@@ -13076,7 +13076,7 @@ __metadata:
     "@carbon/icons-vue": ^10.37.0
     "@carbon/themes": ^10.34.0
     "@carbon/vue": ^2.40.0
-    "@nethserver/ns8-ui-lib": ^0.1.26
+    "@nethserver/ns8-ui-lib": ^0.1.27
     "@storybook/addon-actions": ^6.2.9
     "@storybook/addon-essentials": ^6.2.9
     "@storybook/addon-links": ^6.2.9


### PR DESCRIPTION
Get default value for VPN endpoint address from `get-info` action.

Trello card: https://trello.com/c/UMt11syd/409-core-p1-bad-endpoint-in-node-promotion-page

Other changes:
- App drawer: fix app logo alternate text
- Update `@nethserver/ns8-ui-lib`