### PR TITLE
Restore cluster: fix upload of backup file on Windows

### DIFF
--- a/core/ui/src/views/InitializeCluster.vue
+++ b/core/ui/src/views/InitializeCluster.vue
@@ -1588,9 +1588,7 @@ export default {
         console.log("error converting file to base64:", result.message);
         return;
       } else {
-        this.restore.base64FileUploaded = result.split(
-          "data:application/pgp-encrypted;base64,"
-        )[1];
+        this.restore.base64FileUploaded = result.split(";base64,")[1];
       }
     },
     validateRetrieveClusterBackupFromFile() {


### PR DESCRIPTION
Upload of backup file during cluster restore was broken on Windows clients: the detected MIME type is different from the one detected on Linux clients.

The retrieval of the base64 representation of the uploaded file now ignores its MIME type and works as expected.

Refs:
- https://github.com/NethServer/dev/issues/6832