### PR TITLE
fix: infinite scrolling in sw center and app drawer

### DIFF
--- a/core/ui/src/components/shell/NotificationDrawer.vue
+++ b/core/ui/src/components/shell/NotificationDrawer.vue
@@ -85,7 +85,7 @@ export default {
       // infinite scroll
       recentNotificationsLoaded: [],
       pageNum: 0,
-      pageSize: 20,
+      pageSize: 50,
     };
   },
   computed: {

--- a/core/ui/src/components/software-center/AppList.vue
+++ b/core/ui/src/components/software-center/AppList.vue
@@ -171,7 +171,7 @@ export default {
       // infinite scroll
       appsLoaded: [],
       pageNum: 0,
-      pageSize: 20,
+      pageSize: 50,
       isShownCoreAppModal: false,
     };
   },


### PR DESCRIPTION
Fix page size of infinite scrolling in software center and app drawer: on larger screens infinite scrolling didn't work.