### PR TITLE
UI: fix enable 2FA modal

### DIFF
--- a/core/ui/src/components/settings/Enable2FaModal.vue
+++ b/core/ui/src/components/settings/Enable2FaModal.vue
@@ -245,7 +245,9 @@ export default {
       this.loading.verify2FaCode = true;
 
       // invoke API
-      const [verify2FaCodeError] = await to(this.verify2FaSecret(this.setupKey, this.twoFaCode));
+      const [verify2FaCodeError] = await to(
+        this.verify2FaSecret(this.setupKey, this.twoFaCode)
+      );
       this.loading.verify2FaCode = false;
 
       if (verify2FaCodeError) {

--- a/core/ui/src/components/settings/Enable2FaModal.vue
+++ b/core/ui/src/components/settings/Enable2FaModal.vue
@@ -21,7 +21,7 @@
   >
     <template slot="title">{{ $t("settings_account.enable_2fa") }}</template>
     <template slot="content">
-      <cv-form>
+      <cv-form @submit.prevent="nextStep">
         <NsInlineNotification
           v-if="error.get2FaQrCode"
           kind="error"


### PR DESCRIPTION
Enable 2FA modal: fix a bug that refreshes the page when hitting <kbd>Enter</kbd> key on **6-digit code** input field