### PR TITLE
fix: extraction of module UI

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-module/50update
@@ -139,7 +139,11 @@ for idx, retval in enumerate(update_retvals):
         agent.run_helper('extract-ui', image_url).check_returncode()
         # Replace the app UI directory. Cannot find a way to do this
         # atomically and faster.
-        os.rename(appspath + mid, appspath + mid + dsfx + '~')
+        try:
+            os.rename(appspath + mid, appspath + mid + dsfx + '~')
+        except Exception as ex:
+            print(agent.SD_WARNING + f"Cannot rename the old {mid} UI directory: {ex}", file=sys.stderr)
+            pass # ignore errors if the source dir is missing
         os.rename(appspath + mid + dsfx, appspath + mid)
         agent.run_helper('rm', '-rf', appspath + mid + dsfx + '~')
         # Remove the previous image, we do not need anymore


### PR DESCRIPTION
The cluster leader keeps a copy of UI code. During the module update the previous UI code is renamed before being deleted. If an error occurs it is ignored in this case.

```text
Mar  5 07:37:55 server1 agent@cluster[2049224]: Module UI update failed for instance nethvoice-proxy2: [Errno 2] No such file or directory: '/var/lib/nethserver/cluster/ui/apps/nethvoice-proxy2' -> '/var/lib/nethserver/cluster/ui/apps/nethvoice-proxy2.d1bf94bf~'
Mar  5 07:37:55 server1 agent@cluster[2049224]: Assertion failed
Mar  5 07:37:55 server1 agent@cluster[2049224]:  File "/var/lib/nethserver/cluster/actions/update-module/50update", line 154, in <module>
Mar  5 07:37:55 server1 agent@cluster[2049224]:    agent.assert_exp(errors == 0)
Mar  5 07:37:55 server1 agent@cluster[2049224]: task/cluster/d1bf94bf-7cb6-4250-a54f-7338e4ab1a7f: action "update-module" status is "aborted" (2) at step 50update
```


Refs https://mattermost.nethesis.it/nethesis/pl/utjk4jt117r5jr9z14oou9qu6y