### PR TITLE
Add validation for displayName in CreateOrEditUserModal

### DIFF
--- a/core/ui/src/components/domains/CreateOrEditUserModal.vue
+++ b/core/ui/src/components/domains/CreateOrEditUserModal.vue
@@ -164,7 +164,7 @@ export default {
         alterUser: "",
         getDomainUser: "",
         user: "",
-        displayName: "",
+        display_name: "",
         newPassword: "",
         confirmPassword: "",
         groups: "",
@@ -285,6 +285,15 @@ export default {
 
         if (isValidationOk) {
           this.focusElement("user");
+          isValidationOk = false;
+        }
+      }
+      // displayName is required
+      if (!this.displayName) {
+        this.error.display_name = this.$t("common.required");
+
+        if (isValidationOk) {
+          this.focusElement("display_name");
           isValidationOk = false;
         }
       }


### PR DESCRIPTION
This pull request adds validation for the displayName field in the CreateOrEditUserModal component. If the displayName is not provided, an error message is displayed and the focus is set on the displayName input field. This change improves the user experience by ensuring that the required field is filled out before submitting the form.

https://github.com/NethServer/dev/issues/6930