### PR TITLE
feat(phonehome): add module installation date

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/bin/print-phonehome
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/print-phonehome
@@ -9,7 +9,9 @@
 Helper script that retrieves info for the phonehome server.
 '''
 
+import os
 import sys
+import pwd
 import json
 import agent
 from cluster import modules
@@ -42,7 +44,15 @@ def modules_facts():
 
     # Collect facts from modules:
     for module in instance_list:
-        minfo = {"id": module.get('id'), "version": module.get("version"), "name": module.get("module"), "node": module.get("node") } 
+        # Default info
+        minfo = {"id": module.get('id'), "version": module.get("version"), "name": module.get("module"), "node": module.get("node"), "installation_date": None }
+        try:
+            home_dir = pwd.getpwnam(module.get('id')).pw_dir
+            agent_dir = f"{home_dir}/.config/state"
+        except Exception as ex:
+            agent_dir = f"/var/lib/nethserver/{module.get('id')}/state"
+        if os.path.exists(agent_dir):
+            minfo["installation_date"] = int(os.path.getmtime(f"{agent_dir}/agent.env"))
 
         try:
             list_actions_result = agent.tasks.run(


### PR DESCRIPTION
As requested by DavideP.

Outoput example `runagent print-phonehome | jq .facts.modules`:
```json
[
  {
    "id": "traefik1",
    "version": "2.2.6-dev.1",
    "name": "traefik",
    "node": "1",
    "installation_date": 1737624417,
    "custom_path_routes": 0,
    "custom_host_routes": 0,
    "custom_certificates": 0,
    "acme_manual_certificates": 0,
    "acme_auto_certificates": 0,
    "acme_failed_certificates": 0
  },
  {
    "id": "ldapproxy1",
    "version": "1.1.0",
    "name": "ldapproxy",
    "node": "1",
    "installation_date": 1737624443
  },
  {
    "id": "loki1",
    "version": "1.2.3-dev.1",
    "name": "loki",
    "node": "1",
    "installation_date": 1737624442,
    "retention_days": 365,
    "cloud_log_manager": false,
    "syslog": false
  }
]
```