### PR TITLE
fix(stop-support-session): prevent action failure

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/stop-support-session/51publish_event
+++ b/core/imageroot/var/lib/nethserver/node/actions/stop-support-session/51publish_event
@@ -5,12 +5,17 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+import sys
 import agent
 import os
 import json
 
 node_id = os.environ['NODE_ID']
-session_id = agent.read_envfile("support.env").get("VPN_PASSWORD")
+try:
+    session_id = agent.read_envfile("support.env").get("VPN_PASSWORD")
+except:
+    # If file does not exists, no support sessions have ever been started
+    sys.exit(0)
 support_user = agent.redis_connect().hget("cluster/subscription", "support_user")
 
 agent.redis_connect(privileged=True).publish("node/" + node_id + "/event/support-session-stopped", json.dumps({


### PR DESCRIPTION
If support sessions have never been started, the stop-support-session action fails with the following error:

Traceback (most recent call last):
  File "/var/lib/nethserver/node/actions/stop-support-session/51publish_event", line 13, in <module>
    session_id = agent.read_envfile("support.env").get("VPN_PASSWORD")
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/agent/pypkg/agent/__init__.py", line 90, in read_envfile
    fo = open(file_path, 'r')
         ^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'support.env'