### PR TITLE
Port allocation: allow to keep existing range 

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -608,7 +608,7 @@ def get_bound_domain_list(rdb, module_id=None):
     else:
         return []
 
-def allocate_ports(ports_number: int, protocol: str, module_id: str=""):
+def allocate_ports(ports_number: int, protocol: str, module_id: str="", keep_existing: bool=False):
     """
     Allocate a range of ports for a given module,
     if it is already allocated it is deallocated first.
@@ -617,6 +617,7 @@ def allocate_ports(ports_number: int, protocol: str, module_id: str=""):
     :param protocol: Protocol type ('tcp' or 'udp').
     :param module_id: Name of the module requesting the ports.
                       Parameter is optional, if not provided, default value is environment variable MODULE_ID.
+    :param keep_existing: If True, keep the existing port range for the module.
     :return: A tuple (start_port, end_port) if allocation is successful, None otherwise.
     """
 
@@ -630,7 +631,8 @@ def allocate_ports(ports_number: int, protocol: str, module_id: str=""):
         data={
             'ports': ports_number,
             'module_id': module_id,
-            'protocol': protocol
+            'protocol': protocol,
+            'keep_existing': keep_existing
         }
     )
     

--- a/core/imageroot/var/lib/nethserver/cluster/actions/clone-module/50clone_module
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/clone-module/50clone_module
@@ -69,7 +69,8 @@ allocated_range = agent.tasks.run(
     data={
         'ports': 1,
         'module_id': dmid + '_rsync',
-        'protocol': 'tcp'
+        'protocol': 'tcp',
+        'keep_existing': False
     },
     endpoint="redis://cluster-leader",
     progress_callback=agent.get_progress_callback(26,40),

--- a/core/imageroot/var/lib/nethserver/cluster/actions/clone-module/50clone_module
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/clone-module/50clone_module
@@ -75,7 +75,6 @@ allocated_range = agent.tasks.run(
     endpoint="redis://cluster-leader",
     progress_callback=agent.get_progress_callback(26,40),
 )
-agent.assert_exp(allocated_range['output'][0] == allocated_range['output'][1])
 rsyncd_port = allocated_range['output'][0] # Allocate a TCP port for rsyncd
 agent.assert_exp(rsyncd_port > 0) # valid destination port number
 
@@ -152,6 +151,5 @@ deallocated_range = agent.tasks.run(
     endpoint="redis://cluster-leader",
     progress_callback=agent.get_progress_callback(96,99),
 )
-agent.assert_exp(allocated_range['output'] == deallocated_range['output'])
 
 json.dump(add_module_result['output'], fp=sys.stdout)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/import-module/50import
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/import-module/50import
@@ -56,7 +56,8 @@ allocated_range = agent.tasks.run(
     data={
         'ports': 1,
         'module_id': dmid + '_rsync',
-        'protocol': 'tcp'
+        'protocol': 'tcp',
+        'keep_existing': False
     },
     endpoint="redis://cluster-leader",
     progress_callback=agent.get_progress_callback(26,40),

--- a/core/imageroot/var/lib/nethserver/node/actions/allocate-ports/50allocate
+++ b/core/imageroot/var/lib/nethserver/node/actions/allocate-ports/50allocate
@@ -19,6 +19,6 @@ if module_env != "" and module_env != f"module/{request['module_id']}":
     print(agent.SD_ERR + f" Agent {module_env} does not have permission to change the port allocation for {request['module_id']}.", file=sys.stderr)
     sys.exit(1)
 
-range = node.ports_manager.allocate_ports(int(request['ports']), request['module_id'], request['protocol'])
+range = node.ports_manager.allocate_ports(int(request['ports']), request['module_id'], request['protocol'], request['keep_existing'])
 
 json.dump(range, fp=sys.stdout)

--- a/core/imageroot/var/lib/nethserver/node/actions/allocate-ports/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/node/actions/allocate-ports/validate-input.json
@@ -7,7 +7,8 @@
     "required": [
         "ports",
         "module_id",
-        "protocol"
+        "protocol",
+        "keep_existing"
     ],
     "properties": {
         "ports": {
@@ -24,6 +25,11 @@
             "type": "string",
             "title": "Ports protocol",
             "enum": ["tcp", "udp"]
+        },
+        "keep_existing": {
+            "type": "boolean",
+            "title": "Keep existing ports",
+            "description": "If false, remove remove existing ports before allocating a new range"
         }
     }
 }

--- a/core/imageroot/var/lib/nethserver/node/actions/deallocate-ports/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/node/actions/deallocate-ports/validate-output.json
@@ -2,6 +2,6 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "deallocate-ports output",
     "$id": "http://schema.nethserver.org/node/deallocate-ports-output.json",
-    "description": "Return an array with old ports range deallocated",
+    "description": "Return an array of tuples, with old port ranges deallocated",
     "type": "array"
 }

--- a/docs/modules/port_allocation.md
+++ b/docs/modules/port_allocation.md
@@ -55,6 +55,9 @@ direct node API calls, as explained in the next section.
 
 The Python `agent` library provides a convenient interface for managing port allocation and deallocation, based on the node actions `allocate_ports` and `deallocate_ports`.
 
+This interface dynamically allocate and deallocate ports based on the
+module's needs without requiring direct interaction with the node's APIs.
+
 It is optional to specify the `module_id` when calling the port allocation or deallocation functions. By default, if the `module_id` is not provided, the function will automatically use the value of the `MODULE_ID` environment variable. This simplifies the function calls in common scenarios, ensuring the correct module name is used without manual input. However, if needed, you can still explicitly pass the `module_id`.
 Note that only the cluster agent can modify the port allocations of other modules.
 
@@ -95,18 +98,15 @@ If the module no longer needs the allocated ports, such as when a feature is rem
 import agent
 
 # Deallocate TCP ports for the module that is calling the function
-deallocated_ports = agent.deallocate_ports("tcp")
+deallocated_port_ranges = agent.deallocate_ports("tcp")
 ```
 or
 ```python
 import agent
 
 # Deallocate UDP ports for the "my_module" module
-deallocated_ports = agent.deallocate_ports("udp", "my_module")
+deallocated_port_ranges = agent.deallocate_ports("udp", "my_module")
 ```
 By deallocating the ports, the module frees up the resources, allowing other modules to use those ports.
 
-For more information about functions, see [Port allocation](../../core/port_allocation)
-
-These functions dynamically allocate and deallocate ports based on the module's needs without requiring direct interaction with the node's APIs.
-
+For more information about the low-level implementation of port allocation, see [Port allocation](../../core/port_allocation) in the core documentation.

--- a/docs/modules/port_allocation.md
+++ b/docs/modules/port_allocation.md
@@ -65,13 +65,26 @@ Imagine an application module that initially requires only one TCP port. Later, 
 If ports are already allocated for this module, the previous allocation will be deallocated, and the new requested range of ports will be allocated. Here’s how this can be done:
 
 ```python
+import agent
+
 # Allocate 4 TCP ports for the module that is calling the function
 allocated_ports = agent.allocate_ports(4, "tcp")
 ```
 or
 ```python
+import agent
+
 # Allocate 4 UDP ports for "my_module" module
 allocated_ports = agent.allocate_ports(4, "udp", "my_module")
+```
+
+If you want to preserve the previously allocated ports and add a new range of ports, you can use the `keep_existing` parameter:
+
+```python
+import agent
+
+# Allocate 4 more TCP ports for the module that is calling the function
+allocated_ports = agent.allocate_ports(4, "tcp", keep_existing=True)
 ```
 
 ### Deallocate ports
@@ -79,11 +92,15 @@ allocated_ports = agent.allocate_ports(4, "udp", "my_module")
 If the module no longer needs the allocated ports, such as when a feature is removed or disabled, the ports can be easily deallocated:
 
 ```python
+import agent
+
 # Deallocate TCP ports for the module that is calling the function
 deallocated_ports = agent.deallocate_ports("tcp")
 ```
 or
 ```python
+import agent
+
 # Deallocate UDP ports for the "my_module" module
 deallocated_ports = agent.deallocate_ports("udp", "my_module")
 ```


### PR DESCRIPTION
Improve existing allocate port method to ease the update of complex modules.

Issue referencec:
- NethServer/dev#6974
- NethServer/dev#7035

Tested with NethSecurity Controller update: https://github.com/NethServer/ns8-nethsecurity-controller/pull/44
