### PR TITLE
fix: broken forced remove-module

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/remove-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/remove-module/50update
@@ -63,10 +63,11 @@ try:
         },
         endpoint="redis://cluster-leader",
     )
-    agent.assert_exp(destroy_module_result['exit_code'] == 0)
+    if destroy_module_result['exit_code'] != 0:
+        raise Exception(f"non-zero exit-code from subtask")
 except Exception as ex:
     if forced_removal:
-        print(agent.SD_WARNING + "Destroy module failed:", ex, file=sys.stderr)
+        print(agent.SD_WARNING + f"module/{module_id}/destroy-module failed:", ex, file=sys.stderr)
     else:
         raise ex
 
@@ -80,10 +81,11 @@ try:
         },
         endpoint="redis://cluster-leader",
     )
-    agent.assert_exp(remove_module_result['exit_code'] == 0) # The node remove-module action must succeed
+    if remove_module_result['exit_code'] != 0: # The node remove-module action must succeed
+        raise Exception(f"non-zero exit-code from subtask")
 except Exception as ex:
     if forced_removal:
-        print(agent.SD_WARNING + "Remove module from node has failed:", ex, file=sys.stderr)
+        print(agent.SD_WARNING + f"node/{node_id}/remove-module failed:", ex, file=sys.stderr)
     else:
         raise ex
 


### PR DESCRIPTION
Avoid premature step termination for sys.exit(2) invoked by agent.assert_exp(). The forced exit happens before the code that ignores the error.

```
Feb 10 15:25:39 ns8 agent@cluster[1114668]: task/cluster/5b8815fa-3309-4432-9044-5b4ce0b3f7c4: remove-module/50update is starting
Feb 10 15:25:54 ns8 agent@cluster[1114668]: Assertion failed
Feb 10 15:25:54 ns8 agent@cluster[1114668]:   File "/var/lib/nethserver/cluster/actions/remove-module/50update", line 66, in <module>
Feb 10 15:25:54 ns8 agent@cluster[1114668]:     agent.assert_exp(destroy_module_result['exit_code'] == 0)
Feb 10 15:25:54 ns8 agent@cluster[1114668]: task/cluster/5b8815fa-3309-4432-9044-5b4ce0b3f7c4: action "remove-module" status is "aborted" (2) at step 50update
```

Note exit code (2) and the "Assertion failed": the proof of agent.assert_exp() invocation.