### PR TITLE
Rename the audio category into multimedia

### DIFF
--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -923,7 +923,7 @@
             "web": "Web",
             "communication": "Communication",
             "security": "Security",
-            "audio": "Audio"
+            "multimedia": "Multimedia"
         },
         "images_label": "Images",
         "rootfull_app_warning_title": "Administrative privileges",


### PR DESCRIPTION
As discussed in the [forum](https://community.nethserver.org/t/ns8-logitechmediaserver-app-alpha/24608/6), a better and broader term for this is desired and there for audio should be renamed into multimedia.