### PR TITLE
feat(ui): add ip_allowlist

### DIFF
--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -728,7 +728,14 @@
         "node_helper": "Select the node where the route will be created",
         "skip_cert_verify": "Skip certificate validation",
         "skipCertVerify_tooltip": "Skip certificate validation for the backend target URL",
-        "instance_pattern": "Allowed characters: A-Z, a-z, 0-9, _ and -"
+        "instance_pattern": "Allowed characters: A-Z, a-z, 0-9, _ and -",
+        "ip_allowlist": "Restric access from",
+        "ip_allowlist_placeholder": "Eg. 192.168.7.0/24",
+        "ip_allowlist_helper": "Enter one IPv4 or CIDR address per line. Leave empty to allow access from any IP address",
+        "invalid_ipv4": "Invalid IPv4 address: {ip}",
+        "automatic": "Automatic",
+        "restricted": "Access restricted",
+        "attributes": "Attributes"
     },
     "settings_tls_certificates": {
         "title": "TLS certificates",

--- a/core/ui/src/components/settings/HttpRouteDetailModal.vue
+++ b/core/ui/src/components/settings/HttpRouteDetailModal.vue
@@ -83,6 +83,14 @@
         </span>
       </div>
       <div class="key-value-setting">
+        <span class="label">{{ $t("settings_http_routes.ip_allowlist") }}</span>
+        <span class="value">{{
+          route.ip_allowlist && route.ip_allowlist.length
+            ? route.ip_allowlist.join(", ")
+            : "-"
+        }}</span>
+      </div>
+      <div class="key-value-setting">
         <span class="label">{{ $t("settings_http_routes.node") }}</span>
         <span class="value">{{ route.longNodeLabel }}</span>
       </div>

--- a/core/ui/src/views/settings/SettingsHttpRoutes.vue
+++ b/core/ui/src/views/settings/SettingsHttpRoutes.vue
@@ -153,6 +153,24 @@
                         <cv-data-table-cell>
                           <span>{{ row.node }}</span>
                         </cv-data-table-cell>
+                        <cv-data-table-cell>
+                          <NsTag
+                            v-if="!row.user_created"
+                            kind="grey"
+                            size="sm"
+                            :label="$t('settings_http_routes.automatic')"
+                          />
+                          <NsTag
+                            v-if="
+                              row.ip_allowlist !== undefined &&
+                              row.ip_allowlist.length > 0
+                            "
+                            kind="high-contrast"
+                            size="sm"
+                            :label="$t('settings_http_routes.restricted')"
+                            class="no-margin"
+                          />
+                        </cv-data-table-cell>
                         <cv-data-table-cell class="table-overflow-menu-cell">
                           <cv-overflow-menu
                             flip-menu
@@ -170,7 +188,6 @@
                             </cv-overflow-menu-item>
                             <cv-overflow-menu-item
                               @click="showEditRouteModal(row)"
-                              :disabled="!row.user_created"
                               :data-test-id="row.name + '-edit'"
                             >
                               <NsMenuItem
@@ -279,7 +296,7 @@ export default {
         selectedNodeId: "",
       },
       tablePage: [],
-      tableColumns: ["name", "type", "node"],
+      tableColumns: ["name", "type", "node", "attributes"],
       routes: [],
       internalNodes: [],
       isShownCreateOrEditRouteModal: false,
@@ -555,6 +572,10 @@ export default {
           type = "path";
         }
         route.type = type;
+        route.ip_allowlist = route.ip_allowlist ? route.ip_allowlist : [];
+        route.ip_allowlist_str = route.ip_allowlist
+          ? route.ip_allowlist.join("\n")
+          : "";
 
         const traefikId = taskContext.extra.traefikInstance.id;
         const nodeId = taskContext.extra.traefikInstance.node;

--- a/core/ui/src/views/settings/SettingsHttpRoutes.vue
+++ b/core/ui/src/views/settings/SettingsHttpRoutes.vue
@@ -178,21 +178,21 @@
                             :data-test-id="row.name + '-menu'"
                           >
                             <cv-overflow-menu-item
-                              @click="showRouteDetailModal(row)"
-                              :data-test-id="row.name + '-details'"
-                            >
-                              <NsMenuItem
-                                :icon="ArrowRight20"
-                                :label="$t('common.see_details')"
-                              />
-                            </cv-overflow-menu-item>
-                            <cv-overflow-menu-item
                               @click="showEditRouteModal(row)"
                               :data-test-id="row.name + '-edit'"
                             >
                               <NsMenuItem
                                 :icon="Edit20"
                                 :label="$t('common.edit')"
+                              />
+                            </cv-overflow-menu-item>
+                            <cv-overflow-menu-item
+                              @click="showRouteDetailModal(row)"
+                              :data-test-id="row.name + '-details'"
+                            >
+                              <NsMenuItem
+                                :icon="ArrowRight20"
+                                :label="$t('common.see_details')"
                               />
                             </cv-overflow-menu-item>
                             <cv-overflow-menu-item


### PR DESCRIPTION
Changes:

- manual routes: add list of allowed IPs inside edit and add modal
- automatic routes: change only the allowed IPs
- kebab menu: move the Edit action as first action (is likely the one that users will access more often)
- route list: show new tags, "automatic" for module-created rules, "access restricted" if IP allow list is set

NethServer/dev#7348

List:
![image](https://github.com/user-attachments/assets/209ff3a0-381e-476f-acfa-def81418aef3)

Details with ip allow list:
![image](https://github.com/user-attachments/assets/d6e9376d-42db-4a6a-8b67-6fb9e45db81b)

Details no ip allow list:
![image](https://github.com/user-attachments/assets/ff739d3b-52f9-468a-a24b-e87db492461e)

Edit manual route:
![image](https://github.com/user-attachments/assets/c3fe48d1-564b-4926-bb9b-79215476b562)

Now automatic routes are editable, only the ip allow list is editable for automatic routes:
![image](https://github.com/user-attachments/assets/f4acdf53-47f6-4f9b-b2d5-cb8615e3279c)

Validation error:
![image](https://github.com/user-attachments/assets/54238473-741c-4896-8c5c-8288d30a77b8)
