### PR TITLE
Add minLength and checkComplexity password policy functionality

### DIFF
--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -16,7 +16,7 @@
     "@carbon/icons-vue": "^10.37.0",
     "@carbon/themes": "^10.34.0",
     "@carbon/vue": "^2.40.0",
-    "@nethserver/ns8-ui-lib": "^0.1.31",
+    "@nethserver/ns8-ui-lib": "^0.1.32",
     "await-to-js": "^3.0.0",
     "axios": "^0.21.2",
     "carbon-components": "^10.41.0",

--- a/core/ui/src/components/domains/ChangeUserPasswordModal.vue
+++ b/core/ui/src/components/domains/ChangeUserPasswordModal.vue
@@ -34,7 +34,7 @@
           :focus="focusPasswordField"
           :clearConfirmPasswordCommand="clearConfirmPasswordCommand"
           :minLength="policy.strength.enforced ? policy.strength.password_min_length : 0"
-          :checkStrength="policy.strength.enforced ? policy.strength.complexity_check : false"
+          :checkComplexity="policy.strength.enforced ? policy.strength.complexity_check : false"
         />
         <div v-if="error.alterUser">
           <NsInlineNotification

--- a/core/ui/src/components/domains/ChangeUserPasswordModal.vue
+++ b/core/ui/src/components/domains/ChangeUserPasswordModal.vue
@@ -43,6 +43,13 @@
             :showCloseButton="false"
           />
         </div>
+        <NsInlineNotification
+          v-if="error.ListPasswordPolicy"
+          kind="error"
+          :title="$t('action.get-password-policy')"
+          :description="error.ListPasswordPolicy"
+          :showCloseButton="false"
+        />
       </cv-form>
     </template>
     <template slot="secondary-button">{{ $t("common.cancel") }}</template>
@@ -84,6 +91,7 @@ export default {
         alterUser: "",
         newPassword: "",
         confirmPassword: "",
+        ListPasswordPolicy: "",
       },
     };
   },

--- a/core/ui/src/components/domains/ChangeUserPasswordModal.vue
+++ b/core/ui/src/components/domains/ChangeUserPasswordModal.vue
@@ -33,8 +33,12 @@
           :equalLabel="$t('password.equal')"
           :focus="focusPasswordField"
           :clearConfirmPasswordCommand="clearConfirmPasswordCommand"
-          :minLength="policy.strength.enforced ? policy.strength.password_min_length : 0"
-          :checkComplexity="policy.strength.enforced ? policy.strength.complexity_check : false"
+          :minLength="
+            policy.strength.enforced ? policy.strength.password_min_length : 0
+          "
+          :checkComplexity="
+            policy.strength.enforced ? policy.strength.complexity_check : false
+          "
         />
         <div v-if="error.alterUser">
           <NsInlineNotification
@@ -115,7 +119,7 @@ export default {
     },
   },
   methods: {
-      async listPasswordPolicy() {
+    async listPasswordPolicy() {
       this.loading.ListPasswordPolicy = true;
       this.error.ListPasswordPolicy = "";
       const taskAction = "get-password-policy";

--- a/core/ui/src/components/domains/ChangeUserPasswordModal.vue
+++ b/core/ui/src/components/domains/ChangeUserPasswordModal.vue
@@ -33,7 +33,8 @@
           :equalLabel="$t('password.equal')"
           :focus="focusPasswordField"
           :clearConfirmPasswordCommand="clearConfirmPasswordCommand"
-          :minLength="policy.strength.password_min_length"
+          :minLength="policy.strength.enforced ? policy.strength.password_min_length : 0"
+          :checkStrength="policy.strength.enforced ? policy.strength.complexity_check : false"
         />
         <div v-if="error.alterUser">
           <NsInlineNotification

--- a/core/ui/src/components/domains/ChangeUserPasswordModal.vue
+++ b/core/ui/src/components/domains/ChangeUserPasswordModal.vue
@@ -8,7 +8,7 @@
     :visible="isShown"
     @modal-hidden="onModalHidden"
     @primary-click="changeUserPassword"
-    :primary-button-disabled="loading.alterUser || loading.ListPasswordPolicy"
+    :primary-button-disabled="loading.alterUser || loading.listPasswordPolicy"
     class="no-pad-modal"
   >
     <template v-if="user" slot="title">{{
@@ -49,10 +49,10 @@
           />
         </div>
         <NsInlineNotification
-          v-if="error.ListPasswordPolicy"
+          v-if="error.listPasswordPolicy"
           kind="error"
           :title="$t('action.get-password-policy')"
-          :description="error.ListPasswordPolicy"
+          :description="error.listPasswordPolicy"
           :showCloseButton="false"
         />
       </cv-form>
@@ -91,12 +91,13 @@ export default {
       },
       loading: {
         alterUser: false,
+        listPasswordPolicy: false,
       },
       error: {
         alterUser: "",
         newPassword: "",
         confirmPassword: "",
-        ListPasswordPolicy: "",
+        listPasswordPolicy: "",
       },
     };
   },
@@ -120,14 +121,14 @@ export default {
   },
   methods: {
     async listPasswordPolicy() {
-      this.loading.ListPasswordPolicy = true;
-      this.error.ListPasswordPolicy = "";
+      this.loading.listPasswordPolicy = true;
+      this.error.listPasswordPolicy = "";
       const taskAction = "get-password-policy";
       const eventId = this.getUuid();
       // register to task completion
       this.$root.$once(
         `${taskAction}-completed-${eventId}`,
-        this.ListPasswordPolicyCompleted
+        this.listPasswordPolicyCompleted
       );
       const res = await to(
         this.createModuleTaskForApp(this.mainProvider, {
@@ -143,18 +144,18 @@ export default {
 
       if (err) {
         console.error(`error creating task ${taskAction}`, err);
-        this.error.ListPasswordPolicy = this.getErrorMessage(err);
+        this.error.listPasswordPolicy = this.getErrorMessage(err);
         return;
       }
     },
-    ListPasswordPolicyCompleted(taskContext, taskResult) {
-      const Config = taskResult.output;
-      this.policy.strength.enforced = Config.strength.enforced;
-      this.policy.strength.complexity_check = Config.strength.complexity_check;
+    listPasswordPolicyCompleted(taskContext, taskResult) {
+      const config = taskResult.output;
+      this.policy.strength.enforced = config.strength.enforced;
+      this.policy.strength.complexity_check = config.strength.complexity_check;
       this.policy.strength.password_min_length =
-        Config.strength.password_min_length.toString();
+        config.strength.password_min_length.toString();
 
-      this.loading.ListPasswordPolicy = false;
+      this.loading.listPasswordPolicy = false;
     },
     validateChangeUserPassword() {
       this.clearErrors();

--- a/core/ui/src/components/domains/CreateOrEditUserModal.vue
+++ b/core/ui/src/components/domains/CreateOrEditUserModal.vue
@@ -84,7 +84,7 @@
           :focus="focusPasswordField"
           :clearConfirmPasswordCommand="clearConfirmPasswordCommand"
           :minLength="policy.strength.enforced ? policy.strength.password_min_length : 0"
-          :checkStrength="policy.strength.enforced ? policy.strength.complexity_check : false"
+          :checkComplexity="policy.strength.enforced ? policy.strength.complexity_check : false"
         />
         <NsInlineNotification
           v-if="error.addUser"

--- a/core/ui/src/components/domains/CreateOrEditUserModal.vue
+++ b/core/ui/src/components/domains/CreateOrEditUserModal.vue
@@ -99,6 +99,13 @@
           :description="error.alterUser"
           :showCloseButton="false"
         />
+        <NsInlineNotification
+          v-if="error.ListPasswordPolicy"
+          kind="error"
+          :title="$t('action.get-password-policy')"
+          :description="error.ListPasswordPolicy"
+          :showCloseButton="false"
+        />
       </cv-form>
     </template>
     <template slot="secondary-button">{{ $t("common.cancel") }}</template>
@@ -156,6 +163,7 @@ export default {
         newPassword: "",
         confirmPassword: "",
         groups: "",
+        ListPasswordPolicy:""
       },
     };
   },

--- a/core/ui/src/components/domains/CreateOrEditUserModal.vue
+++ b/core/ui/src/components/domains/CreateOrEditUserModal.vue
@@ -83,7 +83,8 @@
           :equalLabel="$t('password.equal')"
           :focus="focusPasswordField"
           :clearConfirmPasswordCommand="clearConfirmPasswordCommand"
-          :minLength="policy.strength.password_min_length"
+          :minLength="policy.strength.enforced ? policy.strength.password_min_length : 0"
+          :checkStrength="policy.strength.enforced ? policy.strength.complexity_check : false"
         />
         <NsInlineNotification
           v-if="error.addUser"

--- a/core/ui/src/components/domains/CreateOrEditUserModal.vue
+++ b/core/ui/src/components/domains/CreateOrEditUserModal.vue
@@ -83,6 +83,7 @@
           :equalLabel="$t('password.equal')"
           :focus="focusPasswordField"
           :clearConfirmPasswordCommand="clearConfirmPasswordCommand"
+          :minLength="policy.strength.password_min_length"
         />
         <NsInlineNotification
           v-if="error.addUser"
@@ -133,10 +134,18 @@ export default {
       passwordValidation: null,
       focusPasswordField: { element: "" },
       clearConfirmPasswordCommand: 0,
+      policy: {
+        strength: {
+          complexity_check: false,
+          enforced: false,
+          password_min_length: 8,
+        },
+      },
       loading: {
         addUser: false,
         alterUser: false,
         getDomainUser: false,
+        ListPasswordPolicy: false,
       },
       error: {
         addUser: "",
@@ -165,6 +174,7 @@ export default {
         this.loading.addUser ||
         this.loading.alterUser ||
         this.loading.getDomainUser ||
+        this.loading.ListPasswordPolicy ||
         !!this.error.getDomainUser
       );
     },
@@ -185,7 +195,7 @@ export default {
     isShown: function () {
       if (this.isShown) {
         this.clearErrors();
-
+        this.listPasswordPolicy();
         if (!this.isEditing) {
           // create user
 
@@ -209,6 +219,43 @@ export default {
     },
   },
   methods: {
+      async listPasswordPolicy() {
+      this.loading.ListPasswordPolicy = true;
+      this.error.ListPasswordPolicy = "";
+      const taskAction = "get-password-policy";
+      const eventId = this.getUuid();
+      // register to task completion
+      this.$root.$once(
+        `${taskAction}-completed-${eventId}`,
+        this.ListPasswordPolicyCompleted
+      );
+      const res = await to(
+        this.createModuleTaskForApp(this.mainProvider, {
+          action: taskAction,
+          extra: {
+            title: this.$t("action." + taskAction),
+            isNotificationHidden: true,
+            eventId,
+          },
+        })
+      );
+      const err = res[0];
+
+      if (err) {
+        console.error(`error creating task ${taskAction}`, err);
+        this.error.ListPasswordPolicy = this.getErrorMessage(err);
+        return;
+      }
+    },
+    ListPasswordPolicyCompleted(taskContext, taskResult) {
+      const Config = taskResult.output;
+      this.policy.strength.enforced = Config.strength.enforced;
+      this.policy.strength.complexity_check = Config.strength.complexity_check;
+      this.policy.strength.password_min_length =
+        Config.strength.password_min_length.toString();
+
+      this.loading.ListPasswordPolicy = false;
+    },
     createOrEditUser() {
       if (this.isEditing) {
         this.alterUser();

--- a/core/ui/src/components/domains/CreateOrEditUserModal.vue
+++ b/core/ui/src/components/domains/CreateOrEditUserModal.vue
@@ -105,10 +105,10 @@
           :showCloseButton="false"
         />
         <NsInlineNotification
-          v-if="error.ListPasswordPolicy"
+          v-if="error.listPasswordPolicy"
           kind="error"
           :title="$t('action.get-password-policy')"
-          :description="error.ListPasswordPolicy"
+          :description="error.listPasswordPolicy"
           :showCloseButton="false"
         />
       </cv-form>
@@ -157,7 +157,7 @@ export default {
         addUser: false,
         alterUser: false,
         getDomainUser: false,
-        ListPasswordPolicy: false,
+        listPasswordPolicy: false,
       },
       error: {
         addUser: "",
@@ -168,7 +168,7 @@ export default {
         newPassword: "",
         confirmPassword: "",
         groups: "",
-        ListPasswordPolicy: "",
+        listPasswordPolicy: "",
       },
     };
   },
@@ -187,7 +187,7 @@ export default {
         this.loading.addUser ||
         this.loading.alterUser ||
         this.loading.getDomainUser ||
-        this.loading.ListPasswordPolicy ||
+        this.loading.listPasswordPolicy ||
         !!this.error.getDomainUser
       );
     },
@@ -233,14 +233,14 @@ export default {
   },
   methods: {
     async listPasswordPolicy() {
-      this.loading.ListPasswordPolicy = true;
-      this.error.ListPasswordPolicy = "";
+      this.loading.listPasswordPolicy = true;
+      this.error.listPasswordPolicy = "";
       const taskAction = "get-password-policy";
       const eventId = this.getUuid();
       // register to task completion
       this.$root.$once(
         `${taskAction}-completed-${eventId}`,
-        this.ListPasswordPolicyCompleted
+        this.listPasswordPolicyCompleted
       );
       const res = await to(
         this.createModuleTaskForApp(this.mainProvider, {
@@ -256,18 +256,18 @@ export default {
 
       if (err) {
         console.error(`error creating task ${taskAction}`, err);
-        this.error.ListPasswordPolicy = this.getErrorMessage(err);
+        this.error.listPasswordPolicy = this.getErrorMessage(err);
         return;
       }
     },
-    ListPasswordPolicyCompleted(taskContext, taskResult) {
-      const Config = taskResult.output;
-      this.policy.strength.enforced = Config.strength.enforced;
-      this.policy.strength.complexity_check = Config.strength.complexity_check;
+    listPasswordPolicyCompleted(taskContext, taskResult) {
+      const config = taskResult.output;
+      this.policy.strength.enforced = config.strength.enforced;
+      this.policy.strength.complexity_check = config.strength.complexity_check;
       this.policy.strength.password_min_length =
-        Config.strength.password_min_length.toString();
+        config.strength.password_min_length.toString();
 
-      this.loading.ListPasswordPolicy = false;
+      this.loading.listPasswordPolicy = false;
     },
     createOrEditUser() {
       if (this.isEditing) {

--- a/core/ui/src/components/domains/CreateOrEditUserModal.vue
+++ b/core/ui/src/components/domains/CreateOrEditUserModal.vue
@@ -83,8 +83,12 @@
           :equalLabel="$t('password.equal')"
           :focus="focusPasswordField"
           :clearConfirmPasswordCommand="clearConfirmPasswordCommand"
-          :minLength="policy.strength.enforced ? policy.strength.password_min_length : 0"
-          :checkComplexity="policy.strength.enforced ? policy.strength.complexity_check : false"
+          :minLength="
+            policy.strength.enforced ? policy.strength.password_min_length : 0
+          "
+          :checkComplexity="
+            policy.strength.enforced ? policy.strength.complexity_check : false
+          "
         />
         <NsInlineNotification
           v-if="error.addUser"
@@ -164,7 +168,7 @@ export default {
         newPassword: "",
         confirmPassword: "",
         groups: "",
-        ListPasswordPolicy:""
+        ListPasswordPolicy: "",
       },
     };
   },
@@ -228,7 +232,7 @@ export default {
     },
   },
   methods: {
-      async listPasswordPolicy() {
+    async listPasswordPolicy() {
       this.loading.ListPasswordPolicy = true;
       this.error.ListPasswordPolicy = "";
       const taskAction = "get-password-policy";

--- a/core/ui/src/stories/NsPasswordInput.stories.js
+++ b/core/ui/src/stories/NsPasswordInput.stories.js
@@ -27,6 +27,7 @@ Default.args = {
   focus: {},
   light: true,
   minLength: 8,
+  checkComplexity: true,
   clearConfirmPasswordCommand: 0,
   lengthLabel: "Long enough",
   lowercaseLabel: "Lowercase letter",

--- a/core/ui/yarn.lock
+++ b/core/ui/yarn.lock
@@ -2002,9 +2002,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nethserver/ns8-ui-lib@npm:^0.1.31":
-  version: 0.1.31
-  resolution: "@nethserver/ns8-ui-lib@npm:0.1.31"
+"@nethserver/ns8-ui-lib@npm:^0.1.32":
+  version: 0.1.32
+  resolution: "@nethserver/ns8-ui-lib@npm:0.1.32"
   dependencies:
     "@rollup/plugin-json": ^4.1.0
     core-js: ^3.15.2
@@ -2013,7 +2013,7 @@ __metadata:
     vue-date-fns: ^2.0.1
   peerDependencies:
     vue: ^2.6.12
-  checksum: 01e384dfc49bd48cd52721dc3d8c674cafd40b5f879e33028060246c7f1038780a0a9ba1f1eed2bee3ca1f793229ae8ad1c05616af9eca66a6a636f936e5cabf
+  checksum: beb45f68c6d6a8e92c6e237fa3fc7e4d7af18c2aced9488a90519a1487272cc950250b73df61e59a134445a13d3baeb4584f27fc75bd9002b8cf3826a249eda2
   languageName: node
   linkType: hard
 
@@ -13076,7 +13076,7 @@ __metadata:
     "@carbon/icons-vue": ^10.37.0
     "@carbon/themes": ^10.34.0
     "@carbon/vue": ^2.40.0
-    "@nethserver/ns8-ui-lib": ^0.1.31
+    "@nethserver/ns8-ui-lib": ^0.1.32
     "@storybook/addon-actions": ^6.2.9
     "@storybook/addon-essentials": ^6.2.9
     "@storybook/addon-links": ^6.2.9


### PR DESCRIPTION
This pull request adds the functionality 

to enforce a minimum length for passwords in the ChangeUserPasswordModal and CreateOrEditUserModal components. The minimum length is set to 8 characters.

to check the complexity of the password (upper, lower, digit and symbol)
  
- strength disabled
![image](https://github.com/NethServer/ns8-ui-lib/assets/3164851/296b7991-d670-4705-8206-eca12ffecfc0)
- strength enabled but complexity disabled
![image](https://github.com/NethServer/ns8-ui-lib/assets/3164851/cd16adaf-37e7-453b-97af-312ca9569540)
- strength enabled and complexity enabled
![image](https://github.com/NethServer/ns8-ui-lib/assets/3164851/589d3eee-a6a1-47a2-a815-69c86ca926e2)

- validation 
![Capture d’écran du 2024-02-20 14-50-55](https://github.com/NethServer/ns8-ui-lib/assets/3164851/60a72e5d-41a0-4053-be62-737b974c79ec)
![Capture d’écran du 2024-02-20 14-50-14](https://github.com/NethServer/ns8-ui-lib/assets/3164851/955cd19d-70db-4e90-a3d4-2dc3dfc1f9bf)
![Capture d’écran du 2024-02-20 14-49-15](https://github.com/NethServer/ns8-ui-lib/assets/3164851/32a62beb-ae5c-4f5a-a96e-6c00b16a50b5)

https://github.com/NethServer/dev/issues/6845