### PR TITLE
Update SetFqdnModal labels for hostname and domain creation

### DIFF
--- a/core/ui/src/components/nodes/SetFqdnModal.vue
+++ b/core/ui/src/components/nodes/SetFqdnModal.vue
@@ -29,7 +29,7 @@
       <cv-form v-else @submit.prevent="setFqdn">
         <template>
           <cv-text-input
-            :label="$t('init.hostname')"
+            :label="$t('init.hostname_create')"
             v-model.trim="hostname"
             :invalid-message="error.hostname"
             :disabled="loading.getFqdn || loading.setFqdn"
@@ -37,7 +37,7 @@
           >
           </cv-text-input>
           <cv-text-input
-            :label="$t('init.domain')"
+            :label="$t('init.domain_create')"
             v-model.trim="domain"
             placeholder="example.org"
             :invalid-message="error.domain"


### PR DESCRIPTION
This pull request updates the labels for the hostname and domain fields in the SetFqdnModal component. The labels were changed to "init.hostname_create" and "init.domain_create" respectively. This change improves the clarity and accuracy of the labels in the user interface.

https://github.com/NethServer/dev/issues/6927