### PR TITLE
Add skip certificate validation option to route creation

### DIFF
--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -633,7 +633,7 @@
         "path_placeholder": "E.g. /foo",
         "url_placeholder": "E.g. http://127.0.0.1:2000",
         "node_helper": "Select the node where the route will be created",
-        "skipCertVerify": "Skip certificate validation",
+        "skip_cert_verify": "Skip certificate validation",
         "skipCertVerify_tooltip": "Skip certificate validation for the backend target URL"
     },
     "settings_tls_certificates": {

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -632,7 +632,9 @@
         "host_placeholder": "E.g. myapp.example.org",
         "path_placeholder": "E.g. /foo",
         "url_placeholder": "E.g. http://127.0.0.1:2000",
-        "node_helper": "Select the node where the route will be created"
+        "node_helper": "Select the node where the route will be created",
+        "skipCertVerify": "Skip certificate validation",
+        "skipCertVerify_tooltip": "Skip certificate validation for the backend target URL"
     },
     "settings_tls_certificates": {
         "title": "TLS certificates",

--- a/core/ui/src/components/settings/CreateOrEditHttpRouteModal.vue
+++ b/core/ui/src/components/settings/CreateOrEditHttpRouteModal.vue
@@ -65,7 +65,7 @@
           value="stripPrefixValue"
           :form-item="true"
           v-model="skipCertVerify"
-          :disabled="loading.setRoute || url.startsWith('http://')"
+          :disabled="loading.setRoute || !url.startsWith('https://')"
           ref="skipCertVerify"
         >
           <template slot="tooltip">
@@ -221,7 +221,7 @@ export default {
       this.updateSelectedNodeId();
     },
     url(newUrl) {
-      if (newUrl.startsWith('http://')) {
+      if (! newUrl.startsWith('https://')) {
         this.skipCertVerify = false;
     }
   },

--- a/core/ui/src/components/settings/CreateOrEditHttpRouteModal.vue
+++ b/core/ui/src/components/settings/CreateOrEditHttpRouteModal.vue
@@ -65,7 +65,7 @@
           value="stripPrefixValue"
           :form-item="true"
           v-model="skipCertVerify"
-          :disabled="loading.setRoute || !url.startsWith('https://')"
+          :disabled="loading.setRoute || url.startsWith('http://')"
           ref="skipCertVerify"
         >
           <template slot="tooltip">

--- a/core/ui/src/components/settings/CreateOrEditHttpRouteModal.vue
+++ b/core/ui/src/components/settings/CreateOrEditHttpRouteModal.vue
@@ -61,12 +61,12 @@
           </template>
         </NsTextInput>
         <NsToggle
-          :label="$t('settings_http_routes.skipCertVerify')"
+          :label="$t('settings_http_routes.skip_cert_verify')"
           value="stripPrefixValue"
           :form-item="true"
-          v-model="skipCertVerify"
+          v-model="skip_cert_verify"
           :disabled="loading.setRoute || !url.startsWith('https://')"
-          ref="skipCertVerify"
+          ref="skip_cert_verify"
         >
           <template slot="tooltip">
             <span
@@ -198,7 +198,7 @@ export default {
       url: "",
       host: "",
       path: "",
-      skipCertVerify: false,
+      skip_cert_verify: false,
       lets_encrypt: false,
       http2https: false,
       strip_prefix: false,
@@ -206,7 +206,7 @@ export default {
         setRoute: false,
       },
       error: {
-        skipCertVerify: "",
+        skip_cert_verify: "",
         setRoute: "",
         instance: "",
         node: "",
@@ -222,7 +222,7 @@ export default {
     },
     url(newUrl) {
       if (! newUrl.startsWith('https://')) {
-        this.skipCertVerify = false;
+        this.skip_cert_verify = false;
     }
   },
     isShown: function () {
@@ -239,7 +239,7 @@ export default {
           this.strip_prefix = this.route.strip_prefix;
           this.lets_encrypt = this.route.lets_encrypt;
           this.http2https = this.route.http2https;
-          this.skipCertVerify = this.route.skipCertVerify;
+          this.skip_cert_verify = this.route.skip_cert_verify;
         }
       } else {
         // closing modal
@@ -407,7 +407,7 @@ export default {
         lets_encrypt: this.lets_encrypt,
         http2https: this.http2https,
         user_created: true,
-        skipCertVerify: this.skipCertVerify,
+        skip_cert_verify: this.skip_cert_verify,
       };
 
       if (this.host) {
@@ -494,7 +494,7 @@ export default {
       this.lets_encrypt = false;
       this.http2https = false;
       this.strip_prefix = false;
-      this.skipCertVerify = false;
+      this.skip_cert_verify = false;
     },
   },
 };

--- a/core/ui/src/components/settings/CreateOrEditHttpRouteModal.vue
+++ b/core/ui/src/components/settings/CreateOrEditHttpRouteModal.vue
@@ -60,6 +60,22 @@
             <span v-html="$t('settings_http_routes.url_tooltip')"></span>
           </template>
         </NsTextInput>
+        <NsToggle
+          :label="$t('settings_http_routes.skipCertVerify')"
+          value="stripPrefixValue"
+          :form-item="true"
+          v-model="skipCertVerify"
+          :disabled="loading.setRoute || !url.startsWith('https://')"
+          ref="skipCertVerify"
+        >
+          <template slot="tooltip">
+            <span
+              v-html="$t('settings_http_routes.skipCertVerify_tooltip')"
+            ></span>
+          </template>
+          <template slot="text-left">{{ $t("common.disabled") }}</template>
+          <template slot="text-right">{{ $t("common.enabled") }}</template>
+        </NsToggle>
         <NsTextInput
           v-model.trim="host"
           :placeholder="$t('settings_http_routes.host_placeholder')"
@@ -182,6 +198,7 @@ export default {
       url: "",
       host: "",
       path: "",
+      skipCertVerify: false,
       lets_encrypt: false,
       http2https: false,
       strip_prefix: false,
@@ -189,6 +206,7 @@ export default {
         setRoute: false,
       },
       error: {
+        skipCertVerify: "",
         setRoute: "",
         instance: "",
         node: "",
@@ -202,7 +220,11 @@ export default {
     defaultNodeId: function () {
       this.updateSelectedNodeId();
     },
-
+    url(newUrl) {
+      if (newUrl.startsWith('http://')) {
+        this.skipCertVerify = false;
+    }
+  },
     isShown: function () {
       if (this.isShown) {
         this.clearErrors();
@@ -217,6 +239,7 @@ export default {
           this.strip_prefix = this.route.strip_prefix;
           this.lets_encrypt = this.route.lets_encrypt;
           this.http2https = this.route.http2https;
+          this.skipCertVerify = this.route.skipCertVerify;
         }
       } else {
         // closing modal
@@ -384,6 +407,7 @@ export default {
         lets_encrypt: this.lets_encrypt,
         http2https: this.http2https,
         user_created: true,
+        skipCertVerify: this.skipCertVerify,
       };
 
       if (this.host) {
@@ -470,6 +494,7 @@ export default {
       this.lets_encrypt = false;
       this.http2https = false;
       this.strip_prefix = false;
+      this.skipCertVerify = false;
     },
   },
 };

--- a/core/ui/src/components/settings/HttpRouteDetailModal.vue
+++ b/core/ui/src/components/settings/HttpRouteDetailModal.vue
@@ -18,14 +18,14 @@
       </div>
       <div class="key-value-setting">
         <span class="label">{{
-          $t("settings_http_routes.skipCertVerify")
+          $t("settings_http_routes.skip_cert_verify")
         }}</span>
         <span class="value">
           <cv-tag
-            :kind="route.skipCertVerify ? 'green' : 'high-contrast'"
+            :kind="route.skip_cert_verify ? 'green' : 'high-contrast'"
             size="sm"
             :label="
-              route.skipCertVerify ? $t('common.enabled') : $t('common.disabled')
+              route.skip_cert_verify ? $t('common.enabled') : $t('common.disabled')
             "
             class="no-margin"
           ></cv-tag>

--- a/core/ui/src/components/settings/HttpRouteDetailModal.vue
+++ b/core/ui/src/components/settings/HttpRouteDetailModal.vue
@@ -16,6 +16,21 @@
         <span class="label">{{ $t("settings_http_routes.url") }}</span>
         <span class="value">{{ route.url }}</span>
       </div>
+      <div class="key-value-setting">
+        <span class="label">{{
+          $t("settings_http_routes.skipCertVerify")
+        }}</span>
+        <span class="value">
+          <cv-tag
+            :kind="route.skipCertVerify ? 'green' : 'high-contrast'"
+            size="sm"
+            :label="
+              route.skipCertVerify ? $t('common.enabled') : $t('common.disabled')
+            "
+            class="no-margin"
+          ></cv-tag>
+        </span>
+      </div>
       <div v-if="route.host" class="key-value-setting">
         <span class="label">{{ $t("settings_http_routes.host") }}</span>
         <span class="value">{{ route.host }}</span>


### PR DESCRIPTION
This pull request adds a new option to the route creation process that allows skipping certificate validation for the backend target URL. This can be useful in cases where the target URL is using a self-signed or invalid certificate.

![image](https://github.com/NethServer/ns8-core/assets/3164851/93977f21-3573-4892-90c8-ab535cd2f22c)
![image](https://github.com/NethServer/ns8-core/assets/3164851/cb4c0658-6d6a-416a-aeb7-fddfcd306c83)
![image](https://github.com/NethServer/ns8-core/assets/3164851/be5e2919-194e-4e8e-86af-5f71625ac585)
![image](https://github.com/NethServer/ns8-core/assets/3164851/6ecf5e02-b7a5-420a-aa73-cbd99bd0e5e2)
![image](https://github.com/NethServer/ns8-core/assets/3164851/eab7c12a-2589-4ca4-9aa1-4d45d2c30d4f)
![image](https://github.com/NethServer/ns8-core/assets/3164851/9a9c305f-0c56-40cc-a095-2f30f0520d38)

https://github.com/NethServer/dev/issues/6822

