### PR TITLE
api. Add `force` flag to `update-module` action

### DIFF
--- a/core/imageroot/usr/local/agent/actions/update-module/05pullimages
+++ b/core/imageroot/usr/local/agent/actions/update-module/05pullimages
@@ -33,8 +33,9 @@ os.chdir(os.environ['AGENT_INSTALL_DIR']) # fail fast!
 
 request = json.load(sys.stdin)
 image_url = request['module_url']
+force = "force" in request and request["force"] is True
 
-if image_url == os.getenv('IMAGE_URL'):
+if not force and image_url == os.getenv('IMAGE_URL'):
     print(agent.SD_WARNING + f"The module URL {image_url} is already installed", file=sys.stderr)
     sys.exit(0)
 
@@ -44,10 +45,15 @@ os.kill(os.getppid(), signal.SIGUSR1)
 
 agent.set_weight('05pullimages', '5')
 
-# Download the requested image
-agent.run_helper('podman-pull-missing', image_url,
-    progress_callback = agent.get_progress_callback(1, 30)
-).check_returncode()
+if not force:
+    # Download the requested image
+    agent.run_helper('podman-pull-missing', image_url,
+        progress_callback = agent.get_progress_callback(1, 30)
+    ).check_returncode()
+else:
+    agent.run_helper('podman', 'pull', image_url,
+      progress_callback = agent.get_progress_callback(1, 30)
+    ).check_returncode()
 
 # Parse the image labels
 with subprocess.Popen(['podman', 'image', 'inspect', image_url], stdout=subprocess.PIPE, stderr=sys.stderr) as proc:
@@ -62,10 +68,15 @@ if 'org.nethserver.images' in inspect_labels:
 else:
     extra_images = []
 
-# Start the download of extra images
-agent.run_helper('podman-pull-missing', *extra_images,
-    progress_callback = agent.get_progress_callback(31, 80)
-).check_returncode()
+if not force:
+    # Start the download of extra images
+    agent.run_helper('podman-pull-missing', *extra_images,
+        progress_callback = agent.get_progress_callback(31, 80)
+    ).check_returncode()
+else:
+    agent.run_helper('podman', 'pull', *extra_images,
+        progress_callback = agent.get_progress_callback(31, 80)
+    ).check_returncode()
 
 # Extract and install the imageroot contents. See chdir() at the beginning
 # of this script.

--- a/core/imageroot/usr/local/agent/actions/update-module/validate-input.json
+++ b/core/imageroot/usr/local/agent/actions/update-module/validate-input.json
@@ -13,6 +13,10 @@
         "module_url": {
             "type": "string",
             "minLength": 1
+        },
+        "force": {
+            "type": "boolean",
+             "default": false
         }
     }
 }

--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
@@ -32,6 +32,7 @@ request = json.load(sys.stdin)
 image_url= request.get('module_url')
 instances = request['instances']
 image_id = ''
+force = "force" in request and request["force"] is True
 
 rdb = agent.redis_connect(privileged=True)
 
@@ -56,10 +57,15 @@ ping_errors = agent.tasks.runp_brief([{"agent_id": f"module/{mid}", "action": "l
 )
 agent.assert_exp(ping_errors == 0)
 
-# Pull the image from the remote server, if not already available locally
-agent.run_helper('podman-pull-missing', image_url,
-    progress_callback=agent.get_progress_callback(0,30)
-).check_returncode()
+if not force:
+    # Pull the image from the remote server, if not already available locally
+    agent.run_helper('podman-pull-missing', image_url,
+        progress_callback=agent.get_progress_callback(0,30)
+    ).check_returncode()
+else:
+    agent.run_helper('podman', 'pull', image_url,
+        progress_callback=agent.get_progress_callback(0,30)
+    ).check_returncode()
 
 # Retrieve the image org.nethserver.authorizations label
 with subprocess.Popen(['podman', 'image', 'inspect', image_url], stdout=subprocess.PIPE, stderr=sys.stderr) as proc:
@@ -89,7 +95,8 @@ for module_id in instances:
         "agent_id": f"module/{module_id}",
         "action": "update-module",
         "data": {
-            "module_url": image_url
+            "module_url": image_url,
+            "force" : force
         }
     })
 

--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-module/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-module/validate-input.json
@@ -36,6 +36,11 @@
                 "pattern": "^.+[0-9]+$"
             },
             "minItems": 1
+        },
+        "force": {
+            "description": "Force the module update even if the given `module_url` is already present in the local Podman storage,",
+            "type": "boolean",
+             "default": false
         }
     }
 }

--- a/docs/modules/updates.md
+++ b/docs/modules/updates.md
@@ -39,12 +39,6 @@ To update an instance from command line, use:
 If the given `module_url` is already present in the local Podman storage,
 no remote download occurs and the local image is used instead. During
 development this might be unwanted and to work around this behavior
-execute the following command in every cluster node, before running
-`update-module`:
+set the flag `"force": true` to the `update-module` action:
 
-    podman rmi ghcr.io/nethserver/mymodule:latest
-
-Depending on the module implementation, the module Podman local storage
-might store auxiliary module images that must be removed as well. E.g.
-
-    ssh mymodule1@localhost podman rmi docker.io/library/postgres:13-alpine
+    api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/mymodule:latest","instances":["mymodule1"],"force":true}'


### PR DESCRIPTION
Force the module update even if the given `module_url` is already present in the local Podman storage