### PR TITLE
Update container name for Restic backup

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -227,7 +227,7 @@ def run_restic(rdb, repository, repo_path, podman_args, restic_args, **kwargs):
         raise Exception(f"Schema {uschema} not supported")
 
     # Build the Podman command line to run Restic
-    container_name = "restic-" + os.environ.get('MODULE_ID', os.environ["AGENT_ID"]) + "-" + str(os.getpid())
+    container_name = "backup-restic"
     podman_cmd = ['podman', 'run', '-i', '--rm', f'--name={container_name}', '--privileged', '--network=host',
         '--volume=restic-cache:/var/cache/restic',
         "--log-driver=none",

--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -227,8 +227,8 @@ def run_restic(rdb, repository, repo_path, podman_args, restic_args, **kwargs):
         raise Exception(f"Schema {uschema} not supported")
 
     # Build the Podman command line to run Restic
-    container_name = "backup-restic"
-    podman_cmd = ['podman', 'run', '-i', '--rm', f'--name={container_name}', '--privileged', '--network=host',
+    container_name = f"restic-{restic_args[0]}-{repository}"
+    podman_cmd = ['podman', 'run', '-i', '--rm', '--replace', f'--name={container_name}', '--privileged', '--network=host',
         '--volume=restic-cache:/var/cache/restic',
         "--log-driver=none",
     ]


### PR DESCRIPTION
This pull request updates the container name for Restic backup from "restic-{MODULE_ID}-{PID}" to "backup-restic". This change improves clarity and consistency in the naming convention.

https://github.com/NethServer/dev/issues/6819