### PR TITLE
App instances count as available applications

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-core-modules/50read
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-core-modules/50read
@@ -23,5 +23,8 @@
 import sys
 import json
 import cluster.modules
+import agent
 
-json.dump(cluster.modules.list_core_modules(), fp=sys.stdout)
+rdb = agent.redis_connect(privileged=True)
+
+json.dump(cluster.modules.list_core_modules(rdb), fp=sys.stdout)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-core/70update_modules
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-core/70update_modules
@@ -21,7 +21,7 @@ rdb = agent.redis_connect(privileged=True)
 
 # Update all core modules
 instances = dict()
-for oimage in cluster.modules.list_core_modules():
+for oimage in cluster.modules.list_core_modules(rdb):
     image_id = oimage['name']
     if image_id == 'core':
         continue # skip core: it is handled by another action step


### PR DESCRIPTION
Even if there is no repository enabled I want to see Apps in the Software Center, and Core components too.

This PR changes the list_available() return value, to include those instances that do not belong to any repository (orphans).

Metadata (logo image included) of orphan apps is synthesized from the metadata.json and .png image installed in the cluster leader, if present. Also the image labels are retrieved from the leader image store.

The list_available function is called from many code points. It affects the results of the following actions, without impact on the output format:

- `list-modules`
- `list-installed-modules`
- `list-core-modules`
- `list-updates`
- `update-modules` (invoked also by apply-updates command)

The ordering of available versions and installed versions has been implemented from newest to oldest.

Refs https://github.com/NethServer/dev/issues/6947