### PR TITLE
fix(create-cluster): use Traefik config of workers

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/50update
@@ -29,7 +29,6 @@ import agent.tasks
 import cluster.grants
 import cluster.vpn
 import uuid
-import pwd
 
 request = json.load(sys.stdin)
 


### PR DESCRIPTION
Traefik API connections originate only from the localhost, access from cluster VPN is not needed.

The cluster VPN is not automatically inserted in Traefik configuration of worker nodes. As result there is a configuration difference between the original cluster leader and other nodes. This commit wants to remove this conflicting configuration.


Refs NethServer/dev#7312
Reverts 7c90ee261983df108715deef714b765360f45012