### PR TITLE
Copy update-core semantics to update-module

### DIFF
--- a/core/imageroot/usr/local/agent/actions/update-module/50run_scriptdir
+++ b/core/imageroot/usr/local/agent/actions/update-module/50run_scriptdir
@@ -33,15 +33,22 @@ if [[ ! -d "${AGENT_INSTALL_DIR}"/update-module.d/ ]]; then
     exit 0
 fi
 
+# systemd-journal log severity codes:
+SD_DEBUG='<7>'
+SD_WARNING='<4>'
+
+shopt -s nullglob
 for script in "${AGENT_INSTALL_DIR}"/update-module.d/* ; do
 
     if [[ ! -x "${script}" ]]; then
-        echo "Skipping non-executable file ${script}..."
+        echo "${SD_DEBUG}Skipping non-executable file ${script}..."
         continue
     fi
 
     echo "Running ${script}..."
 
-    command ${script}
+    if ! command ${script} ; then
+        echo "${SD_WARNING}${script} has exit code $?"
+    fi
 
 done


### PR DESCRIPTION
If an update script fails, do not stop the whole module update procedure. Instead continue with the next module update script.

https://github.com/NethServer/ns8-core/blob/43e04becfb40bc973fbc0c873ca0942aeb8c5feb/core/imageroot/var/lib/nethserver/node/actions/update-core/60run_scriptdir#L29

This commit implements for update-module the same semantics of update-core. What do you think?

---
Edit:
Before going in production I want to have the same behavior for both update procedures. As we come from e-smith, I feel more confident with the non-fatal approach.