### PR TITLE
Fix issue with missing 'ui_names' in cluster restore

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/restore-cluster/30load
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/restore-cluster/30load
@@ -50,7 +50,8 @@ del(dump['cluster']['favorites'])
 for d in dump['cluster']['user_domain']['ldap'].keys():
     domain = dump['cluster']['user_domain']['ldap'][d]
     rdb.hset(f'cluster/user_domain/ldap/{d}/conf', mapping=domain['conf'])
-    rdb.hset(f'cluster/user_domain/ldap/{d}/ui_names', mapping=domain['ui_names'])
+    if 'ui_names' in domain:
+        rdb.hset(f'cluster/user_domain/ldap/{d}/ui_names', mapping=domain['ui_names'])
     for p in domain['providers']:
         r = rdb.lpush(f'cluster/user_domain/ldap/{d}/providers', p)
 


### PR DESCRIPTION
This pull request fixes an issue where the 'ui_names' were missing in the cluster restore process. The code now checks if 'ui_names' is present in the domain before setting it in the Redis database. This ensures that the 'ui_names' are properly restored during the cluster restore process.

https://github.com/NethServer/dev/issues/6855