### PR TITLE
fix: remove v-html from CLM modal

### DIFF
--- a/core/ui/src/components/settings/CloudLogManagerConfigureModal.vue
+++ b/core/ui/src/components/settings/CloudLogManagerConfigureModal.vue
@@ -49,9 +49,7 @@
           :invalid-message="error.tenant"
         >
           <template slot="tooltip">
-            <span
-              v-html="$t('cloud_log_manager_forwarder.tenant_tooltip')"
-            ></span>
+            <span>{{ $t("cloud_log_manager_forwarder.tenant_tooltip") }}</span>
           </template>
         </NsTextInput>
         <div v-if="toggleEnabled && this.configuration.last_timestamp != ''">

--- a/core/ui/src/components/software-center/AppList.vue
+++ b/core/ui/src/components/software-center/AppList.vue
@@ -258,7 +258,7 @@ export default {
     },
     showSoftwareCenterCoreApps() {
       this.$router.push("/software-center/SoftwareCenterCoreApps");
-    }
+    },
   },
 };
 </script>

--- a/core/ui/src/views/InitializeCluster.vue
+++ b/core/ui/src/views/InitializeCluster.vue
@@ -1899,7 +1899,7 @@ export default {
 @import "../styles/carbon-utils";
 
 .welcome-grid {
-  max-width: 70rem;
+  max-width: 56rem;
 }
 
 .bx--form .bx--form-item {

--- a/core/ui/src/views/Login.vue
+++ b/core/ui/src/views/Login.vue
@@ -6,7 +6,7 @@
   <div>
     <div class="bx--grid bx--grid--full-width login-bg">
       <div class="bx--row">
-        <div class="bx--offset-md-1 bx--col-md-6 bx--offset-lg-4 bx--col-lg-8">
+        <div class="bx--offset-md-1 bx--col-md-6 bx--offset-lg-4 bx--col-lg-8 bx--col-xlg-6 bx--offset-xlg-5">
           <div class="test">
             <cv-tile :light="true" class="login-tile">
               <h2 class="login-title">{{ $t("login.title") }}</h2>

--- a/core/ui/src/views/SoftwareCenterCoreApps.vue
+++ b/core/ui/src/views/SoftwareCenterCoreApps.vue
@@ -231,7 +231,6 @@ export default {
     showAppInfo(app) {
       this.appInfo.isShown = true;
       this.appInfo.app = app;
-
     },
     updateTableData() {
       this.tableColumns = this.isCoreUpdatable


### PR DESCRIPTION
Remove unnecessary (and potentially dangerous) `v-html` from CloudLogManagerConfigureModal template.

Other changes:
- Reduce max-width of initialize cluster page
- Reduce max-width of login form on large screens
- Format code