### PR TITLE
fix(password warning): prevent form submit

### DIFF
--- a/core/ui/src/components/domains/EditPasswordWarningModal.vue
+++ b/core/ui/src/components/domains/EditPasswordWarningModal.vue
@@ -8,6 +8,9 @@
     :visible="isShown"
     @modal-hidden="$emit('hide')"
     @primary-click="$emit('confirm')"
+    :primaryButtonDisabled="
+      !policy.expiration.enforced || !policy.warning.smtp_enabled
+    "
   >
     <template slot="title">{{ $t("domains.edit_password_warning") }}</template>
     <template slot="content">
@@ -112,12 +115,9 @@
       />
     </template>
     <template slot="secondary-button">{{ $t("common.cancel") }}</template>
-    <template
-      v-if="policy.expiration.enforced"
-      @submit.prevent="setPasswordWarning"
-      slot="primary-button"
-      >{{ $t("domains.edit_password_warning") }}</template
-    >
+    <template slot="primary-button">{{
+      $t("domains.edit_password_warning")
+    }}</template>
   </NsModal>
 </template>
 


### PR DESCRIPTION
Disable the modal primary button if SMTP is not
configured or password age is disabled