### PR TITLE
Fix import-module action

### DIFF
--- a/core/imageroot/usr/local/agent/actions/import-module/10recvstate
+++ b/core/imageroot/usr/local/agent/actions/import-module/10recvstate
@@ -41,6 +41,7 @@ podman_cmd = ['podman', 'run', '--rm', '--privileged', '--network=host', '--work
         '--env=RSYNCD_PASSWORD=' + password,
         '--env=RSYNCD_SYSLOG_TAG=' + os.environ['MODULE_ID'],
         '--volume=/dev/log:/dev/log',
+        '--replace',
         '--name=rsync-' + os.environ['MODULE_ID'],
     ] + agent.get_existing_volume_args()
 


### PR DESCRIPTION
If the rsync server dies suddenly, the NS7 client cannot resume it because the dead container is on the way.

The proposed solution has been already tested on the field.