### PR TITLE
Avoid docker.io rate limit failures

### DIFF
--- a/core/imageroot/etc/containers/registries.conf.d/800-nethserver.conf
+++ b/core/imageroot/etc/containers/registries.conf.d/800-nethserver.conf
@@ -1,0 +1,8 @@
+#
+# Try NethServer mirrors before going to docker.io
+#
+[[registry]]
+location = "docker.io"
+
+[[registry.mirror]]
+location = "ghcr.io/nethserver/docker.io"


### PR DESCRIPTION
Try NethServer mirror on ghcr.io before going to docker.io. This configuration is applied to Podman Buildah and Skopeo tools.

Refs NethServer/dev#7160