### PR TITLE
Fix RPM key installation on Rocky Linux 

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -54,6 +54,7 @@ if [[ "${PLATFORM_ID}" == "platform:el9" ]]; then
     if [[ "${ID}" == rocky ]]; then
         print_ns_yum_config > /etc/yum.repos.d/nethserver.repo
         dnf config-manager --save --set-disabled appstream baseos extras
+        rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
     fi
     dnf update -y # Fix SELinux issues with basic packages
     dnf install -y wireguard-tools podman jq openssl firewalld pciutils python3.11


### PR DESCRIPTION
The RPM key is not imported on a pristine Rocky Linux installation, until the first RPM is installed.

If we disable official Rocky repos without importing the key DNF does not know how to find it.

This commit imports the key in the RPM DB forcibly, so it is always found.

Refs https://github.com/NethServer/dev/issues/6779