### PR TITLE
Refactor service path handling for systemd template and exclude certain services

### DIFF
--- a/core/imageroot/usr/local/agent/actions/get-status/20read
+++ b/core/imageroot/usr/local/agent/actions/get-status/20read
@@ -31,7 +31,6 @@ import json
 import agent
 import os.path
 import subprocess
-import re
 
 # Prepare return variable
 status = {}
@@ -56,26 +55,19 @@ else:
     systemd_path = f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/*.service'
 
 status["services"] = []
-file_paths = []
+units = []
 
-# Extract the service name foo@.service template from the path
-pattern = r'([^/]+)@\.service'
-
-for path in glob.glob(systemd_path):
-    match = re.search(pattern, path)
-    if match:
-        # search for all instances of the template
-        extracted_value = match.group(1)
-        file_paths.extend(glob.glob(f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/**/{extracted_value}@*.service', recursive=True))
+# find all services paths and retrieve unit names
+for file in glob.glob(systemd_path):
+    # look for templates
+    if file.endswith('@.service'):
+        for template in glob.glob(f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/default.target.wants/*@*.service', recursive=False):
+            units.append(os.path.basename(template))
     else:
-        file_paths.append(path)
+        units.append(os.path.basename(file))
 
-# Read the status of each service
-for f in file_paths:
-    unit = os.path.basename(f)
-    # Exclude services with names like "phpfpm@.service"
-    if "@.service" in unit:
-        continue
+# iterate over units and retrieve status
+for unit in units:
     service = {"name": unit.removesuffix(".service")}
     for a in ["active", "enabled", "failed"]:
         if rootfull:

--- a/core/imageroot/usr/local/agent/actions/get-status/20read
+++ b/core/imageroot/usr/local/agent/actions/get-status/20read
@@ -65,7 +65,7 @@ for file in glob.glob(base_dir+systemd_path):
     if file.endswith('@.service'):
         # replace the name of the unit foo@.service to foo@*.service
         unit = os.path.basename(file.replace('@.service', '@*.service'))
-        for template in glob.glob(base_dir + f'/default.target.wants/{unit}', recursive=False):
+        for template in glob.glob(base_dir + 'default.target.wants/' + unit, recursive=False):
             # add only the unit name
             units.append(os.path.basename(template))
     else:

--- a/core/imageroot/usr/local/agent/actions/get-status/20read
+++ b/core/imageroot/usr/local/agent/actions/get-status/20read
@@ -45,18 +45,24 @@ rootfull = os.getuid() == 0
 image_filter = []
 
 if rootfull:
-    systemd_path = f'/etc/systemd/system/{status["instance"]}*.service'
+    systemd_path = glob.glob(f'/etc/systemd/system/{status["instance"]}*.service')
     # prepare image filter
     env = agent.read_envfile(os.environ["AGENT_STATE_DIR"] + "/environment")
     for key in env.keys():
         if key.endswith("_IMAGE"):
             image_filter.append(env[key])
 else:
-    systemd_path = f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/*.service'
+    default = f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/*.service'
+    # we want to look for foo@.service in default.target.wants but in other target zones too
+    template = f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/**/*@*.service'
+    systemd_path = glob.glob(default) + glob.glob(template, recursive=True)
 
 status["services"] = []
-for f in glob.glob(systemd_path):
+for f in systemd_path:
     unit = os.path.basename(f)
+    # Exclude services with names like "phpfpm@.service"
+    if "@.service" in unit:
+        continue
     service = {"name": unit.removesuffix(".service")}
     for a in ["active", "enabled", "failed"]:
         if rootfull:

--- a/core/imageroot/usr/local/agent/actions/get-status/20read
+++ b/core/imageroot/usr/local/agent/actions/get-status/20read
@@ -59,10 +59,12 @@ units = []
 
 # find all services paths and retrieve unit names
 for file in glob.glob(systemd_path):
-    # look for templates
+    # look for templates foo@.service
     if file.endswith('@.service'):
         for template in glob.glob(f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/default.target.wants/*@*.service', recursive=False):
-            units.append(os.path.basename(template))
+            # we want to push only if we match 'foo@'
+            if template.startswith(template.replace('.service','')):
+                units.append(os.path.basename(template))
     else:
         units.append(os.path.basename(file))
 

--- a/core/imageroot/usr/local/agent/actions/get-status/20read
+++ b/core/imageroot/usr/local/agent/actions/get-status/20read
@@ -31,6 +31,7 @@ import json
 import agent
 import os.path
 import subprocess
+import re
 
 # Prepare return variable
 status = {}
@@ -45,20 +46,32 @@ rootfull = os.getuid() == 0
 image_filter = []
 
 if rootfull:
-    systemd_path = glob.glob(f'/etc/systemd/system/{status["instance"]}*.service')
+    systemd_path = f'/etc/systemd/system/{status["instance"]}*.service'
     # prepare image filter
     env = agent.read_envfile(os.environ["AGENT_STATE_DIR"] + "/environment")
     for key in env.keys():
         if key.endswith("_IMAGE"):
             image_filter.append(env[key])
 else:
-    default = f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/*.service'
-    # we want to look for foo@.service in default.target.wants but in other target zones too
-    template = f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/**/*@*.service'
-    systemd_path = glob.glob(default) + glob.glob(template, recursive=True)
+    systemd_path = f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/*.service'
 
 status["services"] = []
-for f in systemd_path:
+file_paths = []
+
+# Extract the service name foo@.service template from the path
+pattern = r'([^/]+)@\.service'
+
+for path in glob.glob(systemd_path):
+    match = re.search(pattern, path)
+    if match:
+        # search for all instances of the template
+        extracted_value = match.group(1)
+        file_paths.extend(glob.glob(f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/**/{extracted_value}@*.service', recursive=True))
+    else:
+        file_paths.append(path)
+
+# Read the status of each service
+for f in file_paths:
     unit = os.path.basename(f)
     # Exclude services with names like "phpfpm@.service"
     if "@.service" in unit:

--- a/core/imageroot/usr/local/agent/actions/get-status/20read
+++ b/core/imageroot/usr/local/agent/actions/get-status/20read
@@ -45,26 +45,28 @@ rootfull = os.getuid() == 0
 image_filter = []
 
 if rootfull:
-    systemd_path = f'/etc/systemd/system/{status["instance"]}*.service'
+    systemd_path = f'{status["instance"]}*.service'
+    base_dir= '/etc/systemd/system/'
     # prepare image filter
     env = agent.read_envfile(os.environ["AGENT_STATE_DIR"] + "/environment")
     for key in env.keys():
         if key.endswith("_IMAGE"):
             image_filter.append(env[key])
 else:
-    systemd_path = f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/*.service'
+    systemd_path = '*.service'
+    base_dir = f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/'
 
 status["services"] = []
 units = []
 
 # find all services paths and retrieve unit names
-for file in glob.glob(systemd_path):
+for file in glob.glob(base_dir+systemd_path):
     # look for templates
     if file.endswith('@.service'):
-        # we want the unit name `foo@*.service` instead of `foo@.service`
+        # replace the name of the unit foo@.service to foo@*.service
         unit = os.path.basename(file.replace('@.service', '@*.service'))
-        for template in glob.glob(f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/default.target.wants/{unit}', recursive=False):
-            # push only the template name
+        for template in glob.glob(base_dir + f'/default.target.wants/{unit}', recursive=False):
+            # add only the unit name
             units.append(os.path.basename(template))
     else:
         units.append(os.path.basename(file))

--- a/core/imageroot/usr/local/agent/actions/get-status/20read
+++ b/core/imageroot/usr/local/agent/actions/get-status/20read
@@ -59,12 +59,13 @@ units = []
 
 # find all services paths and retrieve unit names
 for file in glob.glob(systemd_path):
-    # look for templates foo@.service
+    # look for templates
     if file.endswith('@.service'):
-        for template in glob.glob(f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/default.target.wants/*@*.service', recursive=False):
-            # we want to push only if we match 'foo@'
-            if template.startswith(template.replace('.service','')):
-                units.append(os.path.basename(template))
+        # we want the unit name `foo@*.service` instead of `foo@.service`
+        unit = os.path.basename(file.replace('@.service', '@*.service'))
+        for template in glob.glob(f'{os.environ["AGENT_INSTALL_DIR"]}/systemd/user/default.target.wants/{unit}', recursive=False):
+            # push only the template name
+            units.append(os.path.basename(template))
     else:
         units.append(os.path.basename(file))
 


### PR DESCRIPTION
This pull request refactors the service path handling for the systemd template and adds exclusion for services with names like "phpfpm@.service". This improves the efficiency and accuracy of the service filtering process.

systemed template appears but only the master template

![image](https://github.com/NethServer/ns8-core/assets/3164851/bc79eec8-0be5-4fa5-8ad4-3e33209a74ca)


instead I would like rootless


![image](https://github.com/NethServer/ns8-core/assets/3164851/8a57f7d8-ade1-41db-9487-babaf75fa521)


for rootfull container

![image](https://github.com/NethServer/ns8-core/assets/3164851/20941db1-760f-471f-9331-a5f7b7fc1021)



https://github.com/NethServer/dev/issues/6892