### PR TITLE
Log the path of backup destination

### DIFF
--- a/core/imageroot/usr/local/agent/bin/module-backup
+++ b/core/imageroot/usr/local/agent/bin/module-backup
@@ -99,9 +99,9 @@ if os.path.isfile(install_dir + "/etc/state-exclude.conf"):
 
 # Ensure the restic repository has been initialized
 if agent.run_restic(rdb, repository, repopath, [], ["snapshots"], stdout=subprocess.DEVNULL).returncode == 0:
-    print(f"Repository {repository} is present", file=sys.stderr)
+    print(f"Repository {repository} is present at path {repopath}", file=sys.stderr)
 else:
-    print(f"Initializing repository {repository}", file=sys.stderr)
+    print(f"Initializing repository {repository} at path {repopath}", file=sys.stderr)
     agent.run_restic(rdb, repository, repopath, [], ["init"]).check_returncode()
 
 time_start = int(time.time())


### PR DESCRIPTION
There is no association between an app instance and its backup destination path. If the app is removed and its UUID is lost, it's difficult to find it in a backup destination with many instances.

This commit sends this information in the log: it might help.

For example this is a generated log line:

    Jun 19 12:49:13 rl1.dp.nethserver.net backup1[35869]: Initializing repository 14030a59-a4e6-54cc-b8ea-cd5f97fe44c8 at path loki/759650eb-e654-44ed-9c10-2a2814277eda          

If repository exists this one is printed instead:

    Jun 19 12:58:11 rl1.dp.nethserver.net backup1[36133]: Repository 14030a59-a4e6-54cc-b8ea-cd5f97fe44c8 is present at path loki/759650eb-e654-44ed-9c10-2a2814277eda

No QA is planned for the proposed change.