### PR TITLE
Fix cluster restore script to advertise LDAP provider changes

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/restore-cluster/30load
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/restore-cluster/30load
@@ -54,6 +54,14 @@ for d in dump['cluster']['user_domain']['ldap'].keys():
         rdb.hset(f'cluster/user_domain/ldap/{d}/ui_names', mapping=domain['ui_names'])
     for p in domain['providers']:
         r = rdb.lpush(f'cluster/user_domain/ldap/{d}/providers', p)
+    #
+    # Advertise new account provider setup
+    #
+    rdb.publish(os.getenv('AGENT_ID') + '/event/ldap-provider-changed', json.dumps({
+        'domain': d,
+        'key': f"cluster/user_domain/ldap/{d}/providers",
+    }))
+
 
 del(dump['cluster']['user_domain'])
 

--- a/core/imageroot/var/lib/nethserver/cluster/actions/restore-cluster/30load
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/restore-cluster/30load
@@ -59,7 +59,7 @@ for d in dump['cluster']['user_domain']['ldap'].keys():
     #
     rdb.publish(os.getenv('AGENT_ID') + '/event/ldap-provider-changed', json.dumps({
         'domain': d,
-        'key': f"cluster/user_domain/ldap/{d}/providers",
+        'key': f"cluster/user_domain/ldap/{d}/conf",
     }))
 
 


### PR DESCRIPTION
The cluster restore script has been fixed to properly advertise LDAP provider changes. Previously, the script was not correctly publishing the changes, but now it uses a transaction pipeline to ensure that the changes are properly advertised. This fix ensures that any changes made to the LDAP provider setup are correctly communicated to the relevant components.

https://github.com/NethServer/dev/issues/7027