### PR TITLE
Prevent double-initialization of cluster

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/00validate_cluster
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/00validate_cluster
@@ -17,5 +17,6 @@ network = rdb.get('cluster/network')
 
 if network:
     agent.set_status('validation-failed')
+    print(agent.SD_ERR + "This cluster is already initialized. Run the uninstall procedure then install NS8 again.", file=sys.stderr)
     json.dump([{'field':'network', 'parameter':'network','value': request['network'], 'error':'cluster_network_already_set'}], fp=sys.stdout)
     sys.exit(2)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/00validate_cluster
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/00validate_cluster
@@ -19,6 +19,7 @@ network = rdb.get('cluster/network')
 
 if network:
     agent.set_status('validation-failed')
+    print(agent.SD_ERR + "Cannot join another cluster: Run the uninstall procedure then install NS8 again.", file=sys.stderr)
     json.dump([{'field':'url', 'parameter':'url','value': request['url'], 'error':'cluster_network_already_set'}], fp=sys.stdout)
     sys.exit(2)
 

--- a/core/imageroot/var/lib/nethserver/cluster/actions/join-node/10block_network
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/join-node/10block_network
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import os
+import json
+import agent
+
+request = json.load(sys.stdin)
+network = request['network']
+agent.assert_exp(network)
+rdb = agent.redis_connect(privileged=True)
+# Set the cluster/network to prevent join-cluster and create-cluster to be
+# invoked again on this node, in case of join-node failure.
+rdb.set('cluster/network', network)


### PR DESCRIPTION
- Prevent join-node to be executed two times on the same node, or execute create-cluster after a partially-failed join-node
- Print an error message in the log. If the create-cluster or join-cluster must be executed again, uninstall/reinstall is the way to go.

Refs https://github.com/NethServer/dev/issues/6958