### PR TITLE
fix: testing updates management

### DIFF
--- a/core/ui/src/views/ClusterStatus.vue
+++ b/core/ui/src/views/ClusterStatus.vue
@@ -763,7 +763,9 @@ export default {
       let updates = [];
 
       for (const app of apps) {
-        if (app.updates.length) {
+        const hasStableUpdate = app.updates.some((update) => update.update);
+
+        if (hasStableUpdate) {
           updates.push(app);
         }
 

--- a/core/ui/src/views/SoftwareCenter.vue
+++ b/core/ui/src/views/SoftwareCenter.vue
@@ -425,7 +425,10 @@ export default {
       let numInstancesToUpdate = 0;
 
       for (const appToUpdate of this.appUpdates) {
-        numInstancesToUpdate += appToUpdate.updates.length;
+        const instancesToUpdate = appToUpdate.updates.filter(
+          (update) => update.update
+        );
+        numInstancesToUpdate += instancesToUpdate.length;
       }
       return numInstancesToUpdate;
     },
@@ -512,7 +515,9 @@ export default {
       let appUpdates = [];
 
       for (const module of modules) {
-        if (module.updates.length) {
+        const hasStableUpdate = module.updates.some((update) => update.update);
+
+        if (hasStableUpdate) {
           appUpdates.push(module);
         }
 


### PR DESCRIPTION
Before this fix the software center notified the user about not only stable updates, but testing updates too. Now only stable updates are notified on the UI, as expected.

Ref:
- https://github.com/NethServer/dev/issues/6956