### PR TITLE
Prevent deletion of administrators and domain admins group

### DIFF
--- a/core/ui/src/components/domains/DomainGroups.vue
+++ b/core/ui/src/components/domains/DomainGroups.vue
@@ -101,6 +101,7 @@
                       <NsMenuDivider />
                       <cv-overflow-menu-item
                         danger
+                        :disabled="row.group === 'domain admins'"
                         @click="showDeleteGroupModal(row)"
                         :data-test-id="row.group + '-delete'"
                       >

--- a/core/ui/src/components/domains/DomainUsers.vue
+++ b/core/ui/src/components/domains/DomainUsers.vue
@@ -135,6 +135,7 @@
                       <NsMenuDivider />
                       <cv-overflow-menu-item
                         danger
+                        :disabled="row.user === 'administrator'"
                         @click="showDeleteUserModal(row)"
                         :data-test-id="row.user + '-delete'"
                       >


### PR DESCRIPTION
This pull requests disables the deletion of the `administrator` user and the `domain admins` group

Ref: NethServer/dev#6863 