### PR TITLE
fix: update retention and label bindings in SettingsSystemLogs

### DIFF
--- a/core/ui/src/views/settings/SettingsSystemLogs.vue
+++ b/core/ui/src/views/settings/SettingsSystemLogs.vue
@@ -107,6 +107,7 @@
                   @click="
                     isEditRetentionDialogOpen = true;
                     lokiToEdit = instance;
+                    newRetention = instance.retention_days;
                   "
                   :disabled="instance.offline"
                 >
@@ -119,6 +120,7 @@
                   @click="
                     isEditLabelDialogOpen = true;
                     lokiToEdit = instance;
+                    newLabel = instance.instance_label;
                   "
                   :disabled="instance.offline"
                 >


### PR DESCRIPTION
Refactor the bindings for retention days and node label in the SettingsSystemLogs component to use the `lokiToEdit` object, improving data handling and consistency.

https://github.com/NethServer/dev/issues/7280