### PR TITLE
Add 'node_id' field to installed core modules

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
@@ -310,7 +310,7 @@ def list_installed_core(rdb):
         
             if url not in installed.keys():
                 installed[url] = []
-            installed[url].append({'id': vars["MODULE_ID"], 'version': tag, 'module': image})
+            installed[url].append({'id': vars["MODULE_ID"], 'version': tag, 'module': image, 'node': vars['NODE_ID']})
 
     return installed
 
@@ -384,6 +384,7 @@ def list_core_modules(rdb):
                 "id": instance["id"],
                 "version": instance["version"],
                 "update": _calc_update(image_name, instance["version"]),
+                "node_id": instance.get("node", '1'),
             })
 
     return list(core_modules.values())

--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-core-modules/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-core-modules/validate-output.json
@@ -11,7 +11,8 @@
                   {
                       "id": "core",
                       "version": "updates_from_repo",
-                      "update": ""
+                      "update": "",
+                      "node_id": "1"
                   }
               ]
           },
@@ -21,7 +22,8 @@
                   {
                       "id": "promtail1",
                       "version": "latest",
-                      "update": ""
+                      "update": "",
+                      "node_id": "1"
                   }
               ]
           },
@@ -31,7 +33,8 @@
                   {
                       "id": "traefik1",
                       "version": "0.0.1",
-                      "update": ""
+                      "update": "",
+                      "node_id": "1"
                   }
               ]
           },
@@ -41,12 +44,14 @@
                   {
                       "id": "loki1",
                       "version": "latest",
-                      "update": ""
+                      "update": "",
+                      "node_id": "1"
                   },
                   {
                       "id": "loki2",
                       "version": "0.0.1-alpha1",
-                      "update": "0.0.1"
+                      "update": "0.0.1",
+                      "node_id": "1"
                   }
               ]
           },
@@ -56,7 +61,8 @@
                   {
                       "id": "ldapproxy1",
                       "version": "latest",
-                      "update": ""
+                      "update": "",
+                      "node_id": "1"
                   }
               ]
           }
@@ -86,12 +92,17 @@
                       "update": {
                           "type": "string",
                           "description": "Available version update, can be empty"
+                      },
+                      "node_id": {
+                          "type": "string",
+                          "description": "Node ID"
                       }
                   },
                   "required": [
                       "id",
                       "version",
-                      "update"
+                      "update",
+                      "node_id"
                   ]
               }
           }


### PR DESCRIPTION
This pull request adds a new 'node_id' field to the installed core modules. The 'node_id' field is included in the 'list_installed_core' and 'list_core_modules' functions, and it is also added to the validation output JSON file. This enhancement allows for better tracking and identification of the node associated with each installed core module.


https://github.com/orgs/NethServer/projects/8/views/2?pane=issue&itemId=70723897