### PR TITLE
fix(node_exporter): make backup.prom readable

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/events/backup-status-changed/10node_monitor
+++ b/core/imageroot/var/lib/nethserver/cluster/events/backup-status-changed/10node_monitor
@@ -57,4 +57,5 @@ with tempfile.NamedTemporaryFile('w', delete=False, dir=os.path.dirname(OUTPUT_F
     temp_filename = temp_file.name
 
 os.replace(temp_filename, OUTPUT_FILE)
-
+# make OUTPUT_FILE readable by node_exporter
+os.chmod(OUTPUT_FILE, 0o644)


### PR DESCRIPTION
Avoid error like:
```
"failed to collect textfile data" collector=textfile file=backup.prom err="failed to open textfile data file
\"/host/run/node_exporter/backup.prom\": open /host/run/node_exporter/backup.prom: permission denied"
```