### PR TITLE
Check the user has root privs before install

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -34,6 +34,11 @@ gpgkey=http://mirrorlist.nethserver.org/rpm-gpg-key-ns8
 EOF
 }
 
+if [[ $EUID != 0 ]]; then
+    echo "This script must be executed with root privileges."
+    exit 1
+fi
+
 echo "Checking port 80 and 443 are not already in use"
 for port in 80 443
 do


### PR DESCRIPTION
The installation script must run with root privileges: let's print a clear message.