### PR TITLE
Add Subscription units to clean up list

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/uninstall.sh
+++ b/core/imageroot/var/lib/nethserver/node/uninstall.sh
@@ -69,8 +69,19 @@ fi
 
 firewall-cmd --reload
 
-echo "Stopping the core services"
-systemctl disable --now api-server.service redis.service wg-quick@wg0.service phonehome.timer rclone-webdav.service promtail.service
+echo "Stopping the core services and timers"
+systemctl disable --now \
+  api-server.service \
+  redis.service \
+  wg-quick@wg0.service \
+  phonehome.timer \
+  rclone-webdav.service \
+  promtail.service \
+  node-monitor.service \
+  send-heartbeat.service \
+  send-inventory.timer \
+  send-backup.timer \
+  # end of unit list
 rm -vf /etc/wireguard/wg0.conf
 userdel -r api-server
 ip link delete wg0 # force removal of wg0 interface


### PR DESCRIPTION
If a Subscription is active, additional units may be enabled. This commit stops and disables Subscription units.

It also reformats the unit list to simplify adding or removing list items in the future.