### PR TITLE
Cluster user expiration and mail address UI

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/list-domain-users/50list_users
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/list-domain-users/50list_users
@@ -30,7 +30,7 @@ request = json.load(sys.stdin)
 
 domain = Ldapproxy().get_domain(request['domain'])
 
-users = Ldapclient.factory(**domain).list_users()
+users = Ldapclient.factory(**domain).list_users(extra_info=True)
 
 users = sorted(users, key=lambda rec: rec['user'])
 json.dump({"users":users}, fp=sys.stdout)

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -1197,7 +1197,9 @@
         "warning_template_subject_tip": "Enter plain text. Available placeholders: $user (username), $name (user display name), $days (days to expiration), $domain (user domain), $portal_url (user portal URL)",
         "warning_smtp_disabled_title": "Cluster SMTP is disabled",
         "warning_smtp_disabled_description": "Enable SMTP in the cluster settings to send password expiration warnings",
-        "go_to_smtp_settings": "Go to Mail notifications"
+        "go_to_smtp_settings": "Go to Mail notifications",
+        "password_expired": "Password expired",
+        "password_does_not_expire": "No expiration"
     },
     "samba": {
         "adminuser": "Samba admin username",

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -1197,9 +1197,9 @@
         "warning_template_subject_tip": "Enter plain text. Available placeholders: $user (username), $name (user display name), $days (days to expiration), $domain (user domain), $portal_url (user portal URL)",
         "warning_smtp_disabled_title": "Cluster SMTP is disabled",
         "warning_smtp_disabled_description": "Enable SMTP in the cluster settings to send password expiration warnings",
-        "go_to_smtp_settings": "Go to Mail notifications",
+        "go_to_smtp_settings": "Go to Email notifications",
         "password_expired": "Password expired",
-        "password_does_not_expire": "No expiration"
+        "password_does_not_expire": "No password expiration"
     },
     "samba": {
         "adminuser": "Samba admin username",
@@ -1284,7 +1284,10 @@
         "user_string_lte": "Must be less than or equal to 255 characters",
         "group_with_same_name": "A group with this name already exists",
         "user_with_same_name": "A user with this name already exists",
-        "display_name_string_lte": "Must be less than or equal to 256 characters"
+        "display_name_string_lte": "Must be less than or equal to 256 characters",
+        "mail_field": "Mail address (optional)",
+        "mail": "Mail address",
+        "mail_format": "Invalid mail format"
     },
     "domain_configuration": {
         "title": "Domain configuration",

--- a/core/ui/src/components/domains/CreateOrEditUserModal.vue
+++ b/core/ui/src/components/domains/CreateOrEditUserModal.vue
@@ -85,7 +85,9 @@
           :focus="focusPasswordField"
           :clearConfirmPasswordCommand="clearConfirmPasswordCommand"
           :minLength="
-            policy.strength.enforced ? policy.strength.password_min_length : 0
+            policy.strength.enforced
+              ? parseInt(policy.strength.password_min_length, 10)
+              : 0
           "
           :checkComplexity="
             policy.strength.enforced ? policy.strength.complexity_check : false

--- a/core/ui/src/components/domains/DomainUsers.vue
+++ b/core/ui/src/components/domains/DomainUsers.vue
@@ -88,6 +88,9 @@
                     {{ row.display_name }}
                   </cv-data-table-cell>
                   <cv-data-table-cell>
+                    {{ row.mail ? row.mail : "" }}
+                  </cv-data-table-cell>
+                  <cv-data-table-cell>
                     <cv-tag
                       v-if="row.locked"
                       kind="high-contrast"
@@ -100,14 +103,12 @@
                       kind="high-contrast"
                       :label="$t('domains.password_expired')"
                       size="sm"
-                      class="expired-tag"
                     ></cv-tag>
                     <cv-tag
                       v-if="row.password_expiration < 0"
                       kind="gray"
                       :label="$t('domains.password_does_not_expire')"
                       size="sm"
-                      class="expired-tag"
                     ></cv-tag>
                   </cv-data-table-cell>
                   <cv-data-table-cell
@@ -234,7 +235,7 @@ export default {
       isEditingUser: false,
       currentUser: null,
       userToDelete: null,
-      tableColumns: ["user", "display_name", "attributes"],
+      tableColumns: ["user", "display_name", "mail", "attributes"],
       tablePage: [],
       loading: {
         listDomainUsers: false,

--- a/core/ui/src/components/domains/DomainUsers.vue
+++ b/core/ui/src/components/domains/DomainUsers.vue
@@ -95,6 +95,20 @@
                       size="sm"
                       class="disabled-tag"
                     ></cv-tag>
+                    <cv-tag
+                      v-if="row.expired"
+                      kind="high-contrast"
+                      :label="$t('domains.password_expired')"
+                      size="sm"
+                      class="expired-tag"
+                    ></cv-tag>
+                    <cv-tag
+                      v-if="row.password_expiration < 0"
+                      kind="gray"
+                      :label="$t('domains.password_does_not_expire')"
+                      size="sm"
+                      class="expired-tag"
+                    ></cv-tag>
                   </cv-data-table-cell>
                   <cv-data-table-cell
                     v-if="domain && domain.location == 'internal'"


### PR DESCRIPTION
Main issue: NethServer/dev#7349

To work properly, the UI requires to use updated version of Samba e OpenLdap modules:
- https://github.com/NethServer/ns8-samba/pull/84
- https://github.com/NethServer/ns8-openldap/pull/56

User list:
![image](https://github.com/user-attachments/assets/d3725371-03f3-4595-853c-9675873a13fa)

Add user, with mail validation:
![image](https://github.com/user-attachments/assets/0d370120-95f0-443c-96f1-988b55582e73)


Edit user, mail field:
![image](https://github.com/user-attachments/assets/496825e5-d036-4608-bb19-37a0805326aa)



Install the custom core image:
```
curl https://raw.githubusercontent.com/NethServer/ns8-core/main/core/install.sh > install.sh 
bash install.sh ghcr.io/nethserver/core:user_expiration_ui
create-cluster rl1.leader.cluster0.gs.nethserver.net:55820 10.5.4.0/24 Nethesis,1234
```

Setup custom images for Samba and OpenLDAP:
```
redis-cli hset cluster/override/modules samba ghcr.io/nethserver/samba:cluster_ui
redis-cli hset cluster/override/modules openldap ghcr.io/nethserver/openldap:cluster_ui
```