### PR TITLE
Fix agent secrets obfuscation

### DIFF
--- a/core/agent/test/suite/10__obfuscate_input.robot
+++ b/core/agent/test/suite/10__obfuscate_input.robot
@@ -11,3 +11,12 @@ Passwords are obfuscated in Redis context keys
     When The command is received   set  obfuscate-test/context
     Then The task context should contain    XXX
     And The task context should contain    PRE-SERVED
+
+Obfuscation does not alter the input structure
+    Given The task is submitted    obfuscate-test    {"tags":["t1","t2"],"account_info":{"password":"Nethesis,1234","claims":["c1","c2"],"ratio":1.2},"password_not_replaced":"PRE-SERVED"}
+    When The command is received   set  obfuscate-test/context
+    Then The task context should contain    XXX
+    And The task context should contain    PRE-SERVED
+    And The task context should contain    ["t1","t2"]
+    And The task context should contain    ["c1","c2"]
+    And The task context should contain    1.2


### PR DESCRIPTION
The flatten/unflatten library has a known bug that does not preserve JSON arrays. This fix recursively walk the JSON decoded structure and replaces sensitive fields in the same way.

See 
- https://github.com/nqd/flat/issues/7
- https://github.com/NethServer/ns8-core/pull/451

Fixes bug https://trello.com/c/AKVeMcbT/430-core-p0-ui-progress-indicator-freezes-at-100