### PR TITLE
Hide the JWT join token in audit trail

### DIFF
--- a/core/api-server/configuration/configuration.go
+++ b/core/api-server/configuration/configuration.go
@@ -93,6 +93,6 @@ func Init() {
 	if os.Getenv("SENSITIVE_LIST") != "" {
 		Config.SensitiveList = strings.Split(os.Getenv("SENSITIVE_LIST"), ",")
 	} else {
-		Config.SensitiveList = []string{"password", "secret", "token"}
+		Config.SensitiveList = []string{"password", "secret", "token", "jwt"}
 	}
 }


### PR DESCRIPTION
The JWT join token is a sensible value: we must obfuscate it before writing the audit trail.

E.g. in `join-cluster`

```json
{
  "action": "join-cluster",
  "data": {
    "jwt": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVAJ9.eyIyZmEiOmZhbHNlLCJhY3Rpb25zIjpbXSwiZXhwIjoxNzE5NTUyNDk0LCJpZCI6ImFkbWluIiwib3JpZ19pYXQiOjE3MTgzNDI4OTQtInJvbGUiOiIifQ.b8CC4HZOSoiu_rtZ7gRw6fXqBa-2GuixLT0oTP7vhnc",
    "tls_verify": true,
    "url": "https://rl1.dp.nethserver.net"
  },
  "extra": {
    "isNotificationHidden": true,
    "title": "Join a cluster",
    "toastTimeout": 0
  },
  "id": "f1f315a7-9721-4570-ac01-9ebc4e47f786",
  "parent": "",
  "queue": "cluster/tasks",
  "timestamp": "2024-06-20T13:23:37.028891077Z",
  "user": "admin"
}
```