### PR TITLE
Prevent cloud-init from overwriting /etc/hosts

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/install-finalize.sh
+++ b/core/imageroot/var/lib/nethserver/node/install-finalize.sh
@@ -21,7 +21,7 @@ fi
 
 if [ -f /etc/cloud/cloud.cfg ]; then
     echo "Remove update_etc_hosts cloud-init module:"
-    sed -i.orig -r '/-\s*update_etc_hosts/ d' /etc/cloud/cloud.cfg || :
+    sed -i.orig -r '/-\s*update_etc_hosts/ d ; /-\s*update_hostname/ d' /etc/cloud/cloud.cfg || :
 fi
 
 echo "Generate WireGuard VPN key pair:"


### PR DESCRIPTION
Some cloud vendors attempt to overwrite /etc/hosts, which is managed by set-fqdn and other NS8 actions. This commit prevents cloud-init from overwriting its contents and losing NS8 settings.

To reproduce the bug:
- run the stable .qcow2 image with a cloud-init CD-ROM image that changes /etc/hosts. Set FQDN from NS8 UI. After reboot the file is changed.

To test this fix:
- build a patched .qcow2 image and run it with a cloud-init CD-ROM image that changes /etc/hosts.  Set FQDN from NS8 UI. After reboot the file is not changed.

As alternative to the CD-ROM image, an HTTP service for cloud-init can be passed to boot params:

https://cloudinit.readthedocs.io/en/latest/tutorial/qemu.html

See also https://cloudinit.readthedocs.io/en/latest/reference/modules.html#update-etc-hosts

Refs https://github.com/NethServer/dev/issues/6993