### PR TITLE
Run the script only at boot

### DIFF
--- a/core/imageroot/etc/systemd/system/overlay-cleanup.service
+++ b/core/imageroot/etc/systemd/system/overlay-cleanup.service
@@ -2,5 +2,6 @@
 Description=Cleanup the overlay-merged volume
 
 [Service]
+RemainAfterExit=true
 ExecStart=/usr/local/sbin/overlay-cleanup
 Type=oneshot


### PR DESCRIPTION
The unit is pulled in by the Redis unit, and runs before it at boot. However it must run before containers are started, only one time at boot, otherwise the removal of merged/ dirs breaks the overlay filesystem.

Prevent the script to be invoked multiple times, if Redis is restarted.

Refs NethServer/dev#6933