### PR TITLE
fix(node-monitor): add new swap alert

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/bin/node-monitor
+++ b/core/imageroot/var/lib/nethserver/node/bin/node-monitor
@@ -74,8 +74,17 @@ async def raise_alert(value, alert):
     elif alert_provider == 'nscom':
         await send_alert(f'{dartagnan_url}/machine/alerts/store', value, alert)
 
+async def check_swap_presence():
+    meminfo = parse_meminfo()
+    if int(meminfo['SwapTotal']) == 0:
+        return (CRITICAL, 'swap:notpresent:' + node_name)
+    else:
+        return (CLEAR, 'swap:notpresent:' + node_name)
+
 async def check_swap():
     meminfo = parse_meminfo()
+    if int(meminfo['SwapTotal']) == 0:
+        return (CLEAR, 'swap:full:' + node_name)
     try:
         swapfree_ratio = float(meminfo['SwapFree']) / int(meminfo['SwapTotal'])
     except:
@@ -150,6 +159,7 @@ async def main():
     # Run each check inside a monitor loop in parallel:
     await asyncio.gather(
         monitor_loop(check_swap, period=3, hysteresis=10), # 30 seconds
+        monitor_loop(check_swap_presence, period=60, hysteresis=30), # 30 minutes
         monitor_loop(check_systemload, period=5, hysteresis=24), # 2 minutes
         monitor_loop(check_mountpoints, fargs=['/', 'root'], period=15, hysteresis=4), # 1 minute
         monitor_loop(check_mountpoints, fargs=['/boot', 'boot'], period=15, hysteresis=4), # 1 minute


### PR DESCRIPTION
Changes:

- do not raise swap:full:<node_id> alert if the swap is not configured
- add a new swap:notpresent:<node_id> alert if swap is not present

NethServer/dev#7163

Example on my.nethesis.it:
![Screenshot From 2025-02-17 14-51-37](https://github.com/user-attachments/assets/3c1ec290-275c-43dc-ad3d-784343a6b2b1)
