### PR TITLE
Force restart of subscription services

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/update-core.d/30restart_subscription
+++ b/core/imageroot/var/lib/nethserver/node/update-core.d/30restart_subscription
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2023 Nethesis S.r.l.
+# Copyright (C) 2024 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 


### PR DESCRIPTION
The Subscription services, node-monitor and send-heartbeat must be restarted after the core update, to execute the new version.

See also https://nethserver.github.io/ns8-core/core/subscription/

Refs https://github.com/NethServer/dev/issues/6815