### PR TITLE
Fix agent.tasks regression

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/tasks/redisclient.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/tasks/redisclient.py
@@ -80,6 +80,7 @@ async def run_redisclient(taskrq, **kwargs):
         taskctx = {
             'id': task_id,
             'status_path': f"task/{taskrq['agent_id']}/{task_id}",
+            'progress_channel': f"progress/{taskrq['agent_id']}/task/{task_id}",
             'rq': taskrq,
             'lock': asyncio.Lock(),
             'pushed': False,
@@ -184,7 +185,7 @@ async def _aread_status(rdb, status_path):
 async def _acontrol_task(rdb, taskctx, **kwargs):
     progress_callback = kwargs['progress_callback']
     async with rdb.pubsub() as pubsub:
-        await _retry_request(pubsub.subscribe, 'progress/' + taskctx['status_path'])
+        await _retry_request(pubsub.subscribe, taskctx['progress_channel'])
 
         if taskctx['lock'].locked() and taskctx['pushed'] is False:
             taskrq = taskctx['rq']


### PR DESCRIPTION
A recent change to the Python agent.tasks library introduced a new key pattern for task output, error and exit code. The pattern does not apply to the Redis event channel name. As result since that change, the Redis client of agent.tasks is no longer capable of listening to task progress and falls back to task polling which is much slower.

This PR reverts the Pubsub channel name to the original value for the Redis client library. Note that a similar issue is not found in the HTTP library because `api-server` uses a different protocol based on the web socket.

See https://trello.com/c/b9reQ77C/428-core-p0-slow-api-cli-task-response
Refs https://github.com/NethServer/ns8-core/pull/391

