### PR TITLE
Fix the VPN endpoint value in set-fqdn action

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/set-fqdn/25adjust_vpn_endpoint
+++ b/core/imageroot/var/lib/nethserver/node/actions/set-fqdn/25adjust_vpn_endpoint
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2023 Nethesis S.r.l.
+# Copyright (C) 2024 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 


### PR DESCRIPTION
The new node FQDN is forcibly set as VPN endpoint too.

Other nodes will pick up this change when their wg0 interface is restarted on the next node reboot, or on the next cluster VPN change.

Discussion https://mattermost.nethesis.it/nethesis/pl/j5mqtt5xyjdyjech9abz7zubte

Refs https://github.com/NethServer/dev/issues/6960