### PR TITLE
Inhibit automated updates during NS7 migration

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/bin/apply-updates
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/apply-updates
@@ -18,7 +18,7 @@ rdb = agent.redis_connect()
 for kflags in rdb.keys('node/*/flags'):
     if bool(rdb.sismember(kflags, 'nomodules')):
         node_id = kflags.removesuffix('/flags')
-        print(agent.SD_NOTICE + f"Skipping updates: NS7 {node_id} is part of the cluster.")
+        print(agent.SD_NOTICE + f"Skipping updates: NS7 {node_id} is part of the cluster.", file=sys.stderr)
         sys.exit(0)
 
 # Find cluster nodes from the index key. Any NS8 node has at least a


### PR DESCRIPTION
Skip the nightly apply-updates process if a NS7 node is part of the cluster to prevent unintended updates during migration.

Refs NethServer/dev#7070