### PR TITLE
Check ports allocation for NS8 Modules

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/add-module/50update
@@ -129,6 +129,10 @@ os.mkdir(f'/var/lib/nethserver/cluster/ui/apps/{module_id}')
 os.chdir(f'/var/lib/nethserver/cluster/ui/apps/{module_id}')
 agent.run_helper('extract-ui', image_url).check_returncode()
 
+# Write on redis image ports demands
+rdb.hset('cluster/tcp_ports_demand', mapping={module_id: tcp_ports_demand})
+rdb.hset('cluster/udp_ports_demand', mapping={module_id: udp_ports_demand})
+
 # Wait for the module host to set up the module environment: it
 # has to return us the module password hash
 add_module_result = agent.tasks.run(

--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
@@ -55,10 +55,22 @@ else:
 
 # Retrieve the image org.nethserver.authorizations label
 with subprocess.Popen(['podman', 'image', 'inspect', image_url], stdout=subprocess.PIPE, stderr=sys.stderr) as proc:
+    inspect = json.load(proc.stdout)
+    inspect_labels = inspect[0]['Labels']
     try:
-        authorizations = json.load(proc.stdout)[0]['Labels']['org.nethserver.authorizations'].split()
+        authorizations = inspect_labels['org.nethserver.authorizations'].split()
     except:
         authorizations = []
+        
+if 'org.nethserver.tcp-ports-demand' in inspect_labels:
+    tcp_ports_demand = int(inspect_labels['org.nethserver.tcp-ports-demand'])
+else:
+    tcp_ports_demand = 0
+
+if 'org.nethserver.udp-ports-demand' in inspect_labels:
+    udp_ports_demand = int(inspect_labels['org.nethserver.udp-ports-demand'])
+else:
+    udp_ports_demand = 0
 
 # Run sanity checks on the org.nethserver.authorizations label:
 if not cluster.grants.check_authorizations_sanity(authorizations):
@@ -68,6 +80,11 @@ if not cluster.grants.check_authorizations_sanity(authorizations):
 # Start the module update on each instance
 update_tasks = []
 for module_id in instances:
+    
+    # Write on redis image ports demands
+    rdb.hset('cluster/tcp_ports_demand', mapping={module_id: tcp_ports_demand})
+    rdb.hset('cluster/udp_ports_demand', mapping={module_id: udp_ports_demand})
+    
     if authorizations:
         # Replace existing authorizations with the new image:
         rdb.delete(f'cluster/authorizations/module/{module_id}')


### PR DESCRIPTION
This pull request adds a check to the port allocation library to ensure modules don’t request more ports than allowed. When a module is installed, its maximum required TCP and UDP ports are stored in Redis. Then, when allocating new ports, the system checks that the total number of allocated ports plus the requested ports doesn’t exceed this limit. This prevents over-allocation and keeps port usage within safe limits.