### PR TITLE
docs(metadata): add release notes URL to module metadata

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/modules.py
@@ -336,6 +336,14 @@ def _get_available_modules(rdb):
                 continue # skip duplicated images from lower priority modules
             modules[rmod["source"]] = rmod
             rmod['versions'].sort(key=lambda v: _parse_version_object(v["tag"]), reverse=True)
+            # Set the general release note URL if the code URL is a GitHub repository
+            if rmod.get('docs') and rmod['docs'].get('code_url').startswith("https://github.com/") and not rmod['docs'].get('relnotes_url'):
+                rmod['docs']['relnotes_url']= f"{rmod['docs']['code_url']}/releases"
+            else:
+                if not rmod.get('docs'):
+                    rmod['docs'] = {}
+                rmod['docs']['relnotes_url']= ""
+
     # Integrate the available set with instances that do not belong to any
     # repository. They can be found in the "installed" dict:
     for module_source, module_instances in list_installed(rdb).items():

--- a/docs/modules/metadata.md
+++ b/docs/modules/metadata.md
@@ -38,7 +38,8 @@ Example of `metadata.json`:
     "terms_url": "https://docs.kickstart.com/terms/",
     "documentation_url": "https://docs.kickstart.com/",
     "bug_url": "https://github.com/NethServer/dev",
-    "code_url": "https://github.com/author/ns8-kickstart"
+    "code_url": "https://github.com/author/ns8-kickstart",
+    "relnotes_url": "https://github.com/author/ns8-kickstart/releases"
   },
   "source": "ghcr.io/nethserver/kickstart"
 }
@@ -52,6 +53,8 @@ source
 file](https://github.com/NethServer/ns8-core/blob/main/core/ui/public/i18n/en/translation.json),
 under the `app_categories` object. Change proposals to the category list can be
 discussed on the community forum, as explained in [development process](../../development_process/).
+
+The `relnotes_url` is an optional key in the module metadata that specifies the URL to the release changelog page. This URL points to the location where users can find detailed information about the changes, improvements, and fixes included in each release of the module.
 
 ## Logo
 


### PR DESCRIPTION
Introduce functionality to set release note URLs for modules, enhancing documentation accessibility.

https://github.com/NethServer/dev/issues/7243