### PR TITLE
Fix semver comparison

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
@@ -370,7 +370,7 @@ def list_core_modules(rdb):
         try:
             vupdate = module["versions"][0]['tag']
             vinfo = semver.VersionInfo.parse(vupdate)
-            if vupdate > cur:
+            if vinfo > cur:
                 return vupdate
         except:
             pass


### PR DESCRIPTION
Comparison between strings is wrong: use the semver variable instead.

This PR contains a commit for version 2.9.4, and will be merged into branch hotfix-7040. Once merged we can release it as 2.9.5.

Refs NethServer/dev#7040