### PR TITLE
Update instance name in RestoreMultipleInstancesSelector.vue

### DIFF
--- a/core/ui/src/components/backup/RestoreMultipleInstancesSelector.vue
+++ b/core/ui/src/components/backup/RestoreMultipleInstancesSelector.vue
@@ -70,7 +70,7 @@
             :id="instance.path"
           />
           <div>
-            <div>{{ instance.instance }}</div>
+            <div>{{ instance.installed_instance }}</div>
             <div class="instance-description">
               {{ instance.repository_name }}
               <cv-interactive-tooltip


### PR DESCRIPTION
This pull request updates the instance name in the RestoreMultipleInstancesSelector.vue file. The previous instance name was "instance" and it has been changed to "installed_instance". This changefix the empty value