### PR TITLE
fix(ui): support for preventing app installation

### DIFF
--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -951,8 +951,11 @@
         "cannot_install_app_on_node": "Cannot install {app} {version} on {node}",
         "no_node_eligible_for_app_installation": "No node is eligible for app installation",
         "no_node_eligible_for_instance_cloning": "No node is eligible for instance cloning",
-        "no_node_eligible_for_instance_migration": "No node is eligible for instance migration"
-
+        "no_node_eligible_for_instance_migration": "No node is eligible for instance migration",
+        "no_version_reason": {
+            "core_version_too_low": "Update core to version {core_min} or higher to install an instance of this app",
+            "rootfull_certification_level_too_low": "Apps with administrative privileges must have a minimum certification level of {certification_min}/5 to be installed"
+        }
     },
     "system_logs": {
         "title": "System logs",

--- a/core/ui/src/components/software-center/AppInfoModal.vue
+++ b/core/ui/src/components/software-center/AppInfoModal.vue
@@ -74,7 +74,7 @@
               {{ $t("software_center.latest_version") }}
             </span>
             <span class="value">
-              {{ app.versions.length ? app.versions[0].tag : "latest" }}
+              {{ app.versions.length ? app.versions[0].tag : "-" }}
               <span v-if="app.upstream_name"> ({{ app.upstream_name }}) </span>
             </span>
           </div>
@@ -176,7 +176,11 @@ export default {
   },
   computed: {
     appImages() {
-      if (this.app && this.app.versions[0]["labels"]["org.nethserver.images"]) {
+      if (
+        this.app &&
+        this.app.versions.length &&
+        this.app.versions[0]["labels"]["org.nethserver.images"]
+      ) {
         return this.app.versions[0]["labels"]["org.nethserver.images"]
           .trim()
           .replace(/\s+/g, " ")

--- a/core/ui/src/components/software-center/AppList.vue
+++ b/core/ui/src/components/software-center/AppList.vue
@@ -124,13 +124,34 @@
           </div>
           <div v-else class="app-row">
             <!-- app is not installed -->
-            <NsButton
-              kind="secondary"
-              size="field"
-              :icon="Download20"
-              @click="installInstance(app)"
-              >{{ $t("software_center.install") }}</NsButton
-            >
+            <div class="flex items-center">
+              <NsButton
+                kind="secondary"
+                size="field"
+                :icon="Download20"
+                :disabled="!app.versions.length"
+                @click="installInstance(app)"
+                >{{ $t("software_center.install") }}</NsButton
+              >
+              <cv-interactive-tooltip
+                v-if="app.no_version_reason && app.no_version_reason.message"
+                alignment="center"
+                direction="bottom"
+                class="info mg-left-sm"
+              >
+                <template slot="trigger">
+                  <Information16 />
+                </template>
+                <template slot="content">
+                  {{
+                    $t(
+                      `software_center.no_version_reason.${app.no_version_reason.message}`,
+                      app.no_version_reason.params
+                    )
+                  }}
+                </template>
+              </cv-interactive-tooltip>
+            </div>
           </div>
         </cv-tile>
       </div>
@@ -148,10 +169,11 @@
 import { IconService, UtilService } from "@nethserver/ns8-ui-lib";
 import AppInfoModal from "./AppInfoModal";
 import CertificationLevelBadge from "./CertificationLevelBadge.vue";
+import Information16 from "@carbon/icons-vue/es/information/16";
 
 export default {
   name: "AppList",
-  components: { AppInfoModal, CertificationLevelBadge },
+  components: { AppInfoModal, CertificationLevelBadge, Information16 },
   mixins: [IconService, UtilService],
   props: {
     apps: {

--- a/core/ui/src/components/software-center/InstallAppModal.vue
+++ b/core/ui/src/components/software-center/InstallAppModal.vue
@@ -166,7 +166,7 @@ export default {
       if (this.app.versions.length) {
         return this.app.versions[0].tag;
       } else {
-        return "latest";
+        return "-";
       }
     },
     canInstallOnSingleNode() {

--- a/core/ui/src/styles/_utils.scss
+++ b/core/ui/src/styles/_utils.scss
@@ -4,6 +4,10 @@
   display: flex;
 }
 
+.inline-flex {
+  display: inline-flex;
+}
+
 .flex-row {
   flex-direction: row;
 }

--- a/core/ui/src/views/SoftwareCenterAppInstances.vue
+++ b/core/ui/src/views/SoftwareCenterAppInstances.vue
@@ -95,13 +95,36 @@
             class="mg-right-sm"
             >{{ $t("software_center.update_all_instances") }}
           </NsButton>
-          <NsButton
+          <div
             v-if="app.installed && app.installed.length"
-            kind="secondary"
-            :icon="Download20"
-            @click="installInstance()"
-            >{{ $t("software_center.install_new_instance") }}
-          </NsButton>
+            class="flex items-center"
+          >
+            <NsButton
+              kind="secondary"
+              :icon="Download20"
+              :disabled="!app.versions.length"
+              @click="installInstance()"
+              >{{ $t("software_center.install_new_instance") }}
+            </NsButton>
+            <cv-interactive-tooltip
+              v-if="app.no_version_reason && app.no_version_reason.message"
+              alignment="center"
+              direction="bottom"
+              class="info mg-left-sm"
+            >
+              <template slot="trigger">
+                <Information16 />
+              </template>
+              <template slot="content">
+                {{
+                  $t(
+                    `software_center.no_version_reason.${app.no_version_reason.message}`,
+                    app.no_version_reason.params
+                  )
+                }}
+              </template>
+            </cv-interactive-tooltip>
+          </div>
         </cv-column>
       </cv-row>
       <cv-row>
@@ -124,12 +147,33 @@
         <cv-column v-else-if="!app.installed.length">
           <NsEmptyState :title="$t('software_center.no_instance_installed')">
             <template #description>
-              <NsButton
-                kind="primary"
-                :icon="Download20"
-                @click="installInstance()"
-                >{{ $t("software_center.install_new_instance") }}
-              </NsButton>
+              <div class="inline-flex items-center">
+                <NsButton
+                  kind="primary"
+                  :icon="Download20"
+                  :disabled="!app.versions.length"
+                  @click="installInstance()"
+                  >{{ $t("software_center.install_new_instance") }}
+                </NsButton>
+                <cv-interactive-tooltip
+                  v-if="app.no_version_reason && app.no_version_reason.message"
+                  alignment="center"
+                  direction="bottom"
+                  class="info mg-left-sm"
+                >
+                  <template slot="trigger">
+                    <Information16 />
+                  </template>
+                  <template slot="content">
+                    {{
+                      $t(
+                        `software_center.no_version_reason.${app.no_version_reason.message}`,
+                        app.no_version_reason.params
+                      )
+                    }}
+                  </template>
+                </cv-interactive-tooltip>
+              </div>
             </template>
           </NsEmptyState>
         </cv-column>
@@ -416,10 +460,16 @@ import {
 import { mapState, mapActions } from "vuex";
 import CloneOrMoveAppModal from "@/components/software-center/CloneOrMoveAppModal";
 import UpdateAppModal from "../components/software-center/UpdateAppModal";
+import Information16 from "@carbon/icons-vue/es/information/16";
 
 export default {
   name: "SoftwareCenterAppInstances",
-  components: { InstallAppModal, CloneOrMoveAppModal, UpdateAppModal },
+  components: {
+    InstallAppModal,
+    CloneOrMoveAppModal,
+    UpdateAppModal,
+    Information16,
+  },
   mixins: [
     TaskService,
     UtilService,


### PR DESCRIPTION
If an app in the sofware center has no version available, disable the installation button and display a tooltip explaining the reason.

![image](https://github.com/user-attachments/assets/a21681a1-a640-4d9f-ab22-fadd85521ef3)

![image](https://github.com/user-attachments/assets/4392c242-4fa4-48e2-a561-d8414dc699e2)


Ref:
- https://github.com/NethServer/dev/issues/7211