### PR TITLE
Return wg listen-port number from node/get-info

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/get-info/20read
+++ b/core/imageroot/var/lib/nethserver/node/actions/get-info/20read
@@ -1,23 +1,23 @@
-#!/bin/bash
+#!/usr/bin/env python3
 
 #
-# Copyright (C) 2023 Nethesis S.r.l.
-# http://www.nethesis.it - nethserver@nethesis.it
-#
-# This script is part of NethServer.
-#
-# NethServer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License,
-# or any later version.
-#
-# NethServer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with NethServer.  If not, see COPYING.
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-echo -n "{\"hostname\": \"$(hostname -f)\", \"machine_id\": \"$(cat /etc/machine-id)\"}"
+import json
+import agent
+import sys
+import os
+import subprocess
+
+try:
+    vpn_port = int(subprocess.check_output(['/usr/bin/wg', 'show', 'wg0', 'listen-port'], text=True).rstrip())
+except Exception as ex:
+    print(agent.SD_ERR, ex, file=sys.stderr)
+    vpn_port = 55820
+
+json.dump({
+    "hostname": agent.get_hostname(),
+    "vpn_port": vpn_port,
+}, fp=sys.stdout)

--- a/core/imageroot/var/lib/nethserver/node/actions/get-info/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/node/actions/get-info/validate-output.json
@@ -1,12 +1,27 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "get-info output",
-  "$id": "http://schema.nethserver.org/node/get-infp-output.json",
+  "$id": "http://schema.nethserver.org/node/get-info-output.json",
   "description": "Output schema of the get-info action",
   "examples": [
     {
-      "hostname": "dn2.worker.cluster0.gs.nethserver.net",
-      "machine_id": "96b91e27d15ae6d7ef0cc79c621f7904"
+      "hostname": "node1.example.org",
+      "vpn_port": 55820
     }
-  ]
+  ],
+  "type": "object",
+  "required": [
+    "hostname",
+    "vpn_port"
+  ],
+  "properties": {
+    "hostname": {
+      "type": "string",
+      "description": "The node fully qualified hostname"
+    },
+    "vpn_port": {
+      "type": "integer",
+      "description": "The listening port number of wg0 Wireguard interface, detected at runtime"
+    }
+  }
 }


### PR DESCRIPTION
- Return the listening port number of wg0 interface
- Remove obsolete machine_id attribute
- Fix output JSON schema

Refs https://github.com/NethServer/dev/issues/6960