### PR TITLE
feat(phonehome): add new info

### DIFF
--- a/core/imageroot/etc/systemd/system/phonehome.service
+++ b/core/imageroot/etc/systemd/system/phonehome.service
@@ -3,4 +3,4 @@ Description=PhoneHome
 
 [Service]
 Type=oneshot
-ExecStart=runagent phonehome
+ExecStart=runagent send-phonehome

--- a/core/imageroot/usr/local/agent/pypkg/cluster/inventory.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/inventory.py
@@ -1,0 +1,81 @@
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import cluster.modules
+import agent
+
+def subscription_fact():
+    ret = {"subscription": ""}
+    rdb = agent.redis_connect(use_replica=True)
+    provider = rdb.hget('cluster/subscription', 'provider')
+    if provider == "nsent":
+        ret["subscription"] = "enterprise"
+    elif provider == "nscom":
+        ret["subscription"] = "community"
+    else:
+        ret["subscription"] = "disabled"
+
+    return ret
+
+def cluster_facts():
+    result = agent.tasks.run(
+        agent_id='cluster',
+        action='get-facts',
+        extra={
+            'isNotificationHidden': True,
+        },
+        endpoint="redis://cluster-leader"
+    )
+
+    if result['exit_code'] == 0:
+        return result['output']
+    else:
+        print(agent.SD_ERR + f"cluster/get-facts failed", file=sys.stderr)
+        return None
+ 
+def modules_facts():
+    ret = []
+    rdb = agent.redis_connect(use_replica=True)
+    installed_modules = cluster.modules.list_installed(rdb, skip_core_modules = False)
+    instance_list = list(mi for module_instances in installed_modules.values() for mi in module_instances)
+
+    # Collect facts from modules:
+    for module in instance_list:
+        minfo = {"id": module.get('id'), "version": module.get("version"), "name": module.get("module"), "node": module.get("node") } 
+
+        list_actions_result = agent.tasks.run(
+            agent_id='module/' + module.get('id'),
+            action='list-actions',
+            extra={
+                'isNotificationHidden': True,
+            },
+            endpoint="redis://cluster-leader",
+        )
+
+        if not list_actions_result or list_actions_result['exit_code'] != 0:
+            print(agent.SD_WARNING + f"module/{module.get('id')}/list-actions failed", file=sys.stderr)
+            return None
+        
+        if 'get-facts' in list_actions_result.get('output', []):
+
+            get_facts_result = agent.tasks.run(
+                agent_id='module/' + module.get('id'),
+                action='get-facts',
+                extra={ 'isNotificationHidden': True },
+                endpoint="redis://cluster-leader",
+            )
+
+            if get_facts_result['exit_code'] != 0:
+                print(agent.SD_WARNING, f"get-facts failed for {module.get('id')}", file=sys.stderr)
+                continue
+
+            ofacts = get_facts_result['output']
+            # merge info from get-facts
+            minfo.update(ofacts)
+
+        ret.append(minfo)
+
+    return ret

--- a/core/imageroot/usr/local/agent/pypkg/cluster/inventory.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/inventory.py
@@ -3,13 +3,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-import sys
-import cluster.modules
+import os
 import agent
 
-def fact_subscription():
-    ret = {"subscription": ""}
-    rdb = agent.redis_connect(use_replica=True)
+def fact_subscription(rdb):
+    # Get subscription status
     provider = rdb.hget('cluster/subscription', 'provider')
     if provider == "nsent":
         return "enterprise"
@@ -18,11 +16,9 @@ def fact_subscription():
     else:
         return "disabled"
 
-
-def fact_admins():
-    rdb = agent.redis_connect(privileged=True)
+def fact_admins(rdb):
+    # Count admin users and users with 2FA enabled
     users = {"count": 0, "2fa": 0}
-    # get all user keys
     for ukey in rdb.scan_iter('user/*'):
         users["count"] += 1
         two_fa = rdb.hget(ukey, '2fa')
@@ -30,66 +26,22 @@ def fact_admins():
             users["2fa"] += 1
     return users
 
-
-def cluster_facts():
-    result = agent.tasks.run(
-        agent_id='cluster',
-        action='get-facts',
-        extra={
-            'isNotificationHidden': True,
-        },
-        endpoint="redis://cluster-leader"
-    )
-
-    if result['exit_code'] == 0:
-        return result['output']
-    else:
-        print(agent.SD_ERR + f"cluster/get-facts failed", file=sys.stderr)
-        return None
- 
-def modules_facts():
+def fact_repositories(rdb):
+    # List enabled repositories
     ret = []
-    rdb = agent.redis_connect(use_replica=True)
-    installed_modules = cluster.modules.list_installed(rdb, skip_core_modules = False)
-    instance_list = list(mi for module_instances in installed_modules.values() for mi in module_instances)
-
-    # Collect facts from modules:
-    for module in instance_list:
-        minfo = {"id": module.get('id'), "version": module.get("version"), "name": module.get("module"), "node": module.get("node") } 
-
-        try:
-            list_actions_result = agent.tasks.run(
-                agent_id='module/' + module.get('id'),
-                action='list-actions',
-                extra={
-                    'isNotificationHidden': True,
-                },
-                endpoint="redis://cluster-leader",
-            )
-
-            if not list_actions_result or list_actions_result['exit_code'] != 0:
-                print(agent.SD_WARNING + f"module/{module.get('id')}/list-actions failed", file=sys.stderr)
-                raise Exception("list-actions failed")
-            
-            if 'get-facts' in list_actions_result.get('output', []):
-
-                get_facts_result = agent.tasks.run(
-                    agent_id='module/' + module.get('id'),
-                    action='get-facts',
-                    extra={ 'isNotificationHidden': True },
-                    endpoint="redis://cluster-leader",
-                )
-
-                if get_facts_result['exit_code'] != 0:
-                    print(agent.SD_WARNING, f"get-facts failed for {module.get('id')}", file=sys.stderr)
-                    raise Exception("get-facts failed")
-
-                ofacts = get_facts_result['output']
-                # merge info from get-facts
-                minfo.update(ofacts)
-        except:
-            pass
-        finally:
-            ret.append(minfo)
-
+    for m in rdb.scan_iter('cluster/repository/*'):
+        repo = rdb.hgetall(m)
+        if repo.get("status") == "1":
+            ret.append(os.path.basename(m))
     return ret
+
+def fact_smarthost(rdb):
+    # Get smarthost configuration
+    manual_configuration = True
+    smtp = agent.get_smarthost_settings(rdb)
+    # we query all the list of service provider
+    for key in agent.list_service_providers(rdb,'submission','tcp'):
+        if manual_configuration == True:
+            # no need to check the rest of the list if manual_configuration == False
+            manual_configuration = False if key['host'] == smtp['host'] and str(smtp['port']) == "25" else True
+    return{"enabled": smtp["enabled"], "manual_configuration": manual_configuration}

--- a/core/imageroot/usr/local/agent/pypkg/cluster/inventory.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/inventory.py
@@ -7,18 +7,29 @@ import sys
 import cluster.modules
 import agent
 
-def subscription_fact():
+def fact_subscription():
     ret = {"subscription": ""}
     rdb = agent.redis_connect(use_replica=True)
     provider = rdb.hget('cluster/subscription', 'provider')
     if provider == "nsent":
-        ret["subscription"] = "enterprise"
+        return "enterprise"
     elif provider == "nscom":
-        ret["subscription"] = "community"
+        return "community"
     else:
-        ret["subscription"] = "disabled"
+        return "disabled"
 
-    return ret
+
+def fact_admins():
+    rdb = agent.redis_connect(privileged=True)
+    users = {"count": 0, "2fa": 0}
+    # get all user keys
+    for ukey in rdb.scan_iter('user/*'):
+        users["count"] += 1
+        two_fa = rdb.hget(ukey, '2fa')
+        if two_fa:
+            users["2fa"] += 1
+    return users
+
 
 def cluster_facts():
     result = agent.tasks.run(
@@ -46,36 +57,39 @@ def modules_facts():
     for module in instance_list:
         minfo = {"id": module.get('id'), "version": module.get("version"), "name": module.get("module"), "node": module.get("node") } 
 
-        list_actions_result = agent.tasks.run(
-            agent_id='module/' + module.get('id'),
-            action='list-actions',
-            extra={
-                'isNotificationHidden': True,
-            },
-            endpoint="redis://cluster-leader",
-        )
-
-        if not list_actions_result or list_actions_result['exit_code'] != 0:
-            print(agent.SD_WARNING + f"module/{module.get('id')}/list-actions failed", file=sys.stderr)
-            return None
-        
-        if 'get-facts' in list_actions_result.get('output', []):
-
-            get_facts_result = agent.tasks.run(
+        try:
+            list_actions_result = agent.tasks.run(
                 agent_id='module/' + module.get('id'),
-                action='get-facts',
-                extra={ 'isNotificationHidden': True },
+                action='list-actions',
+                extra={
+                    'isNotificationHidden': True,
+                },
                 endpoint="redis://cluster-leader",
             )
 
-            if get_facts_result['exit_code'] != 0:
-                print(agent.SD_WARNING, f"get-facts failed for {module.get('id')}", file=sys.stderr)
-                continue
+            if not list_actions_result or list_actions_result['exit_code'] != 0:
+                print(agent.SD_WARNING + f"module/{module.get('id')}/list-actions failed", file=sys.stderr)
+                raise Exception("list-actions failed")
+            
+            if 'get-facts' in list_actions_result.get('output', []):
 
-            ofacts = get_facts_result['output']
-            # merge info from get-facts
-            minfo.update(ofacts)
+                get_facts_result = agent.tasks.run(
+                    agent_id='module/' + module.get('id'),
+                    action='get-facts',
+                    extra={ 'isNotificationHidden': True },
+                    endpoint="redis://cluster-leader",
+                )
 
-        ret.append(minfo)
+                if get_facts_result['exit_code'] != 0:
+                    print(agent.SD_WARNING, f"get-facts failed for {module.get('id')}", file=sys.stderr)
+                    raise Exception("get-facts failed")
+
+                ofacts = get_facts_result['output']
+                # merge info from get-facts
+                minfo.update(ofacts)
+        except:
+            pass
+        finally:
+            ret.append(minfo)
 
     return ret

--- a/core/imageroot/var/lib/nethserver/cluster/actions/get-facts/50get
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/get-facts/50get
@@ -1,57 +1,25 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2023 Nethesis S.r.l.
+# Copyright (C) 2025 Nethesis S.r.l.
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 
 '''
-Get the facts for each of the agents below the cluster.
+Get the facts about the cluster itself.
 '''
 
 import json
 import sys
-
+from cluster import inventory
 import agent
-import agent.tasks
 
-# setup redis connection
-redis_client = agent.redis_connect(privileged=True)
+rdb = agent.redis_connect(privileged=True, use_replica=True)
 
-# Init dictionary that returns the data
 facts = {
-    '$schema': 'https://schema.nethserver.org/facts/2022-12.json',
-    'uuid': '',
-    'installation': 'nethserver',
-    'facts': {
-        'cluster': [],
-        'nodes': {},
-        'modules': []
-    }
+    'subscription': inventory.fact_subscription(rdb),
+    'admins': inventory.fact_admins(rdb),
+    'repositories': inventory.fact_repositories(rdb),
+    'smarthost': inventory.fact_smarthost(rdb),
 }
-
-facts['uuid'] = redis_client.get('cluster/uuid')
-
-# TODO: node_id not representative, change with NODE_UUID when available.
-tasks = [{
-    'agent_id': 'node/'+redis_client.hget(key, 'NODE_ID'),
-    'action': 'get-facts'
-} for key in redis_client.scan_iter('node/*/environment')]
-
-results = agent.tasks.runp(
-    tasks,
-    extra={
-        'isNotificationHidden': True,
-    },
-    endpoint="redis://cluster-leader"
-)
-
-facts['facts']['nodes'] = {}
-for item in results:
-    for key in item['output']:
-        facts['facts']['nodes'][key] = item['output'][key]
-
-json.dump(
-    facts,
-    fp=sys.stdout
-)
+json.dump(facts, fp=sys.stdout)

--- a/core/imageroot/var/lib/nethserver/cluster/actions/get-facts/50get
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/get-facts/50get
@@ -21,5 +21,6 @@ facts = {
     'admins': inventory.fact_admins(rdb),
     'repositories': inventory.fact_repositories(rdb),
     'smarthost': inventory.fact_smarthost(rdb),
+    "backup": inventory.fact_backup(rdb),
 }
 json.dump(facts, fp=sys.stdout)

--- a/core/imageroot/var/lib/nethserver/cluster/bin/phonehome
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/phonehome
@@ -6,33 +6,34 @@
 #
 
 '''
-Helper script that sends into the tasks of the cluster 'get-facts', without
-passing through the API.
-The suprocess is used instead of redis library due to missing pip.
+Helper script that retrive cluster info and send them to
+the phonehome server
 '''
 
-import http.client
+import sys
 import json
-
 import agent
-import agent.tasks
+import http.client
+import cluster.inventory
 
-result = agent.tasks.run(
-    agent_id='cluster',
-    action='get-facts',
-    extra={
-        'isNotificationHidden': True,
-    },
-    endpoint="redis://cluster-leader"
+facts = cluster.inventory.cluster_facts()
+if facts:
+    facts['modules'] = cluster.inventory.modules_facts()
+    facts['cluster'] = cluster.inventory.subscription_fact()
+else:
+    print(agent.SD_ERR + f"phonehome failed", file=sys.stderr)
+    sys.exit(1)
+
+redis_client = agent.redis_connect(privileged=False)
+client = http.client.HTTPSConnection(
+    redis_client.get('cluster/phonehome/endpoint')
 )
+client.request('POST', '/api/installation', json.dumps(facts), {
+    "Content-type": "application/json",
+    "Accept": "application/json"
+})
+resp = client.getresponse()
 
-if result['exit_code'] == 0:
-    redis_client = agent.redis_connect(privileged=False)
-    client = http.client.HTTPSConnection(
-        redis_client.get('cluster/phonehome/endpoint')
-    )
-    client.request('POST', '/api/installation', json.dumps(result['output']), {
-        "Content-type": "application/json",
-        "Accept": "application/json"
-    })
-    client.getresponse()
+if resp.status >= 400:
+    print(agent.SD_ERR + f"phonehome failed with status {resp.status}", file=sys.stderr)
+    sys.exit(1)

--- a/core/imageroot/var/lib/nethserver/cluster/bin/print-phonehome
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/print-phonehome
@@ -108,22 +108,20 @@ def node_facts():
     return ret
 
 
-# Init dictionary that returns the data
-rdb = agent.redis_connect(privileged=True)
-facts = {
-    '$schema': 'https://schema.nethserver.org/facts/2022-12.json',
-    'uuid': rdb.get('cluster/uuid'),
-    'installation': 'nethserver',
-    'facts': {
-        'cluster': cluster_facts(),
-        'nodes': node_facts(),
-        'modules': modules_facts()
+def main():
+    # Init dictionary that returns the data
+    rdb = agent.redis_connect(privileged=True)
+    facts = {
+        '$schema': 'https://schema.nethserver.org/facts/2022-12.json',
+        'uuid': rdb.get('cluster/uuid'),
+        'installation': 'nethserver',
+        'facts': {
+            'cluster': cluster_facts(),
+            'nodes': node_facts(),
+            'modules': modules_facts()
+        }
     }
-}
+    print(json.dumps(facts))
 
-# Call all tasks
-facts['facts']['nodes'] = node_facts()
-facts["facts"]["modules"] = modules_facts()
-facts["facts"]["cluster"] = cluster_facts()
-
-print(json.dumps(facts))
+if __name__ == "__main__":
+    main()

--- a/core/imageroot/var/lib/nethserver/cluster/bin/print-phonehome
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/print-phonehome
@@ -6,22 +6,124 @@
 #
 
 '''
-Helper script that retrieve cluster infor for the phonehome server.
+Helper script that retrieves info for the phonehome server.
 '''
 
 import sys
 import json
 import agent
-from cluster import inventory
+from cluster import modules
 
-facts = inventory.cluster_facts()
-if facts:
-    facts['facts']['modules'] = inventory.modules_facts()
-    facts['facts']['cluster'] = {}
-    facts['facts']['cluster']['subscription'] = inventory.fact_subscription()
-    facts['facts']['cluster']['admins'] = inventory.fact_admins()
-else:
-    print(agent.SD_ERR + f"phonehome failed", file=sys.stderr)
-    sys.exit(1)
+def cluster_facts():
+    try:
+        result = agent.tasks.run(
+            agent_id='cluster',
+            action='get-facts',
+            extra={
+                'isNotificationHidden': True,
+            },
+            endpoint="redis://cluster-leader"
+        )
+    except:
+        print(agent.SD_WARNING + f"cluster/get-facts failed", file=sys.stderr)
+        return None
+
+    if result['exit_code'] == 0:
+        return result['output']
+    else:
+        print(agent.SD_WARNING + f"cluster/get-facts failed", file=sys.stderr)
+        return None
+ 
+def modules_facts():
+    ret = []
+    rdb = agent.redis_connect(use_replica=True)
+    installed_modules = modules.list_installed(rdb, skip_core_modules = False)
+    instance_list = list(mi for module_instances in installed_modules.values() for mi in module_instances)
+
+    # Collect facts from modules:
+    for module in instance_list:
+        minfo = {"id": module.get('id'), "version": module.get("version"), "name": module.get("module"), "node": module.get("node") } 
+
+        try:
+            list_actions_result = agent.tasks.run(
+                agent_id='module/' + module.get('id'),
+                action='list-actions',
+                extra={
+                    'isNotificationHidden': True,
+                },
+                endpoint="redis://cluster-leader",
+            )
+
+            if not list_actions_result or list_actions_result['exit_code'] != 0:
+                print(agent.SD_WARNING + f"module/{module.get('id')}/list-actions failed", file=sys.stderr)
+                raise Exception("list-actions failed")
+            
+            if 'get-facts' in list_actions_result.get('output', []):
+
+                get_facts_result = agent.tasks.run(
+                    agent_id='module/' + module.get('id'),
+                    action='get-facts',
+                    extra={ 'isNotificationHidden': True },
+                    endpoint="redis://cluster-leader",
+                )
+
+                if get_facts_result['exit_code'] != 0:
+                    print(agent.SD_WARNING, f"get-facts failed for {module.get('id')}", file=sys.stderr)
+                    raise Exception("get-facts failed")
+
+                ofacts = get_facts_result['output']
+                # merge info from get-facts
+                minfo.update(ofacts)
+        except Exception as ex:
+            print(agent.SD_WARNING + "module_facts() exception:", ex, file=sys.stderr)
+
+        ret.append(minfo)
+
+    return ret
+
+def node_facts():
+    ret = {}
+    rdb = agent.redis_connect(privileged=True)
+
+    tasks = [{
+        'agent_id': 'node/'+rdb.hget(key, 'NODE_ID'),
+        'action': 'get-facts'
+    } for key in rdb.scan_iter('node/*/environment')]
+
+    try:
+        results = agent.tasks.runp(
+            tasks,
+            extra={
+                'isNotificationHidden': True,
+            },
+            endpoint="redis://cluster-leader"
+        )
+
+        for item in results:
+            for key in item['output']:
+                ret[key] = item['output'][key]
+    except:
+        print(agent.SD_WARNING + f"node/get-facts failed", file=sys.stderr)
+
+    return ret
+
+
+# Init dictionary that returns the data
+rdb = agent.redis_connect(privileged=True)
+facts = {
+    '$schema': 'https://schema.nethserver.org/facts/2022-12.json',
+    'uuid': rdb.get('cluster/uuid'),
+    'installation': 'nethserver',
+    'facts': {
+        'cluster': cluster_facts(),
+        'nodes': node_facts(),
+        'modules': modules_facts()
+    }
+}
+
+# Call all tasks
+facts['facts']['nodes'] = node_facts()
+facts["facts"]["modules"] = modules_facts()
+facts["facts"]["cluster"] = cluster_facts()
 
 print(json.dumps(facts))

--- a/core/imageroot/var/lib/nethserver/cluster/bin/print-phonehome
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/print-phonehome
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+'''
+Helper script that retrieve cluster infor for the phonehome server.
+'''
+
+import sys
+import json
+import agent
+from cluster import inventory
+
+facts = inventory.cluster_facts()
+if facts:
+    facts['facts']['modules'] = inventory.modules_facts()
+    facts['facts']['cluster'] = {}
+    facts['facts']['cluster']['subscription'] = inventory.fact_subscription()
+    facts['facts']['cluster']['admins'] = inventory.fact_admins()
+else:
+    print(agent.SD_ERR + f"phonehome failed", file=sys.stderr)
+    sys.exit(1)
+
+print(json.dumps(facts))

--- a/core/imageroot/var/lib/nethserver/cluster/bin/send-phonehome
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/send-phonehome
@@ -17,7 +17,7 @@ import agent
 import http.client
 import subprocess
 
-facts = json.loads(subprocess.check_output(['runagent', 'print-phonehome']))
+facts = json.loads(subprocess.check_output(['print-phonehome']))
 if not facts:
     print(agent.SD_ERR + f"send-phonehome failed: can't execute print-phonehome", file=sys.stderr)
     sys.exit(1)

--- a/core/imageroot/var/lib/nethserver/cluster/bin/send-phonehome
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/send-phonehome
@@ -6,7 +6,7 @@
 #
 
 '''
-Helper script that send cluster info to the phonehome server.
+Helper script that sends cluster info to the phonehome server.
 To see what is sent, run the following command:
     runagent print-phonehome
 '''

--- a/core/imageroot/var/lib/nethserver/cluster/bin/send-phonehome
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/send-phonehome
@@ -1,27 +1,25 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2023 Nethesis S.r.l.
+# Copyright (C) 2025 Nethesis S.r.l.
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 
 '''
-Helper script that retrive cluster info and send them to
-the phonehome server
+Helper script that send cluster info to the phonehome server.
+To see what is sent, run the following command:
+    runagent print-phonehome
 '''
 
 import sys
 import json
 import agent
 import http.client
-import cluster.inventory
+import subprocess
 
-facts = cluster.inventory.cluster_facts()
-if facts:
-    facts['modules'] = cluster.inventory.modules_facts()
-    facts['cluster'] = cluster.inventory.subscription_fact()
-else:
-    print(agent.SD_ERR + f"phonehome failed", file=sys.stderr)
+facts = json.loads(subprocess.check_output(['runagent', 'print-phonehome']))
+if not facts:
+    print(agent.SD_ERR + f"send-phonehome failed: can't execute print-phonehome", file=sys.stderr)
     sys.exit(1)
 
 redis_client = agent.redis_connect(privileged=False)
@@ -35,5 +33,5 @@ client.request('POST', '/api/installation', json.dumps(facts), {
 resp = client.getresponse()
 
 if resp.status >= 400:
-    print(agent.SD_ERR + f"phonehome failed with status {resp.status}", file=sys.stderr)
+    print(agent.SD_ERR + f"send-phonehome failed with status {resp.status}", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
Changes:
- add a new inventory.py library
- create a `print-phonehome` script that uses the inventory library and generate the JSON ready to be sent to phonehome server
- create a `send-phonehome` script to actually send data

New info added to the phonehome:

- subscription status
- installed applications
- number of admins
- number of admins with 2fa enabled
- smarthost status
- list of enabled repositories

NethServer/dev#7274

Example if `runagent print-phonehome  | jq .facts.modules`:
```json
[
  {
    "id": "traefik1",
    "version": "2.2.5",
    "name": "traefik",
    "node": "1"
  },
  {
    "id": "ldapproxy1",
    "version": "1.1.0",
    "name": "ldapproxy",
    "node": "1"
  },
  {
    "id": "loki1",
    "version": "1.2.2",
    "name": "loki",
    "node": "1"
  },
  {
    "id": "netdata1",
    "version": "2.0.0",
    "name": "netdata",
    "node": "1"
  },
  {
    "id": "nextcloud1",
    "version": "1.3.0",
    "name": "nextcloud",
    "node": "1",
    "active_users": 0,
    "total_users": 0
  }
]
```

Example for `runagent print-phonehome  | jq .facts.cluster`:
```json
{
  "subscription": "disabled",
  "admins": {
    "count": 1,
    "2fa": 1
  },
  "repositories": [
    "default"
  ],
  "smarthost": {
    "enabled": true,
    "manual_configuration": true
  }
}
```
