### PR TITLE
UI development explanation on certificate acceptation

### DIFF
--- a/docs/ui/core.md
+++ b/docs/ui/core.md
@@ -104,7 +104,7 @@ Follow the steps below to prepare the development environment for coding NS8 cor
 echo GIN_MODE=debug >> /etc/nethserver/api-server.env; systemctl restart api-server
 ```
 
-You can develop NS8 UI inside a container (recommended) or on your workstation.
+You can develop NS8 UI inside a container (recommended) or on your workstation. You need to accept the first time the selfsigned certificate of the server in a new tab of your browser : `https://IP_address/cluster-admin/api/login`
 
 ### Develop NS8 UI inside a container
 


### PR DESCRIPTION
The first time we connect to the UI development, the certificate must be accepted, hence we have an error and the login part won't be workable

![image](https://github.com/NethServer/ns8-core/assets/3164851/1c5f2631-cff5-4a80-a765-4003de11e00d)
