### PR TITLE
fix: Traefik restore for disaster recovery

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/retrieve-cluster-backup/20save
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/retrieve-cluster-backup/20save
@@ -87,8 +87,6 @@ result = {
     'vpn': dump['vpn']['endpoint'],
     'domains': len(dump['cluster']['user_domain']['ldap']),
     'backup_repositories': len(dump['cluster']['backup_repository']),
-    'routes': len(dump['traefik']['leader']['routes']),
-    'certificates': len(dump['traefik']['leader']['uploaded_certificates']),
 }
 
 json.dump(result, fp=sys.stdout)

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -243,8 +243,6 @@
         "traveling_back_in_time": "Traveling back in time...",
         "reading_backup_repositories": "Reading backup repositories...",
         "creating_cluster": "Creating cluster...",
-        "custom_routes": "Custom HTTP routes",
-        "custom_certificates": "Uploaded certificates",
         "leader_node_hostname": "Leader node hostname",
         "worker_node_hostname": "Worker node hostname",
         "leader_node_domain": "Leader node domain",

--- a/core/ui/src/views/InitializeCluster.vue
+++ b/core/ui/src/views/InitializeCluster.vue
@@ -627,18 +627,6 @@
                       <span class="value">{{ restore.summary.domains }}</span>
                     </div>
                     <div class="key-value-setting">
-                      <span class="label">{{ $t("init.custom_routes") }}</span>
-                      <span class="value">{{ restore.summary.routes }}</span>
-                    </div>
-                    <div class="key-value-setting">
-                      <span class="label">{{
-                        $t("init.custom_certificates")
-                      }}</span>
-                      <span class="value">{{
-                        restore.summary.certificates
-                      }}</span>
-                    </div>
-                    <div class="key-value-setting">
                       <span class="label">{{
                         $t("init.backup_repositories")
                       }}</span>


### PR DESCRIPTION
Remove references to Traefik custom certificates and routes in the cluster backup, now that they are part of Traefik backup itsef.

Ref #790, NethServer/dev#7158 