### PR TITLE
Add an information line on "Nodes" card about nodes status in "Cluster status" view

### DIFF
--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -1179,6 +1179,7 @@
         "node_is_offline": "Node is offline",
         "nodes_offline_c": "{num} node is offline | {num} nodes are offline",
         "nodes_offline_description_c": "Check node status and connectivity | Check nodes status and connectivity",
+        "nodes_online_cluster_status": "All nodes are online",
         "node_is_offline_description": "Check node status and connectivity",
         "remove_from_cluster": "Remove from cluster",
         "remove_node_from_cluster": "Remove node from cluster",

--- a/core/ui/src/views/ClusterStatus.vue
+++ b/core/ui/src/views/ClusterStatus.vue
@@ -148,8 +148,11 @@
         >
           <template slot="content">
             <div class="card-rows">
-              <div class="card-row">
-                <div v-if="!loading.getClusterStatus">
+              <div
+                class="card-row"
+                v-if="!loading.getClusterStatus && nodes.length > 1"
+              >
+                <div class="mg-top-sm">
                   <div
                     v-if="nodesOffline.length"
                     class="card-row icon-and-text"

--- a/core/ui/src/views/ClusterStatus.vue
+++ b/core/ui/src/views/ClusterStatus.vue
@@ -72,7 +72,7 @@
           <template slot="content">
             <div class="card-rows">
               <div class="card-row">
-                <div v-if="!loading.getSubscription" class="card-row ">
+                <div v-if="!loading.getSubscription" class="card-row">
                   <cv-tag
                     v-if="subscription_status === 'active'"
                     kind="green"
@@ -85,7 +85,10 @@
                   ></cv-tag>
                 </div>
               </div>
-              <div v-if="support_active && !loading.getSubscription" class="card-row">
+              <div
+                v-if="support_active && !loading.getSubscription"
+                class="card-row"
+              >
                 <div class="mg-top-sm icon-and-text">
                   <NsSvg :svg="InformationFilled16" class="icon ns-info" />
                   <span>{{
@@ -93,15 +96,15 @@
                   }}</span>
                 </div>
               </div>
-            <div v-if="!loading.getSubscription" class="card-row">
-              <NsButton
-                kind="ghost"
-                :icon="ArrowRight20"
-                @click="$router.push('/settings/subscription')"
-              >
-                {{ $t("cluster_status.go_to_subscription") }}
-              </NsButton>
-            </div>
+              <div v-if="!loading.getSubscription" class="card-row">
+                <NsButton
+                  kind="ghost"
+                  :icon="ArrowRight20"
+                  @click="$router.push('/settings/subscription')"
+                >
+                  {{ $t("cluster_status.go_to_subscription") }}
+                </NsButton>
+              </div>
             </div>
           </template>
         </NsInfoCard>
@@ -144,13 +147,38 @@
           class="min-height-card"
         >
           <template slot="content">
-            <NsButton
-              kind="ghost"
-              :icon="ArrowRight20"
-              @click="$router.push('/nodes')"
-            >
-              {{ $t("cluster_status.go_to_nodes") }}
-            </NsButton>
+            <div class="card-rows">
+              <div class="card-row">
+                <div v-if="!loading.getClusterStatus">
+                  <div
+                    v-if="nodesOffline.length"
+                    class="card-row icon-and-text"
+                  >
+                    <NsSvg :svg="ErrorFilled16" class="icon ns-error" />
+                    <span>
+                      {{
+                        $tc("nodes.nodes_offline_c", nodesOffline.length, {
+                          num: nodesOffline.length,
+                        })
+                      }}
+                    </span>
+                  </div>
+                  <div v-else class="card-row icon-and-text">
+                    <NsSvg :svg="CheckmarkFilled16" class="icon ns-success" />
+                    <span>
+                      {{ $t("nodes.nodes_online_cluster_status") }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <NsButton
+                kind="ghost"
+                :icon="ArrowRight20"
+                @click="$router.push('/nodes')"
+              >
+                {{ $t("cluster_status.go_to_nodes") }}
+              </NsButton>
+            </div>
           </template>
         </NsInfoCard>
       </cv-column>
@@ -309,6 +337,9 @@ export default {
     erroredBackups() {
       return this.backups.filter((b) => b.errorInstances.length);
     },
+    nodesOffline() {
+      return this.nodes.filter((n) => n.online == false);
+    },
     installedModules() {
       let installedModules = [];
 
@@ -462,7 +493,6 @@ export default {
       this.getSupportSession();
       this.subscription_status = output.subscription.status;
       this.loading.getSubscription = false;
-
     },
     async getClusterStatus() {
       this.error.getClusterStatus = "";


### PR DESCRIPTION
This pull request add a line in the "Nodes" card in the "Cluster status" view to inform the user about the status of the nodes in the "Nodes" view.

![Schermata del 2024-02-29 11-33-32](https://github.com/NethServer/ns8-core/assets/110453832/134bf4a0-5ec7-40c5-9231-1081bb27636b)
![Schermata del 2024-02-29 11-33-58](https://github.com/NethServer/ns8-core/assets/110453832/1b54a71d-8e6f-4ba0-bc61-b69206b1c9db)


Ref: NethServer/dev#6868