### PR TITLE
Hide delete button certificate for type route

### DIFF
--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -641,7 +641,8 @@
     "cert_upload_label": "Certificate",
     "cert_upload_helptext": "Chain of certificates must be in the same file.",
     "upload_certs": "Upload certificate",
-    "instance_selection_label": "Select instance to upload the file to."
+    "instance_selection_label": "Select instance to upload the file to.",
+    "certificate_tls_tooltips":"The certificate is required by a HTTP route"
   },
   "settings_acme_servers": {
     "title": "ACME servers",

--- a/core/ui/src/views/settings/SettingsTlsCertificates.vue
+++ b/core/ui/src/views/settings/SettingsTlsCertificates.vue
@@ -204,8 +204,8 @@
                         <cv-data-table-cell>
                           <div class="justify-flex-end">
                             <cv-icon-button
-                              v-if="row.type !== 'route'"
-                              :label="$t('common.delete')"
+                              :disabled="row.type === 'route'"
+                              :label="row.type === 'route' ? $t('settings_tls_certificates.certificate_tls_tooltips') :  $t('common.delete')"
                               kind="danger"
                               :icon="TrashCan20"
                               size="small"

--- a/core/ui/src/views/settings/SettingsTlsCertificates.vue
+++ b/core/ui/src/views/settings/SettingsTlsCertificates.vue
@@ -204,6 +204,7 @@
                         <cv-data-table-cell>
                           <div class="justify-flex-end">
                             <cv-icon-button
+                              v-if="row.type !== 'route'"
                               :label="$t('common.delete')"
                               kind="danger"
                               :icon="TrashCan20"


### PR DESCRIPTION
With the PR https://github.com/NethServer/ns8-traefik/pull/45 We list all obtained or requested LE certificate but these certificate cannot be removed from the UI when they have been obtained by set-route. You have to go to the module page and set to false the toggle button of lets_encrypt

This PR only disabled the trash button when the type === 'route'
![image](https://github.com/NethServer/ns8-core/assets/3164851/6a6b96cb-ee49-4c68-837b-0eb23ce0d757)

See https://trello.com/c/WwdiFzRf/435-core-p0-list-of-certificates-is-incomplete