### PR TITLE
style: resume max-width rule for form fields

### DIFF
--- a/core/ui/src/styles/_core.scss
+++ b/core/ui/src/styles/_core.scss
@@ -558,6 +558,18 @@ a {
   max-width: 12rem;
 }
 
+// styles for large devices
+@media (min-width: $breakpoint-medium) {
+  // limit form fields width on large devices
+  .bx--text-input,
+  .bx--text-input__field-wrapper,
+  .cv-select,
+  .cv-multi-select,
+  .cv-combo-box {
+    max-width: 38rem;
+  }
+}
+
 // fix padding of number input
 .bx--number input[type="number"] {
   padding-right: 5rem;

--- a/core/ui/src/views/Login.vue
+++ b/core/ui/src/views/Login.vue
@@ -6,7 +6,9 @@
   <div>
     <div class="bx--grid bx--grid--full-width login-bg">
       <div class="bx--row">
-        <div class="bx--offset-md-1 bx--col-md-6 bx--offset-lg-4 bx--col-lg-8 bx--col-xlg-6 bx--offset-xlg-5">
+        <div
+          class="bx--offset-md-1 bx--col-md-6 bx--offset-lg-4 bx--col-lg-8 bx--offset-xlg-5 bx--col-xlg-6 bx--offset-max-6 bx--col-max-4"
+        >
           <div class="test">
             <cv-tile :light="true" class="login-tile">
               <h2 class="login-title">{{ $t("login.title") }}</h2>


### PR DESCRIPTION
Resume max-width rule for form fields on large screens.
This rule was previously removed but had a negative effect on several pages.

Before this PR:
![image](https://github.com/user-attachments/assets/6aded5d6-bfbe-45fa-8f87-2573a7587e2e)

After this PR:
![image](https://github.com/user-attachments/assets/da1aab4f-61ac-4229-b998-653cd0d98fe6)

Other changes:
- Improve style of login form on large screens