### PR TITLE
feat(softwareCenter): add release note URLs for GitHub code repositories

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
@@ -337,12 +337,10 @@ def _get_available_modules(rdb):
             modules[rmod["source"]] = rmod
             rmod['versions'].sort(key=lambda v: _parse_version_object(v["tag"]), reverse=True)
             # Set the general release note URL if the code URL is a GitHub repository
-            if rmod.get('docs') and rmod['docs'].get('code_url').startswith("https://github.com/") and not rmod['docs'].get('relnotes_url'):
+            if rmod['docs']['code_url'].startswith("https://github.com/") and not rmod['docs'].get('relnotes_url', ''):
                 rmod['docs']['relnotes_url']= f"{rmod['docs']['code_url']}/releases"
             else:
-                if not rmod.get('docs'):
-                    rmod['docs'] = {}
-                rmod['docs']['relnotes_url']= ""
+                rmod['docs']['relnotes_url'] = ""
 
     # Integrate the available set with instances that do not belong to any
     # repository. They can be found in the "installed" dict:

--- a/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
@@ -337,10 +337,8 @@ def _get_available_modules(rdb):
             modules[rmod["source"]] = rmod
             rmod['versions'].sort(key=lambda v: _parse_version_object(v["tag"]), reverse=True)
             # Set the general release note URL if the code URL is a GitHub repository
-            if rmod['docs']['code_url'].startswith("https://github.com/") and not rmod['docs'].get('relnotes_url', ''):
-                rmod['docs']['relnotes_url']= f"{rmod['docs']['code_url']}/releases"
-            else:
-                rmod['docs']['relnotes_url'] = ""
+            if rmod['docs']['code_url'].startswith("https://github.com/") and 'relnotes_url' not in rmod['docs']:
+                rmod['docs']['relnotes_url'] = f"{rmod['docs']['code_url']}/releases"
 
     # Integrate the available set with instances that do not belong to any
     # repository. They can be found in the "installed" dict:

--- a/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
@@ -336,6 +336,14 @@ def _get_available_modules(rdb):
                 continue # skip duplicated images from lower priority modules
             modules[rmod["source"]] = rmod
             rmod['versions'].sort(key=lambda v: _parse_version_object(v["tag"]), reverse=True)
+            # Set the general release note URL if the code URL is a GitHub repository
+            if rmod.get('docs') and rmod['docs'].get('code_url').startswith("https://github.com/") and not rmod['docs'].get('relnotes_url'):
+                rmod['docs']['relnotes_url']= f"{rmod['docs']['code_url']}/releases"
+            else:
+                if not rmod.get('docs'):
+                    rmod['docs'] = {}
+                rmod['docs']['relnotes_url']= ""
+
     # Integrate the available set with instances that do not belong to any
     # repository. They can be found in the "installed" dict:
     for module_source, module_instances in list_installed(rdb).items():

--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-modules/validate-output.json
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-modules/validate-output.json
@@ -160,19 +160,23 @@
         "type": "object",
         "parameters": {
           "terms_url": {
-            "type": "uri",
+            "type": "string",
+            "format": "uri",
             "description": "Optional link to the application Terms & Conditions document"
           },
           "documentation_url": {
-            "type": "uri",
+            "type": "string",
+            "format": "uri",
             "description": "Link to the package documentation"
           },
           "bug_url": {
-            "type": "uri",
+            "type": "string",
+            "format": "uri",
             "description": "Link to the package issue tracker"
           },
           "code_url": {
-            "type": "uri",
+            "type": "string",
+            "format": "uri",
             "description": "Link to the source code repository"
           }
         },

--- a/core/imageroot/var/lib/nethserver/cluster/repodata-schema.json
+++ b/core/imageroot/var/lib/nethserver/cluster/repodata-schema.json
@@ -117,23 +117,28 @@
         "type": "object",
         "parameters": {
           "terms_url": {
-            "type": "uri",
+            "type": "string",
+            "format": "uri",
             "description": "Optional link to the application Terms & Conditions document"
           },
           "documentation_url": {
-            "type": "uri",
+            "type": "string",
+            "format": "uri",
             "description": "Link to the package documentation"
           },
           "bug_url": {
-            "type": "uri",
+            "type": "string",
+            "format": "uri",
             "description": "Link to the package issue tracker"
           },
           "code_url": {
-            "type": "uri",
+            "type": "string",
+            "format": "uri",
             "description": "Link to the source code repository"
           }, 
           "relnotes_url": {
-            "type": "uri",
+            "type": "string",
+            "format": "uri",
             "description": "Optional link to the application release notes"
           }
         },

--- a/core/imageroot/var/lib/nethserver/cluster/repodata-schema.json
+++ b/core/imageroot/var/lib/nethserver/cluster/repodata-schema.json
@@ -27,7 +27,8 @@
         "docs": {
           "documentation_url": "https://docs.nethserver.org",
           "bug_url": "https://github.com/NethServer/dev",
-          "code_url": "https://github.com/NethServer/"
+          "code_url": "https://github.com/NethServer/",
+          "relnotes_url": "https://github.com/NethServer/ns8-kickstart/releases"
         },
         "source": "ghcr.io/nethserver/dokuwiki",
         "versions": [
@@ -130,6 +131,10 @@
           "code_url": {
             "type": "uri",
             "description": "Link to the source code repository"
+          }, 
+          "relnotes_url": {
+            "type": "uri",
+            "description": "Optional link to the application release notes"
           }
         },
         "required": [

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -87,7 +87,8 @@
         "configure": "Configure",
         "terms_and_conditions": "Terms and Conditions",
         "terms_required": "Please read and agree to @:common.terms_and_conditions",
-        "not_available": "Not available"
+        "not_available": "Not available",
+        "release_notes": "Release notes"
     },
     "error": {
         "error": "Error",

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -850,7 +850,6 @@
         "uninstall": "Uninstall",
         "cluster_up_to_date": "Your cluster is up to date",
         "instances": "Instances",
-        "release_notes": "Release notes",
         "app_info": "App info",
         "categories": "Category | Categories",
         "latest_version": "Latest version",

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -88,8 +88,7 @@
         "terms_and_conditions": "Terms and Conditions",
         "terms_required": "Please read and agree to @:common.terms_and_conditions",
         "not_available": "Not available",
-        "release_notes": "Release notes",
-        "release_notes_of_version": "Release notes of version {app}"
+        "release_notes": "Release notes"
     },
     "error": {
         "error": "Error",

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -851,6 +851,7 @@
         "uninstall": "Uninstall",
         "cluster_up_to_date": "Your cluster is up to date",
         "instances": "Instances",
+        "release_notes": "Release notes",
         "app_info": "App info",
         "categories": "Category | Categories",
         "latest_version": "Latest version",

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -88,7 +88,8 @@
         "terms_and_conditions": "Terms and Conditions",
         "terms_required": "Please read and agree to @:common.terms_and_conditions",
         "not_available": "Not available",
-        "release_notes": "Release notes"
+        "release_notes": "Release notes",
+        "release_notes_of_version": "Release notes of version {app}"
     },
     "error": {
         "error": "Error",

--- a/core/ui/src/components/software-center/AppInfoModal.vue
+++ b/core/ui/src/components/software-center/AppInfoModal.vue
@@ -157,6 +157,14 @@
                 </cv-link>
               </span>
             </template>
+            <template v-if="app.docs.relnotes_url">
+              &bull;
+              <span>
+                <cv-link :href="app.docs.relnotes_url" target="_blank">
+                  {{ $t("common.release_notes") }}
+                </cv-link>
+              </span>
+            </template>
           </div>
         </div>
       </template>

--- a/core/ui/src/components/software-center/UpdateAppModal.vue
+++ b/core/ui/src/components/software-center/UpdateAppModal.vue
@@ -39,6 +39,16 @@
               }
             )
           }}
+          <template v-if="app.docs.relnotes_url">
+            <span>
+              <cv-link
+                :href="app.docs.relnotes_url + '/tag/' + appVersion"
+                target="_blank"
+              >
+                {{ $t("common.release_notes_of_version", { app: appVersion }) }}
+              </cv-link>
+            </span>
+          </template>
         </div>
         <div v-if="error.updateModule">
           <NsInlineNotification

--- a/core/ui/src/components/software-center/UpdateAppModal.vue
+++ b/core/ui/src/components/software-center/UpdateAppModal.vue
@@ -39,16 +39,6 @@
               }
             )
           }}
-          <template v-if="app.docs.relnotes_url">
-            <span>
-              <cv-link
-                :href="app.docs.relnotes_url + '/tag/' + appVersion"
-                target="_blank"
-              >
-                {{ $t("common.release_notes_of_version", { app: appVersion }) }}
-              </cv-link>
-            </span>
-          </template>
         </div>
         <div v-if="error.updateModule">
           <NsInlineNotification

--- a/core/ui/src/views/SoftwareCenterAppInstances.vue
+++ b/core/ui/src/views/SoftwareCenterAppInstances.vue
@@ -330,7 +330,7 @@
                         :href="app.docs.relnotes_url"
                         target="_blank"
                       >
-                        {{ $t("common.release_notes") }}
+                        {{ $t("common.release_notes") }} <Launch20 />
                       </cv-link>
                     </span>
                   </template>
@@ -472,6 +472,7 @@ import { mapState, mapActions } from "vuex";
 import CloneOrMoveAppModal from "@/components/software-center/CloneOrMoveAppModal";
 import UpdateAppModal from "../components/software-center/UpdateAppModal";
 import Information16 from "@carbon/icons-vue/es/information/16";
+import { Launch20 } from "@carbon/icons-vue";
 
 export default {
   name: "SoftwareCenterAppInstances",
@@ -480,6 +481,7 @@ export default {
     CloneOrMoveAppModal,
     UpdateAppModal,
     Information16,
+    Launch20,
   },
   mixins: [
     TaskService,

--- a/core/ui/src/views/SoftwareCenterAppInstances.vue
+++ b/core/ui/src/views/SoftwareCenterAppInstances.vue
@@ -323,17 +323,23 @@
                       })
                     }}
                   </div>
-                  <template v-if="app.docs.relnotes_url">
-                    <span>
-                      <cv-link
-                        class="row icon-and-text"
-                        :href="app.docs.relnotes_url"
-                        target="_blank"
-                      >
-                        {{ $t("common.release_notes") }} <Launch20 />
-                      </cv-link>
-                    </span>
-                  </template>
+                  <div
+                    v-if="
+                      app.docs.relnotes_url &&
+                      isStableUpdateAvailable(app, instance)
+                    "
+                    class="row"
+                  >
+                    <cv-link
+                      class="row icon-and-text"
+                      :href="app.docs.relnotes_url"
+                      target="_blank"
+                    >
+                      <NsButton kind="ghost" :icon="Launch20">
+                        {{ $t("common.release_notes") }}
+                      </NsButton>
+                    </cv-link>
+                  </div>
                   <div class="row actions">
                     <!-- app is installed and can be updated -->
                     <template v-if="isStableUpdateAvailable(app, instance)">
@@ -472,7 +478,6 @@ import { mapState, mapActions } from "vuex";
 import CloneOrMoveAppModal from "@/components/software-center/CloneOrMoveAppModal";
 import UpdateAppModal from "../components/software-center/UpdateAppModal";
 import Information16 from "@carbon/icons-vue/es/information/16";
-import { Launch20 } from "@carbon/icons-vue";
 
 export default {
   name: "SoftwareCenterAppInstances",
@@ -481,7 +486,6 @@ export default {
     CloneOrMoveAppModal,
     UpdateAppModal,
     Information16,
-    Launch20,
   },
   mixins: [
     TaskService,

--- a/core/ui/src/views/SoftwareCenterAppInstances.vue
+++ b/core/ui/src/views/SoftwareCenterAppInstances.vue
@@ -323,6 +323,17 @@
                       })
                     }}
                   </div>
+                  <template v-if="app.docs.relnotes_url">
+                    <span>
+                      <cv-link
+                        class="row icon-and-text"
+                        :href="app.docs.relnotes_url"
+                        target="_blank"
+                      >
+                        {{ $t("common.release_notes") }}
+                      </cv-link>
+                    </span>
+                  </template>
                   <div class="row actions">
                     <!-- app is installed and can be updated -->
                     <template v-if="isStableUpdateAvailable(app, instance)">

--- a/core/ui/src/views/SoftwareCenterCoreApps.vue
+++ b/core/ui/src/views/SoftwareCenterCoreApps.vue
@@ -97,18 +97,17 @@
                     }}</a></cv-data-table-cell
                   >
                   <cv-data-table-cell>{{ row.node_id }}</cv-data-table-cell>
-                  <cv-data-table-cell
-                    >{{ row.version }}:
-                    <a
-                      v-if="row.docs.relnotes_url"
-                      :href="row.docs.relnotes_url"
-                      target="_blank"
-                      >{{ $t("common.release_notes") }}</a
-                    >
-                    <span v-else>-</span></cv-data-table-cell
-                  >
+                  <cv-data-table-cell>{{ row.version }}</cv-data-table-cell>
                   <cv-data-table-cell v-if="isCoreUpdatable">
                     {{ row.update || "-" }}
+                    <div>
+                      <cv-link
+                        v-if="row.docs.relnotes_url && row.update"
+                        :href="row.docs.relnotes_url"
+                        target="_blank"
+                        >{{ $t("common.release_notes") }} <Launch20
+                      /></cv-link>
+                    </div>
                   </cv-data-table-cell>
                 </cv-data-table-row>
               </template>
@@ -137,10 +136,11 @@ import {
 import { mapState, mapActions } from "vuex";
 import to from "await-to-js";
 import AppInfoModal from "@/components/software-center/AppInfoModal";
+import { Launch20 } from "@carbon/icons-vue";
 
 export default {
   name: "SoftwareCenterCoreApps",
-  components: { AppInfoModal },
+  components: { AppInfoModal, Launch20 },
   mixins: [
     IconService,
     QueryParamService,

--- a/core/ui/src/views/SoftwareCenterCoreApps.vue
+++ b/core/ui/src/views/SoftwareCenterCoreApps.vue
@@ -97,19 +97,19 @@
                     }}</a></cv-data-table-cell
                   >
                   <cv-data-table-cell>{{ row.node_id }}</cv-data-table-cell>
-                  <cv-data-table-cell>{{ row.version }}</cv-data-table-cell>
-                  <cv-data-table-cell v-if="isCoreUpdatable">
-                    {{ row.update || "-" }}
-                  </cv-data-table-cell>
-                  <cv-data-table-cell>
+                  <cv-data-table-cell
+                    >{{ row.version }}:
                     <a
                       v-if="row.docs.relnotes_url"
                       :href="row.docs.relnotes_url"
                       target="_blank"
-                      >{{$t("common.release_notes")}}</a
+                      >{{ $t("common.release_notes") }}</a
                     >
                     <span v-else>-</span></cv-data-table-cell
                   >
+                  <cv-data-table-cell v-if="isCoreUpdatable">
+                    {{ row.update || "-" }}
+                  </cv-data-table-cell>
                 </cv-data-table-row>
               </template>
             </NsDataTable>
@@ -245,8 +245,8 @@ export default {
     },
     updateTableData() {
       this.tableColumns = this.isCoreUpdatable
-        ? ["id", "node_id", "version", "update", "release_notes"]
-        : ["id", "node_id", "version", "release_notes"];
+        ? ["id", "node_id", "version", "update"]
+        : ["id", "node_id", "version"];
     },
     async listCoreModules() {
       this.error.listCoreModules = "";

--- a/core/ui/src/views/SoftwareCenterCoreApps.vue
+++ b/core/ui/src/views/SoftwareCenterCoreApps.vue
@@ -100,14 +100,12 @@
                   <cv-data-table-cell>{{ row.version }}</cv-data-table-cell>
                   <cv-data-table-cell v-if="isCoreUpdatable">
                     {{ row.update || "-" }}
-                    <div>
-                      <cv-link
-                        v-if="row.docs.relnotes_url && row.update"
-                        :href="row.docs.relnotes_url"
-                        target="_blank"
-                        >{{ $t("common.release_notes") }} <Launch20
-                      /></cv-link>
-                    </div>
+                    <cv-link
+                      v-if="row.docs.relnotes_url && row.update"
+                      :href="row.docs.relnotes_url"
+                      target="_blank"
+                      >{{ $t("common.release_notes") }} <Launch20
+                    /></cv-link>
                   </cv-data-table-cell>
                 </cv-data-table-row>
               </template>

--- a/core/ui/src/views/SoftwareCenterCoreApps.vue
+++ b/core/ui/src/views/SoftwareCenterCoreApps.vue
@@ -101,6 +101,15 @@
                   <cv-data-table-cell v-if="isCoreUpdatable">
                     {{ row.update || "-" }}
                   </cv-data-table-cell>
+                  <cv-data-table-cell>
+                    <a
+                      v-if="row.docs.relnotes_url"
+                      :href="row.docs.relnotes_url"
+                      target="_blank"
+                      >{{$t("common.release_notes")}}</a
+                    >
+                    <span v-else>-</span></cv-data-table-cell
+                  >
                 </cv-data-table-row>
               </template>
             </NsDataTable>
@@ -236,8 +245,8 @@ export default {
     },
     updateTableData() {
       this.tableColumns = this.isCoreUpdatable
-        ? ["id", "node_id", "version", "update"]
-        : ["id", "node_id", "version"];
+        ? ["id", "node_id", "version", "update", "release_notes"]
+        : ["id", "node_id", "version", "release_notes"];
     },
     async listCoreModules() {
       this.error.listCoreModules = "";

--- a/core/ui/src/views/SoftwareCenterCoreApps.vue
+++ b/core/ui/src/views/SoftwareCenterCoreApps.vue
@@ -104,8 +104,11 @@
                       v-if="row.docs.relnotes_url && row.update"
                       :href="row.docs.relnotes_url"
                       target="_blank"
-                      >{{ $t("common.release_notes") }} <Launch20
-                    /></cv-link>
+                    >
+                      <NsButton kind="ghost" :icon="Launch20">
+                        {{ $t("common.release_notes") }}
+                      </NsButton></cv-link
+                    >
                   </cv-data-table-cell>
                 </cv-data-table-row>
               </template>
@@ -134,11 +137,10 @@ import {
 import { mapState, mapActions } from "vuex";
 import to from "await-to-js";
 import AppInfoModal from "@/components/software-center/AppInfoModal";
-import { Launch20 } from "@carbon/icons-vue";
 
 export default {
   name: "SoftwareCenterCoreApps",
-  components: { AppInfoModal, Launch20 },
+  components: { AppInfoModal },
   mixins: [
     IconService,
     QueryParamService,


### PR DESCRIPTION
Introduce functionality to set release note URLs for modules sourced from GitHub repositories, enhancing the documentation accessibility for users.

https://github.com/NethServer/dev/issues/7243


```json
  {
    "name": "Mattermost",
    "description": {
      "en": "Mattermost is a secure Open Source chat for team collaboration.",
      "it": "Mattermost è una chat Open Source sicura per la collaborazione in team."
    },
    "logo": "https://distfeed.nethserver.org/ns8/updates/mattermost/logo.png",
    "screenshots": [
      "https://distfeed.nethserver.org/ns8/updates/mattermost/screenshots/screen1.png"
    ],
    "categories": [
      "collaboration"
    ],
    "authors": [
      {
        "name": "de Labrusse Stéphane",
        "email": "stephdl@de-labrusse.fr"
      }
    ],
    "docs": {
      "documentation_url": "https://docs.mattermost.com/",
      "bug_url": "https://github.com/NethServer/dev",
      "code_url": "https://github.com/NethServer/ns8-mattermost",
      "relnotes_url": "https://github.com/NethServer/ns8-mattermost/releases"
    },
    "source": "ghcr.io/nethserver/mattermost",
    "versions": [
      {
        "tag": "2.1.1",
        "testing": false,
        "labels": {
          "io.buildah.version": "1.23.1",
          "org.nethserver.authorizations": "node:fwadm traefik@node:routeadm",
          "org.nethserver.images": "docker.io/postgres:13.13-alpine docker.io/mattermost/mattermost-team-edition:9.11.6",
          "org.nethserver.rootfull": "0",
          "org.nethserver.tcp-ports-demand": "2",
          "org.nethserver.udp-ports-demand": "1"
        }
      }
    ],
    "id": "mattermost",
    "repository": "default",
    "repository_updated": "Tue, 28 Jan 2025 18:42:14 GMT",
    "repository_authority": "distfeed.nethserver.org",
    "certification_level": 4,
    "rootfull": false,
    "disabled_updates_reason": "",
    "installed": [],
    "updates": [],
    "install_destinations": [
      {
        "node_id": 1,
        "instances": 0,
        "eligible": true,
        "reject_reason": null
      }
    ]
  },
```
