### PR TITLE
fix(softwarecenter):  improve conditional rendering for app version tooltip

### DIFF
--- a/core/ui/src/components/software-center/AppList.vue
+++ b/core/ui/src/components/software-center/AppList.vue
@@ -134,7 +134,11 @@
                 >{{ $t("software_center.install") }}</NsButton
               >
               <cv-interactive-tooltip
-                v-if="app.no_version_reason && app.no_version_reason.message"
+                v-if="
+                  app.no_version_reason &&
+                  app.no_version_reason.message &&
+                  app.versions.length
+                "
                 alignment="center"
                 direction="bottom"
                 class="info mg-left-sm"


### PR DESCRIPTION
Enhance the conditional rendering for the app version tooltip to ensure it only displays when appropriate conditions are met.

https://github.com/NethServer/dev/issues/7228