### PR TITLE
Display node name or node number inside app selector in "System Logs" view

### DIFF
--- a/core/ui/src/views/SystemLogs.vue
+++ b/core/ui/src/views/SystemLogs.vue
@@ -316,7 +316,7 @@ export default {
               " - " +
               (instance.node_ui_name
                 ? instance.node_ui_name
-                : `Node ${instance.node}`),
+                : this.$t("common.node") + " " + instance.node),
             value: instance.id,
           });
         }

--- a/core/ui/src/views/SystemLogs.vue
+++ b/core/ui/src/views/SystemLogs.vue
@@ -309,9 +309,14 @@ export default {
         for (let instance of instanceList) {
           apps.push({
             name: instance.id,
-            label: instance.ui_name
-              ? instance.ui_name + " (" + instance.id + ")"
-              : instance.id,
+            label:
+              (instance.ui_name
+                ? instance.ui_name + " (" + instance.id + ")"
+                : instance.id) +
+              " - " +
+              (instance.node_ui_name
+                ? instance.node_ui_name
+                : `Node ${instance.node}`),
             value: instance.id,
           });
         }


### PR DESCRIPTION
This pull request add the name of the application's node inside the app selector in "System Logs" view, if the node has no name, we will display the node number

![image](https://github.com/NethServer/ns8-core/assets/110453832/837ec4da-97d5-4054-9202-fee7271d12f7)

Ref: NethServer/dev#6870