### PR TITLE
Fix the restore summary page

### DIFF
--- a/core/ui/public/i18n/de/translation.json
+++ b/core/ui/public/i18n/de/translation.json
@@ -49,7 +49,6 @@
         "welcome": "Willkommen bei [product}",
         "restore_from_remote_url": "Wiederherstellung von ferner URL",
         "create_cluster_instead": "Stattdessen ein neues Cluster erstellen",
-        "backup_date": "Sicherungsdatum",
         "create_cluster_description": "Ein neues Clusters erstellen und diesen Knoten zum Hauptknoten heraufstufen",
         "vpn_endpoint_address_tooltip": "Arbeitsknoten nutzen diese Adresse um eine Verbindung zum Hauptknoten herzustellen. Korrekte Auflösung und Erreichbarkeit ausgehend von den Arbeitsknoten sicherstellen.",
         "skip_apps_restore_2": "Sie können Anwendungen später über die Seite <strong>Sicherungen</strong> wiederherstellen",

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -213,7 +213,6 @@
         "not_valid_gpg_file": "Invalid GPG file",
         "url_format": "Invalid URL",
         "restore_summary": "Summary",
-        "backup_date": "Backup date",
         "cluster_label": "Cluster label",
         "vpn_endpoint": "VPN endpoint",
         "external_domains": "External user domains",

--- a/core/ui/public/i18n/es/translation.json
+++ b/core/ui/public/i18n/es/translation.json
@@ -775,7 +775,6 @@
         "current_password": "Contraseña de administrador actual",
         "restore_from_remote_url": "Restaurar desde URL remota",
         "create_cluster_instead": "En su lugar, crea un nuevo clúster",
-        "backup_date": "Fecha de copia de seguridad",
         "create_cluster_description": "Crear un nuevo clúster y promover este nodo como líder",
         "join_cluster_instead": "Unirse a un clúster existente en su lugar",
         "skip_apps_restore_1": "¿Quieres omitir la restauración de aplicaciones?",

--- a/core/ui/public/i18n/eu/translation.json
+++ b/core/ui/public/i18n/eu/translation.json
@@ -763,7 +763,6 @@
     },
     "init": {
         "join_cluster_description": "Lehendik dagoen kluster batera nodo hau gehitu",
-        "backup_date": "Babeskopia data",
         "change_password": "Pasahitza aldatu",
         "restoring_cluster": "Restoring cluster",
         "custom_certificates": "Uploaded certificates",

--- a/core/ui/public/i18n/it/translation.json
+++ b/core/ui/public/i18n/it/translation.json
@@ -890,7 +890,6 @@
     "init": {
         "backup_password": "Password del backup",
         "backup_repositories": "Repository del backup",
-        "backup_date": "Data del backup",
         "join_code_helper_text": "Puoi ottenere il codice di join accedendo",
         "join_cluster": "Join a cluster",
         "create_cluster": "Crea cluster",

--- a/core/ui/public/i18n/pt/translation.json
+++ b/core/ui/public/i18n/pt/translation.json
@@ -746,7 +746,6 @@
         "welcome": "Welcome to {product}",
         "restore_from_remote_url": "Restore from remote URL",
         "create_cluster_instead": "Create a new cluster instead",
-        "backup_date": "Backup date",
         "create_cluster_description": "Create a new cluster and promote this node as leader",
         "vpn_endpoint_address_tooltip": "Worker nodes use this address to connect to the leader. Ensure it is correctly resolved and reachable by worker nodes",
         "skip_apps_restore_2": "You can restore apps later in <strong>Backup</strong> page",

--- a/core/ui/public/i18n/pt_BR/translation.json
+++ b/core/ui/public/i18n/pt_BR/translation.json
@@ -276,7 +276,6 @@
         "welcome": "Welcome to {product}",
         "restore_from_remote_url": "Restore from remote URL",
         "create_cluster_instead": "Create a new cluster instead",
-        "backup_date": "Backup date",
         "create_cluster_description": "Create a new cluster and promote this node as leader",
         "vpn_endpoint_address_tooltip": "Worker nodes use this address to connect to the leader. Ensure it is correctly resolved and reachable by worker nodes",
         "skip_apps_restore_2": "You can restore apps later in <strong>Backup</strong> page",

--- a/core/ui/src/views/InitializeCluster.vue
+++ b/core/ui/src/views/InitializeCluster.vue
@@ -655,13 +655,6 @@
                     {{ $t("init.restore_summary") }}
                   </h5>
                   <cv-form @submit.prevent="restoreCluster">
-                    <div class="key-value-setting">
-                      <span class="label">{{ $t("init.backup_date") }}</span>
-                      <span class="value">{{
-                        (restore.summary.timestamp * 1000)
-                          | date("yyyy-MM-dd HH:mm:ss")
-                      }}</span>
-                    </div>
                     <div
                       v-if="restore.summary.cluster"
                       class="key-value-setting"


### PR DESCRIPTION
The "Backup date" field is no more available in the cluster backup. It was removed to make the backup archive binary-reproducible.

![image](https://github.com/NethServer/ns8-core/assets/2920838/0fd20023-f3ec-4972-bda3-9006e10cf819)


Refs b30633b071a1c2aeb9a6976511a243d3e46ce764