### PR TITLE
Configure the agent retry backoff 

### DIFF
--- a/core/agent/hevent.go
+++ b/core/agent/hevent.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/NethServer/ns8-core/core/agent/models"
 	"github.com/go-redis/redis/v8"
@@ -50,6 +51,9 @@ func listenEventsAsync(ctx context.Context, complete chan int) {
 		Password:  agentPrefix,
 		DB:        0,
 		OnConnect: setClientNameCallback,
+		MaxRetries:       10,
+		MinRetryBackoff:   100 * time.Millisecond,
+		MaxRetryBackoff:   5000 * time.Millisecond,
 	})
 
 	pubsub := rdb.PSubscribe(ctx, "*/event/*")

--- a/core/agent/htask.go
+++ b/core/agent/htask.go
@@ -309,6 +309,9 @@ func listenActionsAsync(brpopCtx context.Context, complete chan int) {
 		Password:  redisPassword,
 		DB:        0,
 		OnConnect: setClientNameCallback,
+		MaxRetries:       10,
+		MinRetryBackoff:   100 * time.Millisecond,
+		MaxRetryBackoff:   5000 * time.Millisecond,
 	})
 
 	// Ignore the credential error on agent startup


### PR DESCRIPTION
Increase the retry period, to ensure the task outcome is written even if the Redis master is unreachable for a while.

The go-redis library should retry 10 times for a random period of time between 1 and 100 seconds with exponential backoff.

I calculated this range by looking at this code https://github.com/redis/go-redis/blob/cae67723092cac2cb441bc87044ab9edacb2484d/internal/internal.go#L9 and with http://exponentialbackoffcalculator.com/

For a test run: https://go.dev/play/p/xsjwJOZYpk3

Refs NethServer/dev#6854