### PR TITLE
fix(ui): HTTP route creation

### DIFF
--- a/core/ui/src/components/settings/CreateOrEditHttpRouteModal.vue
+++ b/core/ui/src/components/settings/CreateOrEditHttpRouteModal.vue
@@ -227,7 +227,7 @@ export default {
       strip_prefix: false,
       ip_allowlist: "",
       ip_allowlist_str: "",
-      user_created: false,
+      user_created: true,
       loading: {
         setRoute: false,
       },


### PR DESCRIPTION
The creation form fields are hidden except for "ip allow list". Invert the default user_created default value to show them.

Refs NethServer/dev#7362