### PR TITLE
Write the MOTD when set hostname

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/set-fqdn/20set_fqdn
+++ b/core/imageroot/var/lib/nethserver/node/actions/set-fqdn/20set_fqdn
@@ -22,3 +22,6 @@ sed -i -E "/^[^#].+\s${old_hostname}(\s|$)/ s/^/# commented by set-fqdn #/" /etc
 
 # Append to /etc/hosts according to hostname man page:
 printf "127.0.1.1 %s %s\n" "${hostname}.${domain}" "${hostname}" >> /etc/hosts
+
+# write the MOTD and exit
+/usr/bin/systemctl start api-server-motd.service


### PR DESCRIPTION
When we configure the hostname during the first connexion to `cluster-admin` we write the /etc/hosts accordingly but we do not write the relevant MOTD, it needs to wait a restart of the server or of the service api-server to rewrite it fully correctly

https://github.com/NethServer/dev/issues/6821