### PR TITLE
Fix node removal in extreme cases

### DIFF
--- a/core/ui/src/components/nodes/RemoveNodeModal.vue
+++ b/core/ui/src/components/nodes/RemoveNodeModal.vue
@@ -297,8 +297,11 @@ export default {
     },
     listInstalledModulesCompleted(taskContext, taskResult) {
       const appsByNode = this.getInstalledAppsByNode(taskResult.output);
-
-      const nodeApps = appsByNode[this.node.id].filter((app) => {
+      let nodeApps = [];
+      if (this.node.id in appsByNode) {
+        nodeApps = appsByNode[this.node.id];
+      }
+      nodeApps = nodeApps.filter((app) => {
         // exclude core apps (but keep account providers)
         return (
           !app.flags.includes("core_module") ||


### PR DESCRIPTION
If a VPN error occurs during the node join, no applications are installed in it: no references to the failing node are returned.

Refs https://github.com/NethServer/dev/issues/6798

In dev console:

```
TypeError: o[this.node.id] is undefined
    listInstalledModulesCompleted RemoveNodeModal.vue:301
```