### PR TITLE
Remove previous image in module update on leader

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
@@ -119,6 +119,10 @@ for idx, retval in enumerate(update_retvals):
         os.rename(appspath + mid, appspath + mid + dsfx + '~')
         os.rename(appspath + mid + dsfx, appspath + mid)
         agent.run_helper('rm', '-rf', appspath + mid + dsfx + '~')
+        # Remove the previous image
+        previous_image_id = rdb.hget(f'module/{mid}/environment', 'PREV_IMAGE_URL')
+        if previous_image_id:
+            agent.run_helper("podman", "rmi", "--ignore", previous_image_id)
     except Exception as ex:
         print(agent.SD_ERR + f"Module UI update failed for instance {mid}: {ex}", file=sys.stderr)
         errors += 1

--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
@@ -119,7 +119,7 @@ for idx, retval in enumerate(update_retvals):
         os.rename(appspath + mid, appspath + mid + dsfx + '~')
         os.rename(appspath + mid + dsfx, appspath + mid)
         agent.run_helper('rm', '-rf', appspath + mid + dsfx + '~')
-        # Remove the previous image
+        # Remove the previous image, we do not need anymore
         previous_image_id = rdb.hget(f'module/{mid}/environment', 'PREV_IMAGE_URL')
         if previous_image_id:
             agent.run_helper("podman", "rmi", "--ignore", previous_image_id)


### PR DESCRIPTION
This pull request removes the previous image in the module update on leader. The previous image URL is no longer needed and is now being removed.