### PR TITLE
Removed loki instance label validation

### DIFF
--- a/core/ui/src/views/settings/SettingsSystemLogs.vue
+++ b/core/ui/src/views/settings/SettingsSystemLogs.vue
@@ -446,23 +446,7 @@ export default {
       this.newRetention = null;
       this.getClusterLokiInstances();
     },
-    validateLokiInstanceLabel() {
-      this.clearErrors(this);
-      let isValidationOk = true;
-
-      if (!this.newLabel) {
-        this.error.newLabel = this.$t("common.required");
-        isValidationOk = false;
-      }
-
-      return isValidationOk;
-    },
     async setLokiInstanceLabel() {
-      const isValidationOk = this.validateLokiInstanceLabel();
-      if (!isValidationOk) {
-        return;
-      }
-
       this.error.setLokiInstanceLabel = "";
       this.loading.setLokiInstanceLabel = true;
       const taskAction = "set-name";


### PR DESCRIPTION
This pull request remove a validation on core ui, to avoid incorrect error on loki instance label change.
Now it is possbile to reset loki instance label to empty.

[NethServer/dev#6929](https://github.com/NethServer/dev/issues/6929)