### PR TITLE
Hide account provider admin passwords

### DIFF
--- a/core/api-server/configuration/configuration.go
+++ b/core/api-server/configuration/configuration.go
@@ -93,6 +93,6 @@ func Init() {
 	if os.Getenv("SENSITIVE_LIST") != "" {
 		Config.SensitiveList = strings.Split(os.Getenv("SENSITIVE_LIST"), ",")
 	} else {
-		Config.SensitiveList = []string{"password", "secret", "token", "jwt"}
+		Config.SensitiveList = []string{"password", "secret", "token", "jwt", "admpass", "adminpass"}
 	}
 }


### PR DESCRIPTION
Avoid writing the administrative passwords into the audit trail in clear-text form.

This is a well-tested change pattern and does not require any testing.