### PR TITLE
Update translation for "domains" to "external_domains"

### DIFF
--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -215,7 +215,7 @@
         "backup_date": "Backup date",
         "cluster_label": "Cluster label",
         "vpn_endpoint": "VPN endpoint",
-        "external_domains": "External domains",
+        "external_domains": "External user domains",
         "backup_repositories": "Backup repositories",
         "restoring_cluster": "Restoring cluster",
         "restore_apps": "Restore apps",

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -215,7 +215,7 @@
         "backup_date": "Backup date",
         "cluster_label": "Cluster label",
         "vpn_endpoint": "VPN endpoint",
-        "domains": "Domains",
+        "external_domains": "External domains",
         "backup_repositories": "Backup repositories",
         "restoring_cluster": "Restoring cluster",
         "restore_apps": "Restore apps",

--- a/core/ui/src/views/InitializeCluster.vue
+++ b/core/ui/src/views/InitializeCluster.vue
@@ -674,7 +674,7 @@
                       <span class="value">{{ restore.summary.vpn }}</span>
                     </div>
                     <div class="key-value-setting">
-                      <span class="label">{{ $t("init.domains") }}</span>
+                      <span class="label">{{ $t("init.external_domains") }}</span>
                       <span class="value">{{ restore.summary.domains }}</span>
                     </div>
                     <div class="key-value-setting">


### PR DESCRIPTION
This pull request updates the translation for the "domains" label to "external_domains" in the InitializeCluster.vue file. This change ensures consistency and clarity in the user interface.

The translation doesn't reflect the right name of `Domains` string, the [code ](https://github.com/NethServer/ns8-core/blob/main/core/imageroot/var/lib/nethserver/cluster/bin/cluster-backup#L68) is done to make a counter of external ldap user domain IIUC, this is explained in the [documentation](https://github.com/NethServer/ns8-core/blob/main/docs/core/database.md?plain=1#L251)

the documentation states 

`|cluster/user_domain/ldap/{domain}/conf                 |HASH   |An external LDAP domain|`

https://github.com/NethServer/dev/issues/6834