### PR TITLE
feat(add-public-service): implement ports addition

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -421,13 +421,14 @@ def get_image_name_from_url(image_url):
     image_name, _ = image_nametag.replace('@', ':', 1).split(':', 1)
     return image_name
 
-def add_public_service(name, ports):
+def add_public_service(name, ports, replace_ports=False):
     node_id = os.environ['NODE_ID']
     response = agent.tasks.run(
         agent_id=f'node/{node_id}',
         action='add-public-service',
         data={
             'service': name,
+            'replace_ports': replace_ports,
             'ports': ports
         }
     )

--- a/core/imageroot/var/lib/nethserver/node/actions/add-public-service/50add
+++ b/core/imageroot/var/lib/nethserver/node/actions/add-public-service/50add
@@ -23,25 +23,49 @@
 import sys
 import json
 import agent
+import subprocess
 
 request = json.load(sys.stdin)
 name = request['service']
-ports = request['ports']
+new_ports = set(request['ports'])
 
 fw_cmd = ['firewall-cmd', '--permanent']
 
-# Create the service
-agent.run_helper(*fw_cmd, f'--new-service={name}').check_returncode()
-
-# Add the service to default zone
-agent.run_helper(*fw_cmd, f'--add-service={name}').check_returncode()
+try:
+    # Retrieve the current service ports
+    current_ports = set(subprocess.check_output(
+        fw_cmd + [f'--service={name}', '--get-ports'],
+        stderr=subprocess.DEVNULL,
+        text=True,
+    ).split())
+except subprocess.CalledProcessError as ex:
+    if ex.returncode == 101: # INVALID_SERVICE
+        print(agent.SD_INFO + f'Firewall public service "{name}" does not exist and will be created.', file=sys.stderr)
+        current_ports = set()
+        # Create the service
+        agent.run_helper(*fw_cmd, f'--new-service={name}').check_returncode()
+        # Add the service to default zone
+        agent.run_helper(*fw_cmd, f'--add-service={name}').check_returncode()
+    else:
+        raise ex
 
 # Add service ports
-port_cmd = [f'--service={name}']
-for port in ports:
-    port_cmd.append(f'--add-port={port}')
+port_add_cmd = [f'--service={name}']
+for port in new_ports.difference(current_ports):
+    port_add_cmd.append(f'--add-port={port}')
+if len(port_add_cmd) > 1:
+    agent.run_helper(*fw_cmd, *port_add_cmd).check_returncode()
 
-agent.run_helper(*fw_cmd, *port_cmd).check_returncode()
+# If asked, remove any current port not in the request
+port_remove_cmd = [f'--service={name}']
+if request.get('replace_ports'):
+    for port in current_ports.difference(new_ports):
+        port_remove_cmd.append(f'--remove-port={port}')
+    if len(port_remove_cmd) > 1:
+        agent.run_helper(*fw_cmd, *port_remove_cmd).check_returncode()
 
-# Apply the configuration
-agent.run_helper('firewall-cmd', '--reload').check_returncode()
+if len(port_add_cmd) > 1 or len(port_remove_cmd) > 1:
+    # Apply the configuration
+    agent.run_helper('firewall-cmd', '--reload').check_returncode()
+else:
+    print(agent.SD_INFO + f'Firewall public service "{name}" unchanged.', file=sys.stderr)

--- a/core/imageroot/var/lib/nethserver/node/actions/add-public-service/validate-input.json
+++ b/core/imageroot/var/lib/nethserver/node/actions/add-public-service/validate-input.json
@@ -7,6 +7,15 @@
         {
             "service": "smtp",
             "ports": [
+                "587/tcp"
+            ]
+        },
+        {
+            "service": "smtp",
+            "replace_ports": true,
+            "ports": [
+                "465/tcp",
+                "587/tcp",
                 "25/tcp"
             ]
         }
@@ -21,6 +30,11 @@
             "type": "string",
             "title": "Service name",
             "minLength": 1
+        },
+        "replace_ports": {
+            "type":"boolean",
+            "description": "If true, the provided list of ports replaces any existing configuration for the service. If false or omitted, the ports are added to the existing set.",
+            "default": false
         },
         "ports": {
             "type": "array",

--- a/docs/core/firewall.md
+++ b/docs/core/firewall.md
@@ -43,7 +43,8 @@ In `create-module`:
 ```python
 import os
 import agent
-agent.assert_exp(agent.add_public_service(os.environ['MODULE_ID'], ["80/tcp", "443/tcp"]))
+# Raise an exception if add_public_service() returns False
+agent.assert_exp(agent.add_public_service(os.environ['MODULE_ID'], ["9010/tcp", "9011/tcp"]), "Firewall service configuration has failed")
 ```
 
 In `destroy-module`:
@@ -51,5 +52,28 @@ In `destroy-module`:
 ```python
 import os
 import agent
-agent.assert_exp(agent.remove_public_service(os.environ['MODULE_ID']))
+# Ignore errors on service cleanup
+agent.remove_public_service(os.environ['MODULE_ID'])
+```
+
+Function `agent.add_public_service()` can be later invoked with additional
+ports, for example during an application update that implements a new
+public service. The given port list is _added_ to the existing one. For example:
+
+
+```python
+import os
+import agent
+
+agent.add_public_service(os.environ['MODULE_ID'], ["9012/tcp"])
+```
+
+If you want to completely replace the port list, set `replace_ports=True`,
+for example:
+
+```python
+import os
+import agent
+
+agent.add_public_service(os.environ['MODULE_ID'], ["9010/tcp","9012/tcp"], replace_ports=True)
 ```


### PR DESCRIPTION
Allow multiple invocations of add-public-service with or without ports replacement. This new behavior simplifies the addition of new services to existing applications, like Samba WSDD.

Implementation note: `firewall-cmd` does not allow to use both `--add-port` and `--remove-port` in the same invocation, so I split them in two command calls.

Refs NethServer/dev#7372