### PR TITLE
Fix administrator user and group check not working for Active Directory

### DIFF
--- a/core/ui/src/components/domains/DomainGroups.vue
+++ b/core/ui/src/components/domains/DomainGroups.vue
@@ -101,7 +101,7 @@
                       <NsMenuDivider />
                       <cv-overflow-menu-item
                         danger
-                        :disabled="row.group === 'domain admins'"
+                        :disabled="row.group.toLowerCase() === 'domain admins'"
                         @click="showDeleteGroupModal(row)"
                         :data-test-id="row.group + '-delete'"
                       >

--- a/core/ui/src/components/domains/DomainUsers.vue
+++ b/core/ui/src/components/domains/DomainUsers.vue
@@ -135,7 +135,7 @@
                       <NsMenuDivider />
                       <cv-overflow-menu-item
                         danger
-                        :disabled="row.user === 'administrator'"
+                        :disabled="row.user.toLowerCase() === 'administrator'"
                         @click="showDeleteUserModal(row)"
                         :data-test-id="row.user + '-delete'"
                       >


### PR DESCRIPTION
This PR fixes an instance where the administrator and admin domain group check would not work properly because of mixed-case spacing in Active Directory setup. A lowercase cast has been added to ensure the check works for such cases.

Ref: https://github.com/NethServer/dev/issues/6863