### PR TITLE
Fix clean up of old image files

### DIFF
--- a/core/imageroot/usr/local/agent/bin/extract-image
+++ b/core/imageroot/usr/local/agent/bin/extract-image
@@ -70,8 +70,8 @@ if [[ -f "${lst_file}~" ]]; then
         fi
     done < <(diff ${lst_file}~ ${lst_file} | sed -n '/^</ {s/^< // ; p}')
 
-    for dir_entry in "${dirs_list[@]}"; do
-        rmdir -v "${dir_entry}" || :
+    for (( idx=${#dirs_list[@]}-1 ; idx>=0 ; idx-- )) ; do
+        rmdir -v "${dirs_list[idx]}" || :
     done
 fi
 


### PR DESCRIPTION
When a new image is extracted in the AGENT_INSTALL_DIR, files and directories of the previous image version that are no longer required must be removed.

This change to Core will be effective after the second next module update because on the first pass the `.imageroot.lst` file is fixed by removing the leading "imageroot/" prefix. On the second update the comparison starts to work correctly.

For example. The first update the instance is updated:

- `.imageroot.lst` starts with `./actions`
- `.imageroot.lst~` starts with `imageroot/actions`

No file and dir is removed automatically. Then the second time the instance is updated:

- `.imageroot.lst` starts with `./actions`
- `.imageroot.lst~` starts with `./actions`

If a file or dir is not present in the second image, `extract-image` calls rm/rmdir on it to reflect the change in the filesystem.

Refs NethServer/dev#7058