### PR TITLE
fix(ldap): Update domain configuration and reload event

### DIFF
--- a/core/ui/src/components/domains/AddExternalProviderModal.vue
+++ b/core/ui/src/components/domains/AddExternalProviderModal.vue
@@ -176,6 +176,7 @@ export default {
     addExternalProviderCompleted() {
       // hide modal after validation
       this.$emit("hide");
+      this.$emit("reloadDomains");
     },
   },
 };

--- a/core/ui/src/views/DomainConfiguration.vue
+++ b/core/ui/src/views/DomainConfiguration.vue
@@ -1049,7 +1049,7 @@ export default {
       }
       this.currentProvider = provider;
 
-      if (this.domain.schema === "ad") {
+      if (this.domain.schema === "ad" && this.domain.location == "internal") {
         this.isShownDeleteSambaProviderModal = true;
       } else {
         this.isShownDeleteLdapProviderModal = true;

--- a/core/ui/src/views/DomainConfiguration.vue
+++ b/core/ui/src/views/DomainConfiguration.vue
@@ -520,6 +520,7 @@
         :isShown="isShownAddExternalProviderModal"
         :domain="domain"
         @hide="hideAddExternalProviderModal"
+        @reloadDomains="listUserDomains"
       />
     </template>
     <!-- delete ldap provider modal -->


### PR DESCRIPTION
Refine the domain configuration logic for internal Active Directory schemas and emit a reload event after adding an external provider.

https://github.com/NethServer/dev/issues/7315