### PR TITLE
Disable Redis keyspace notifications

### DIFF
--- a/core/build-image.sh
+++ b/core/build-image.sh
@@ -109,7 +109,6 @@ aclfile "/data/etc/redis.acl"
 dir "/data"
 masteruser default
 masterauth nopass
-notify-keyspace-events AKE
 EOR
 
 EOF


### PR DESCRIPTION
Keyspace notifications were enabled for Traefik Redis backend during early alpha stage. As Traefik does not use the Redis configuration backend, there is no more need for it.

Disabling keyspace notifications improves Redis performances.

This change affects only new installations. Existing installations must be fixed manually after upgrading to Traefik 2.0.0.

See also 
- https://trello.com/c/Zc20ffWx/416-core-p1-traefik-dirs-backend-migration
- https://redis.io/docs/manual/keyspace-notifications/
- The commit that added the removed line: https://github.com/NethServer/ns8-core/commit/830e36eb7a590c7618ed852ad4ed73365f11ff57