### PR TITLE
Remove redundant agent graceful restart

### DIFF
--- a/core/imageroot/usr/local/agent/actions/update-module/05pullimages
+++ b/core/imageroot/usr/local/agent/actions/update-module/05pullimages
@@ -39,10 +39,6 @@ if not force and image_url == os.getenv('IMAGE_URL'):
     print(agent.SD_WARNING + f"The module URL {image_url} is already installed", file=sys.stderr)
     sys.exit(0)
 
-# Ask the agent to stop listening for new tasks and exit gracefully as
-# soon as this action terminates.
-os.kill(os.getppid(), signal.SIGUSR1)
-
 agent.set_weight('05pullimages', '5')
 
 if not force:


### PR DESCRIPTION
The agent no longer needs a restart during module updates since its configuration is no longer dependent on the module itself. A restart is only required during core updates.

I noticed SIGUSR1 runs multiple times during core-update if core and Loki (for example) are updated together.

```text
[root@rl1 ~]# journalctl --since=07:03:19 --grep Signal
Sep 13 07:03:19 rl1.dp.nethserver.net agent@node[31796]: Signal "user defined signal 1" caught: shutdown started.
Sep 13 07:03:19 rl1.dp.nethserver.net agent@ldapproxy1[32757]: Signal "user defined signal 1" caught: shutdown started.
Sep 13 07:03:19 rl1.dp.nethserver.net agent@loki1[32786]: Signal "user defined signal 1" caught: shutdown started.
Sep 13 07:03:19 rl1.dp.nethserver.net agent@traefik1[32152]: Signal "user defined signal 1" caught: shutdown started.
Sep 13 07:03:27 rl1.dp.nethserver.net agent@loki1[33746]: Signal "user defined signal 1" caught: shutdown started.
Sep 13 07:03:42 rl1.dp.nethserver.net agent@cluster[31791]: Signal "user defined signal 1" caught: shutdown started.
```

The removed lines were originally added in this commit https://github.com/NethServer/ns8-core/commit/a90baa3c6a0587696365a404598ebd11223b3a13.

When SIGUSR1 is caught, the agent stops running new tasks until the currently running ones finish. This can lead to deadlocks if a running task enqueues a new subtask and waits for it. I think we need to modify the current behavior to prevent these deadlocks (in another PR).

Refs https://github.com/NethServer/dev/issues/7016