### PR TITLE
Compare and remove outdated  image versions

### DIFF
--- a/core/imageroot/usr/local/agent/actions/update-module/95cleanup_images
+++ b/core/imageroot/usr/local/agent/actions/update-module/95cleanup_images
@@ -15,7 +15,7 @@ for image_old in os.environ:
     if not image_old.startswith('PREV_'):
         continue # not a PREV image key, skip it.
 
-    if not (image_old.endswith('_IMAGE') or image_old.endswith('_URL')):
+    if not image_old.endswith('_IMAGE'):
         continue # we want to skip *DIGEST and ID keys
 
     # Check if the new image is different
@@ -24,9 +24,9 @@ for image_old in os.environ:
         print(f"Removing {os.environ.get(image_old)} (differs from {os.environ.get(image_new)})", file=sys.stderr)
         agent.run_helper('podman', 'image', 'rm', os.environ.get(image_old))
 
-    # Handle removal of the old image URL
-    elif image_old == 'PREV_IMAGE_URL':
-        image_new = image_old.removeprefix('PREV_')
-        if os.environ.get(image_new) != os.environ.get(image_old):
-            print(f"Removing {os.environ.get(image_old)} (differs from {os.environ.get(image_new)})", file=sys.stderr)
-            agent.run_helper('podman', 'image', 'rm', os.environ[image_old])
+# Handle removal of the old image URL
+image_old = 'PREV_IMAGE_URL'
+image_new = 'IMAGE_URL'
+if os.environ.get(image_new) != os.environ.get(image_old):
+    print(f"Removing {os.environ.get(image_old)} (differs from {os.environ.get(image_new)})", file=sys.stderr)
+    agent.run_helper('podman', 'image', 'rm', os.environ[image_old])

--- a/core/imageroot/usr/local/agent/actions/update-module/95cleanup_images
+++ b/core/imageroot/usr/local/agent/actions/update-module/95cleanup_images
@@ -1,29 +1,32 @@
-#!/bin/bash
+#!/usr/bin/env python3
 
 #
-# Copyright (C) 2023 Nethesis S.r.l.
+# Copyright (C) 2024 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-exec 1>&2
-set -e
+import os
+import agent
+import sys
 
-# Clean up local images that are no longer required by the new module
-# version
+# Iterate over environment variables
+for image_old in os.environ:
 
-export LC_ALL=C # required by sort for portability
+    if not image_old.startswith('PREV_'):
+        continue # not a PREV image key, skip it.
 
-# Find the images that are no longer required:
-# retrieve from env all variable with the prefix PREV_
-# remove not used images like PREV_*_IMAGE if !== *_IMAGE
-# ignore errors and exit with successful exit status
-for imageOld in ${!PREV_*}; do
-  if [[ $imageOld =~ _IMAGE$ ]]; then
-      # remove the prefix to compare PREV_*_IMAGE != *_IMAGE
-      imageNew=${imageOld##PREV_}
-      # if not the same we remove the image
-      if [[ "${!imageNew}" != "${!imageOld}" ]]; then
-          podman image rm "${!imageOld}" 2>/dev/null || :
-      fi
-  fi
-done
+    if not (image_old.endswith('_IMAGE') or image_old.endswith('_URL')):
+        continue # we want to skip *DIGEST and ID keys
+
+    # Check if the new image is different
+    image_new = image_old.removeprefix('PREV_')
+    if os.environ.get(image_new) != os.environ.get(image_old):
+        print(f"Removing {os.environ.get(image_old)} (differs from {os.environ.get(image_new)})", file=sys.stderr)
+        agent.run_helper('podman', 'image', 'rm', os.environ.get(image_old))
+
+    # Handle removal of the old image URL
+    elif image_old == 'PREV_IMAGE_URL':
+        image_new = image_old.removeprefix('PREV_')
+        if os.environ.get(image_new) != os.environ.get(image_old):
+            print(f"Removing {os.environ.get(image_old)} (differs from {os.environ.get(image_new)})", file=sys.stderr)
+            agent.run_helper('podman', 'image', 'rm', os.environ[image_old])

--- a/core/imageroot/usr/local/agent/actions/update-module/96cleanup_core_images
+++ b/core/imageroot/usr/local/agent/actions/update-module/96cleanup_core_images
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import subprocess
+import agent
+import sys
+
+def get_podman_images():
+    result = subprocess.run(['podman', 'images', '--format', '{{.Repository}}:{{.Tag}}'],
+                            stdout=subprocess.PIPE, text=True)
+    image_list = result.stdout.splitlines()
+    images = {}
+    for img in image_list:
+        image_name, tag = img.rsplit(':', 1)
+        images[image_name] = tag
+    return images
+
+def parse_core_images(core_images):
+    parsed_images = {}
+    for key, value in core_images.items():
+        if not key.endswith('_IMAGE'):  
+            continue # skip non-image variables  
+        image_name, tag = value.rsplit(':', 1)
+        parsed_images[image_name] = tag
+    return parsed_images
+
+def remove_versions(core_images, podman_images):
+    for image_name, core_version in core_images.items():
+        podman_version = podman_images.get(image_name)
+        if podman_version and podman_version != core_version:
+            print(f"Removing {image_name}:{podman_version} (differs from {core_version})", file=sys.stderr)
+            agent.run_helper('podman', 'rmi', '--ignore', f'{image_name}:{podman_version}')
+
+# Read the environment file using the agent module
+version_images = agent.read_envfile('/etc/nethserver/core.env')
+
+# Parse the core images to extract image names and versions
+core_images = parse_core_images(version_images)
+
+# retrieve the images from podman
+podman_images = get_podman_images()
+
+# Remove the images that are no longer required
+remove_versions(core_images, podman_images)


### PR DESCRIPTION
This pull request adds a script that compares the Docker/Podman images defined in the environment file with the currently installed images in Podman.

The script retrieves the list of existing images and their versions, and then compares them with the versions specified in the environment file. If a Podman image has a version lower than the one specified in the environment file, it is automatically removed.

https://github.com/NethServer/dev/issues/7073