### PR TITLE
Fix home dir perms

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
@@ -70,6 +70,7 @@ if is_rootfull:
 else: # rootless
     # Create the module dirs structure
     agent.run_helper('useradd', '-m', '-k', '/etc/nethserver/skel', '-s', '/bin/bash', module_id).check_returncode()
+    agent.run_helper('chmod', '-c', '0700', os.path.expanduser("~" + module_id)).check_returncode()
     os.chdir(os.path.expanduser("~" + module_id) + '/.config')
     save_environment(module_environment)
     redis_sha256 = save_agent_env(module_id)


### PR DESCRIPTION
Ensure home dir perms are 0700. In Debian 12 the default settings create home dir with 0755.

With this PR the following happens during module home dir creation:

```text
Sep 18 15:53:41 dn2 agent@node[12008]: useradd -m -k /etc/nethserver/skel -s /bin/bash webtop1
Sep 18 15:53:41 dn2 agent@node[12008]: chmod -c 0700 /home/webtop1
Sep 18 15:53:41 dn2 agent@node[12008]: mode of '/home/webtop1' changed from 0755 (rwxr-xr-x) to 0700 (rwx------)
```

Refs NethServer/dev#7024