### PR TITLE
Add 'Audio' to software center application categories

### DIFF
--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -906,7 +906,8 @@
             "monitoring": "Monitoring",
             "web": "Web",
             "communication": "Communication",
-            "security": "Security"
+            "security": "Security",
+            "audio": "Audio"
         },
         "images_label": "Images"
     },


### PR DESCRIPTION
I am currently in the process creating Logitech Media Server and Lyrion Music Server as NS8 applications and for that i need a suitable application category in NS8 software center. Therefore i propose that audio is added to the list of categories.