### PR TITLE
Update instance display in RestoreMultipleInstancesSelector.vue

### DIFF
--- a/core/ui/src/components/backup/RestoreMultipleInstancesSelector.vue
+++ b/core/ui/src/components/backup/RestoreMultipleInstancesSelector.vue
@@ -70,7 +70,7 @@
             :id="instance.path"
           />
           <div>
-            <div>{{ instance.instance }}</div>
+            <div>{{ instance.path }}</div>
             <div class="instance-description">
               {{ instance.repository_name }}
               <cv-interactive-tooltip


### PR DESCRIPTION
This pull request updates the instance display in the RestoreMultipleInstancesSelector.vue file. It changes the display from `instance.instance` to `instance.path`. This change improves the accuracy of the displayed information.

![image](https://github.com/NethServer/ns8-core/assets/3164851/6034705b-e8c7-49c8-98fa-972998e64f07)

https://github.com/NethServer/dev/issues/6827