### PR TITLE
Fix failed requests in Software Center

### DIFF
--- a/core/ui/src/App.vue
+++ b/core/ui/src/App.vue
@@ -410,13 +410,13 @@ export default {
         this.createNotification(notification);
       }
 
-      // retry web socket connection if still logged-in
+      // Retry web socket connection if still logged-in. Don't retry before 10 seconds: in some cases (e.g. while updating core) the API server may not be ready to accept requests immediately after websocket reconnection
       setTimeout(() => {
         if (this.loggedUser) {
           console.warn("Retrying websocket connection...");
           this.initWebSocket();
         }
-      }, 5000);
+      }, 10000);
     },
     createErrorNotification(err, message) {
       const notification = {

--- a/core/ui/src/views/SoftwareCenter.vue
+++ b/core/ui/src/views/SoftwareCenter.vue
@@ -57,7 +57,7 @@
           />
         </cv-column>
       </cv-row>
-      <cv-row v-if="error.listModules">
+      <cv-row v-if="error.listCoreModules">
         <cv-column>
           <NsInlineNotification
             kind="error"
@@ -483,6 +483,7 @@ export default {
       if (err) {
         console.error(`error creating task ${taskAction}`, err);
         this.error.listModules = this.getErrorMessage(err);
+        this.loading.listModules = false;
         return;
       }
     },

--- a/core/ui/src/views/SoftwareCenter.vue
+++ b/core/ui/src/views/SoftwareCenter.vue
@@ -837,8 +837,11 @@ export default {
       this.setUpdateInProgressInStore(false);
     },
     updateCoreCompleted() {
-      this.setUpdateInProgressInStore(false);
-      this.listModules();
+      // add a brief delay: API server may not be ready to accept requests immediately
+      setTimeout(() => {
+        this.setUpdateInProgressInStore(false);
+        this.listModules();
+      }, 5000);
     },
   },
 };


### PR DESCRIPTION
After updating core some errors may appear on the UI.
The cause is that API server is not be ready to receive request right after websocket reconnection and `update-core` completion.

- Retry websocket reconnection after 10 seconds instead of 5
- After `update-core` completion, wait 5 seconds before reloading data on the UI

Refs https://github.com/NethServer/dev/issues/6813