### PR TITLE
fix(get-certificate): hide UI notification

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -726,6 +726,7 @@ def get_certificate(name):
         agent_id=resolve_agent_id("traefik@node"),
         action='get-certificate',
         data={ 'fqdn': name },
+        extra={'isNotificationHidden': True},
     )
     if response['exit_code'] != 0:
         raise Exception(f"{response['error']}")


### PR DESCRIPTION
Hide the task notification in UI which is generic and misleading for the user.

Note: the same code is used by other action-wrappers in the same file.

See https://community.nethserver.org/t/banner-flood-in-neth8-done/25615?u=davidep