### PR TITLE
Fix node/allocate-ports regression

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/allocate-ports/50allocate
+++ b/core/imageroot/var/lib/nethserver/node/actions/allocate-ports/50allocate
@@ -43,7 +43,7 @@ else:
     ports_used = 0 + request['ports']
 
 # Check if the total required ports exceed the allowed number of ports
-if ports_used > ports_demand:
+if module_env != "" and ports_used > ports_demand:
     print(agent.SD_ERR + f"Cannot allocate {ports_used} {request['protocol']} ports to {request['module_id']}. Max allowed is {ports_demand}.", file=sys.stderr)
     agent.set_status('validation-failed')
     json.dump([{'field':'ports', 'parameter':'ports', 'value': request['ports'], 'error':'max_ports_exceeded'}], fp=sys.stdout)


### PR DESCRIPTION
The core cannot allocate the additional TCP port for Rsync during NS7 migration.

Refs NethServer/dev#7092