### PR TITLE
Fix loopback IP address for FQDN

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/set-fqdn/20set_fqdn
+++ b/core/imageroot/var/lib/nethserver/node/actions/set-fqdn/20set_fqdn
@@ -21,4 +21,4 @@ hostnamectl set-hostname "${hostname}"
 sed -i -E "/^[^#].+\s${old_hostname}(\s|$)/ s/^/# commented by set-fqdn #/" /etc/hosts
 
 # Append to /etc/hosts according to hostname man page:
-printf "127.0.0.2 %s %s\n" "${hostname}.${domain}" "${hostname}" >> /etc/hosts
+printf "127.0.1.1 %s %s\n" "${hostname}.${domain}" "${hostname}" >> /etc/hosts


### PR DESCRIPTION
The IP address in hostname man page is `127.0.1.1`. Fix the API for it.

Checked on Debian 12 and CentOS Stream 9.