### PR TITLE
Fixed UI System Logs

### DIFF
--- a/core/ui/src/components/settings/CloudLogManagerConfigureModal.vue
+++ b/core/ui/src/components/settings/CloudLogManagerConfigureModal.vue
@@ -167,6 +167,7 @@ export default {
   methods: {
     onModalHidden() {
       this.$emit("hide");
+      this.resetModal();
     },
     resetModal() {
       this.radioVal = "last_timestamp";
@@ -195,6 +196,10 @@ export default {
         this.address = "https://nar.nethesis.it";
       } else {
         this.address = this.configuration.address;
+      }
+
+      if (!this.configuration.tenant == "") {
+        this.tenant = this.configuration.tenant;
       }
 
       if (this.configuration.last_timestamp == "") {


### PR DESCRIPTION
Company Unique Key wasn't showed properly on cloud log manager modal, fixed.

[Nethserver/dev#6932](https://github.com/NethServer/dev/issues/6932)

### Test Case
- Go to `Ssettings` -> `System Logs`
- On active loki instance open cloud log manager modal and set forwarder
- Reopen modal and check if `Company Unique Key` is present and correct