### PR TITLE
fix(backup): remove stale status

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/events/backup-status-changed/10node_monitor
+++ b/core/imageroot/var/lib/nethserver/cluster/events/backup-status-changed/10node_monitor
@@ -21,6 +21,12 @@ leader_id = int(rdb.hget('cluster/environment', 'NODE_ID'))
 self_id = int(os.environ['NODE_ID'])
 
 if self_id != leader_id:
+    # Remove backup status from the worker node:
+    # avoid false alarms after a switch-leader
+    try:
+        os.remove(OUTPUT_FILE)
+    except OSError:
+        pass
     sys.exit(0) # LEADER ONLY! Do not run this procedure in worker nodes.
 
 # Ensure the output directory exists


### PR DESCRIPTION
Prevent alerts for backups generated from a worker node after a switch leader