### PR TITLE
Fix hostname trailing comma format validation in validate-input.json

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-external-domain/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-external-domain/validate-input.json
@@ -73,7 +73,7 @@
                     "type": "string",
                     "oneOf": [
                         {
-                            "format": "hostname",
+                            "format": "hostname"
                         },
                         {
                             "format": "ipv6"


### PR DESCRIPTION
This pull request fixes the format validation for the hostname field in the validate-input.json file. Previously, there was a trailing comma in the format validation, which has been removed in this commit.

https://github.com/NethServer/dev/issues/6856