### PR TITLE
Drop ssh-keygen requirement

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/install-finalize.sh
+++ b/core/imageroot/var/lib/nethserver/node/install-finalize.sh
@@ -13,15 +13,6 @@ set -e
 
 source /etc/nethserver/core.env
 
-if [[ ! -f ~/.ssh/id_rsa.pub ]] ; then
-    echo "Generating a new RSA key pair for SSH:"
-    ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
-fi
-
-echo "Adding id_rsa.pub to module skeleton dir:"
-install -d -m 700 /etc/nethserver/skel/.ssh
-install -m 600 -T ~/.ssh/id_rsa.pub /etc/nethserver/skel/.ssh/authorized_keys
-
 if ! grep -q ' cluster-leader$' /etc/hosts; then
     echo "Add /etc/hosts entries:"
     echo "127.0.0.1 cluster-leader" >> /etc/hosts


### PR DESCRIPTION
Since runagent can replace ssh to access a fully-functional agent environment, generating and installing a local SSH key for every module/user is no more required. We can remove the key generation and drop the dependency on ssh-keygen (provided by openssh-client package).

Refs https://github.com/NethServer/dev/issues/6888