### PR TITLE
Remove the image in the worker node

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/remove-module/50update
@@ -57,3 +57,7 @@ else # Rootless module
         userdel -f -r "${mid}"
     fi
 fi
+
+# Remove the podman image
+podman_image_id=$(REDIS_USER="default" redis-exec hget module/$mid/environment IMAGE_ID)
+podman rmi --ignore "$podman_image_id" || :


### PR DESCRIPTION
The PR intends to remove a local image when we remove a module both in case the module is on a worker or a leader node

https://github.com/NethServer/dev/issues/7054