### PR TITLE
fix: extract-image regression

### DIFF
--- a/core/imageroot/usr/local/agent/bin/extract-image
+++ b/core/imageroot/usr/local/agent/bin/extract-image
@@ -25,9 +25,9 @@ image=${1:?missing image URL argument}
 set -e
 
 # Prevent concurrent execution of this script with a lock file opened with
-# an arbitrary high FD number, like 201. The lock is released when the
-# script completes:
-exec 201>"${AGENT_STATE_DIR:?}"/.extract-image.lock
+# an arbitrary high FD number, like 201. The lock is created in the
+# working directory, and is released when the script completes:
+exec 201>.extract-image.lock
 flock --verbose -n 201
 
 lst_file=".imageroot.lst"


### PR DESCRIPTION
Concurrent node/add-module actions fail on flock acquiring the lock file.

The lock file is created in a unique path by node/add-module, preventing the execution of multiple modules installation at the same time, which normally happens in cluster/create-cluster and cluster/add-node actions.

This commit changes extract-image behavior. The lock file is created under ./ (the working directory) instead of AGENT_INSTALL_DIR/.


Refs NethServer/dev#7058