### PR TITLE
Improve validation error message of join-cluster

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/00validate_cluster
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/join-cluster/00validate_cluster
@@ -11,6 +11,7 @@ import agent
 import agent.tasks
 import requests
 from aiohttp import ClientConnectorCertificateError, ClientResponseError
+from urllib.parse import urlparse
 
 request = json.load(sys.stdin)
 endpoint_url = request['url'].rstrip('/') + '/cluster-admin'
@@ -20,6 +21,13 @@ network = rdb.get('cluster/network')
 if network:
     agent.set_status('validation-failed')
     json.dump([{'field':'url', 'parameter':'url','value': endpoint_url, 'error':'cluster_network_already_set'}], fp=sys.stdout)
+    sys.exit(2)
+
+leader_hostname = urlparse(endpoint_url).hostname
+if leader_hostname == agent.get_hostname():
+    agent.set_status('validation-failed')
+    print(agent.SD_ERR, f"FQDN {leader_hostname} is used by the leader node. Set a different FQDN for this node.", file=sys.stderr)
+    json.dump([{'field':'url', 'parameter':'url','value': leader_hostname, 'error':'cluster_hostname_error'}], fp=sys.stdout)
     sys.exit(2)
 
 try:

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -203,6 +203,7 @@
         "cluster_tls_verify_error": "TLS certificate of leader node is not valid",
         "cluster_auth_error": "Invalid response",
         "cluster_connection_error": "Failed to connect to the leader node at address {value}",
+        "cluster_hostname_error": "FQDN {value} is used by the leader node. Use 'Go Back' and change worker's hostname or domain.",
         "redirect_cluster": "Worker Node",
         "redirect_cluster_description": "This node is a worker of the cluster now. Click the button below to access cluster administration page on the leader node.",
         "redirect_cluster_link": "Go to cluster administration",

--- a/core/ui/public/i18n/it/translation.json
+++ b/core/ui/public/i18n/it/translation.json
@@ -996,6 +996,7 @@
         "the_join_code_is_not_correctly_encoded": "Il codice di join non ha il formato corretto",
         "cluster_auth_error": "Risposta non valida",
         "cluster_connection_error": "Connessione al nodo leader all'indirizzo {value} fallita",
+        "cluster_hostname_error": "Il FQDN {value} è utilizzato dal nodo leader. Usa 'Indietro' e modifica il nome host o il dominio del worker.",
         "the_join_code_cannot_be_parsed": "Il codice di join non può essere interpretato",
         "cluster_tls_verify_error": "Il certificato TLS del nodo leader non è valido",
         "the_join_code_can_not_be_decoded": "Il codice di join non può essere decodificato"


### PR DESCRIPTION
If the leader FQDN is the same of the worker, display a specific error message.

![image](https://github.com/NethServer/ns8-core/assets/2920838/d83ae203-6a9c-4b6b-9983-4b92a4a477e3)


Refs https://github.com/NethServer/dev/issues/6962