### PR TITLE
Avoid propagation of bind_user_domains() errors

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -577,7 +577,7 @@ def get_hostname():
         hostname = "myserver.example.org"
     return hostname
 
-def bind_user_domains(domain_list, check=True):
+def bind_user_domains(domain_list, check=False):
     """Associate the caller module with a new list of user domains. The
     previous list is discarded."""
     response = agent.tasks.run(


### PR DESCRIPTION
If the action `bind-user-domains` fails, do not raise the exception by default to avoid fatal errors in caller code. Instead return a boolean value False, if an error occurred.

Refs https://github.com/NethServer/dev/issues/6860