### PR TITLE
UI: slow down refresh interval of nodes data

### DIFF
--- a/core/ui/src/views/NodeDetail.vue
+++ b/core/ui/src/views/NodeDetail.vue
@@ -373,8 +373,8 @@ export default {
   data() {
     return {
       q: {},
-      NODE_STATUS_TIME_INTERVAL: 5000,
-      CLUSTER_STATUS_TIME_INTERVAL: 5000,
+      NODE_STATUS_TIME_INTERVAL: 30000,
+      CLUSTER_STATUS_TIME_INTERVAL: 30000,
       CPU_LOAD_WARNING_TH: 90,
       LAST_SEEN_WARNING_TH: 5 * 60 * 1000, // milliseconds: 5 minutes
       nodeId: "",

--- a/core/ui/src/views/Nodes.vue
+++ b/core/ui/src/views/Nodes.vue
@@ -358,7 +358,7 @@ export default {
   },
   data() {
     return {
-      REFRESH_DATA_TIME_INTERVAL: 10000,
+      REFRESH_DATA_TIME_INTERVAL: 30000,
       q: {
         isShownAddNodeModal: false,
       },


### PR DESCRIPTION
Refreshing nodes data too often can be expensive; let's slow down refresh interval to 30 seconds.