### PR TITLE
Add events for support session start/stop

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/start-support-session/51publish_event
+++ b/core/imageroot/var/lib/nethserver/node/actions/start-support-session/51publish_event
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+import json
+
+node_id = os.environ['NODE_ID']
+session_id = agent.read_envfile("support.env").get("VPN_PASSWORD")
+support_user = agent.redis_connect().hget("cluster/subscription", "support_user")
+
+agent.redis_connect(privileged=True).publish("node/" + node_id + "/event/support-session-started", json.dumps({
+    "reason": os.getenv("AGENT_TASK_ACTION", "unknown"),
+    "node_id": node_id,
+    "session_id": session_id,
+    "support_user": support_user,
+}))

--- a/core/imageroot/var/lib/nethserver/node/actions/stop-support-session/51publish_event
+++ b/core/imageroot/var/lib/nethserver/node/actions/stop-support-session/51publish_event
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+import json
+
+node_id = os.environ['NODE_ID']
+session_id = agent.read_envfile("support.env").get("VPN_PASSWORD")
+support_user = agent.redis_connect().hget("cluster/subscription", "support_user")
+
+agent.redis_connect(privileged=True).publish("node/" + node_id + "/event/support-session-stopped", json.dumps({
+    "reason": os.getenv("AGENT_TASK_ACTION", "unknown"),
+    "node_id": node_id,
+    "session_id": session_id,
+    "support_user": support_user,
+}))


### PR DESCRIPTION
Introduce two new steps to handle the publishing of events for starting and stopping support sessions. The scripts retrieve necessary information such as node ID, session ID, and support user from environment variables and Redis.
They publish events to the Redis channel to notify about the support session status.

- Created `51publish_event` in `start-support-session` to publish `support-session-started` events.
- Created `51publish_event` in `stop-support-session` to  publish `support-session-stopped` events.

https://github.com/NethServer/dev/issues/7095