### PR TITLE
Refactor firewall service removal in uninstall.sh

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/uninstall.sh
+++ b/core/imageroot/var/lib/nethserver/node/uninstall.sh
@@ -49,6 +49,7 @@ echo "Clean up firewalld core rules"
 # remove BUILTIN_SERVICE
 firewall-cmd --permanent --remove-service=http --remove-service=https >/dev/null
 # Iterate through all services
+#:warning: Adding `--zone=public` prevents `firewall-cmd` to write an informative message to stdout that breaks the FOR loop
 for service in $(firewall-cmd --permanent --list-services --zone=public); do
     # do not remove if the service is a BUILTIN_SERVICE like ssh, dhcpv6-client, etc
     if [[ -f "/usr/lib/firewalld/services/${service}.xml" ]]; then


### PR DESCRIPTION
This pull request refactors the firewall service removal in the uninstall.sh script. Instead of individually removing each service, it now uses an array of excluded services to skip certain services. This improves the efficiency and readability of the code.


at the end after the NS8 removal we still keep some services enabled 

```
[root@R1-pve ~]# firewall-cmd --list-all
public (active)
  target: default
  icmp-block-inversion: no
  interfaces: ens18
  sources: 
  services: cockpit dhcpv6-client ssh
  ports: 
  protocols: 
  forward: yes
  masquerade: no
  forward-ports: 
  source-ports: 
  icmp-blocks: 
  rich rules: 
```
https://github.com/NethServer/dev/issues/6861