### PR TITLE
Add hostname, IPv4, and IPv6 format validation for TCP backend endpoint configuration

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-external-domain/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-external-domain/validate-input.json
@@ -70,7 +70,16 @@
             "description": "Initial TCP backend endpoint configuration",
             "properties": {
                 "host": {
-                    "type": "string"
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "format": "hostname",
+                            "pattern": "\\."
+                        },
+                        {
+                            "format": "ipv6"
+                        }
+                    ]
                 },
                 "port": {
                     "type": "integer",

--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-external-domain/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-external-domain/validate-input.json
@@ -74,7 +74,6 @@
                     "oneOf": [
                         {
                             "format": "hostname",
-                            "pattern": "\\."
                         },
                         {
                             "format": "ipv6"

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -1046,7 +1046,9 @@
         "users_admin_page_title": "User portal",
         "open_users_admin_portal": "Open user portal",
         "users_admin_page_tooltips": "User portal permits domain users to change their own password. The portal is accessible to users also on any node running the domain provider replica. The generic URL is https://{node_fqdn_or_ip}/users-admin/{domain}/",
-        "users_admin_page_description": "User administration self service portal"
+        "users_admin_page_description": "User administration self service portal",
+        "host_format": "Must be a valid domain name or IP address",
+        "host_pattern": "Must be a valid domain name or IP address"
     },
     "samba": {
         "adminuser": "Samba admin username",

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -1048,7 +1048,6 @@
         "users_admin_page_tooltips": "User portal permits domain users to change their own password. The portal is accessible to users also on any node running the domain provider replica. The generic URL is https://{node_fqdn_or_ip}/users-admin/{domain}/",
         "users_admin_page_description": "User administration self service portal",
         "host_format": "Must be a valid domain name or IP address",
-        "host_pattern": "Must be a valid domain name or IP address"
     },
     "samba": {
         "adminuser": "Samba admin username",


### PR DESCRIPTION
This pull request adds hostname, IPv4, and IPv6 format validation for the TCP backend endpoint configuration. This ensures that the host field in the configuration accepts valid hostnames, IPv4 addresses, and IPv6 addresses.

https://github.com/NethServer/dev/issues/6856