### PR TITLE
Fix web socket connection retry procedure

### DIFF
--- a/core/ui/src/App.vue
+++ b/core/ui/src/App.vue
@@ -409,6 +409,14 @@ export default {
         this.$options.sockets.notification = notification;
         this.createNotification(notification);
       }
+
+      // retry web socket connection if still logged-in
+      setTimeout(() => {
+        if (this.loggedUser) {
+          console.warn("Retrying websocket connection...");
+          this.initWebSocket();
+        }
+      }, 5000);
     },
     createErrorNotification(err, message) {
       const notification = {


### PR DESCRIPTION
I want to replace the setInterval()-based retry logic with setTimeout() so I'm sure each new web socket connection attempt is closed before starting a new one.

The setTimeout() ensures there is just one running connection attempt, and avoids to enqueue many concurrent connections: if one of them fails to authorize, just one "authorize-error" message from the server triggers a logout!

NethServer/dev#6809