### PR TITLE
Reset form fields and update loading state in AddExternalProviderModal

### DIFF
--- a/core/ui/src/components/domains/AddExternalProviderModal.vue
+++ b/core/ui/src/components/domains/AddExternalProviderModal.vue
@@ -84,6 +84,9 @@ export default {
     isShown: function () {
       if (this.isShown) {
         this.clearErrors(this);
+        // reset form
+        this.host = "";
+        this.port = "";
 
         setTimeout(() => {
           this.focusElement("host");
@@ -174,6 +177,7 @@ export default {
       }
     },
     addExternalProviderCompleted() {
+      this.loading.addExternalProvider = false;
       // hide modal after validation
       this.$emit("hide");
       this.$emit("reloadDomains");


### PR DESCRIPTION
Reset form fields in the AddExternalProviderModal upon showing the modal and update the loading state after adding an external provider.
https://github.com/NethServer/dev/issues/7326

![image](https://github.com/user-attachments/assets/fa880bab-ac14-459f-9297-005abb5d237f)
