### PR TITLE
Fix `redis-cli` carriage-return in output

### DIFF
--- a/core/imageroot/usr/local/sbin/redis-cli
+++ b/core/imageroot/usr/local/sbin/redis-cli
@@ -47,6 +47,7 @@ if [[ $(id -u) == 0 ]]; then
     # For the root user, spawn a redis-cli command in the rootfull Redis container
     exec podman exec -e REDISCLI_AUTH -i ${with_tty:+-t} redis redis-cli -h "${redis_host}" --user "${redis_user}" "${@}"
 else
+    source /etc/nethserver/core.env
     # For non-root users, run a temporary container
-    exec podman run -e REDISCLI_AUTH -i ${with_tty:+-t} --network=host --rm ghcr.io/nethserver/redis:latest redis-cli -h "${redis_host}" --user "${redis_user}" "${@}"
+    exec podman run -e REDISCLI_AUTH -i ${with_tty:+-t} --network=host --rm "${REDIS_IMAGE:?}" redis-cli -h "${redis_host}" --user "${redis_user}" "${@}"
 fi


### PR DESCRIPTION
If `redis-cli` detects a TTY it prints lines with CR-LF sequences. This might break shell commands like `var=$(redis-cli ...)`, which receive a trailing CR.

The PR adds a check of the passed command arguments: if `-r` or `--raw` are found, TTY setting is ignored and CR is not printed.