### PR TITLE
fix(promtail): replace with alloy

### DIFF
--- a/core/build-image.sh
+++ b/core/build-image.sh
@@ -77,7 +77,7 @@ printf "REDIS_IMAGE=${repobase}/redis:%s\n" "${IMAGETAG:-latest}" >> "${core_env
 printf "RSYNC_IMAGE=${repobase}/rsync:%s\n" "${IMAGETAG:-latest}" >> "${core_env_file}"
 printf "RESTIC_IMAGE=${repobase}/restic:%s\n" "${IMAGETAG:-latest}" >> "${core_env_file}"
 printf "SUPPORT_IMAGE=${repobase}/support:%s\n" "${IMAGETAG:-latest}" >> "${core_env_file}"
-printf "PROMTAIL_IMAGE=docker.io/grafana/promtail:2.9.2\n" >> "${core_env_file}"
+printf "PROMTAIL_IMAGE=docker.io/grafana/alloy:v1.8.0\n" >> "${core_env_file}"
 printf "NODE_EXPORTER_IMAGE=quay.io/prometheus/node-exporter:v1.9.0\n" >> "${core_env_file}"
 chmod -c 644 "${core_env_file}"
 source "${core_env_file}"

--- a/core/imageroot/etc/systemd/system/promtail.service
+++ b/core/imageroot/etc/systemd/system/promtail.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Promtail logs collector for Loki
+Description=Alloy (previously Promtail) logs collector for Loki
 After=redis.service
 
 [Service]
@@ -24,8 +24,7 @@ ExecStart=/usr/bin/podman run \
     --volume=./journal:/var/log/journal \
     --volume=./promtail:/etc/promtail:z \
     --volume=promtail-position:/var/lib/promtail:z \
-    ${PROMTAIL_IMAGE} \
-    -config.file=/etc/promtail/config.yml
+    ${PROMTAIL_IMAGE} run /etc/promtail/config.alloy
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%N.cid -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%N.cid
 PIDFile=%t/%N.pid

--- a/core/imageroot/var/lib/nethserver/node/bin/generate-promtail-config
+++ b/core/imageroot/var/lib/nethserver/node/bin/generate-promtail-config
@@ -6,7 +6,6 @@
 #
 
 import agent
-import yaml
 import sys
 import os
 import pwd
@@ -31,7 +30,7 @@ if not client_list:
     print(agent.SD_ERR + "No client configuration found. Is Loki installed?", file=sys.stderr)
     sys.exit(1)
 
-relabel_configs = []
+relabel_rules = []
 
 # Parse /etc/subuid for later usage
 module_uid_ranges = dict()
@@ -74,13 +73,14 @@ for pwrecord in pwd.getpwall():
     # module_id is a Unix user, if _UID journal field matches the user
     # Unix uid or any of its subuids the journal record belongs to the
     # module.
-    relabel_configs.append({
-        # NOTE: default "action" is "replace"
-        "source_labels": ["__journal__uid"],
-        "regex": rxpat,
-        "replacement": module_id,
-        "target_label": "module_id",
-    })
+    relabel_rules.append(f"""
+    rule {{
+        source_labels = ["__journal__uid"]
+        regex         = "{rxpat}"
+        target_label  = "module_id"
+        replacement   = "{module_id}"
+    }}
+    """)
     print("Generating labeling configuration for " + module_id)
 
 # Iterate over rootfull modules, matching the module_id in AGENT_STATE_DIR
@@ -96,62 +96,69 @@ for rfpath in glob.glob('/var/lib/nethserver/*/state'):
 
     # If module_id is contained in SYSLOG_IDENTIFIER, CONTAINER_NAME
     # or _SYSTEMD_UNIT fields the journal record belongs to it.
-    relabel_configs.append({
-        # NOTE: default "action" is "replace"
-        "source_labels": [
-            "__journal__systemd_unit",
-            "__journal_syslog_identifier",
-            "__journal_container_name",
-        ],
-        "regex": '.*\\b' + module_id + '\\b.*', # match word boundaries (unanchored)
-        "replacement": module_id,
-        "target_label": "module_id",
-    })
-    print("Generating labeling configuration for " + module_id)
+    relabel_rules.append(f"""
+    rule {{
+        source_labels = ["__journal__systemd_unit", "__journal_syslog_identifier", "__journal_container_name"]
+        regex         = ".*\\b{module_id}\\b.*"
+        target_label  = "module_id"
+        replacement   = "{module_id}"
+    }}
+    """)
 
 # Work around log flooding from grafana/loki#7649
 # Drop "context canceled" messages from loki-server container
-relabel_configs.append({
-    "action": "drop",
-    "source_labels": ["__journal_syslog_identifier", "__journal_message"],
-    "regex": "loki-server;.*context canceled.*",
-})
+relabel_rules.append("""
+    rule {
+        source_labels = ["__journal_syslog_identifier", "__journal_message"]
+        regex         = "loki-server;.*context canceled.*"
+        action        = "drop"
+    }
+""")
 
 # Set label category=security for messages from sshd, PAM, Polkit, etc.
 # that are often written to /var/log/secure or equivalent.
-relabel_configs.append({
-    "source_labels": ["__journal_syslog_facility"],
-    "regex": "(4|10|13|14)", # RFC3164 Syslog facility codes for security events
-    "replacement": "security",
-    "target_label": "category",
-})
-
-# Configuration data. Will be converted to a YAML file:
-config = {
-    "server": {
-        "disable": True
-    },
-    "clients": client_list,
-    "scrape_configs": [{
-        "job_name": "journal",
-        "journal": {
-            "max_age": "12h",
-            "json": True,
-            "labels": {
-                "node_id": os.environ["NODE_ID"],
-            },
-        },
-        "relabel_configs": relabel_configs,
-    }],
-    "positions": {
-        "filename": "/var/lib/promtail/positions.yml",
-        "sync_period": "10s",
-        "ignore_invalid_yaml": True,
+# Regex matches RFC3164 Syslog facility codes for security events
+relabel_rules.append("""
+    rule {
+        source_labels = ["__journal_syslog_facility"]
+        regex         = "(4|10|13|14)"
+        target_label  = "category"
+        replacement   = "security"
     }
-}
+""")
+
+# Generate Alloy configuration
+alloy_config = f"""
+discovery.relabel "journal" {{
+    targets = []
+
+    {"".join(relabel_rules)}
+}}
+
+loki.source.journal "journal" {{
+    format_as_json = true
+    max_age        = "12h0m0s"
+    relabel_rules  = discovery.relabel.journal.rules
+    forward_to     = [loki.write.default.receiver]
+    labels         = {{
+        node_id = "{os.environ['NODE_ID']}",
+    }}
+}}
+
+loki.write "default" {{
+    endpoint {{
+        url = "{client_list[0]['url']}"
+
+        authorization {{
+            type        = "Bearer"
+            credentials = "{client_list[0]['bearer_token']}"
+        }}
+    }}
+    external_labels = {{}}
+}}
+"""
 
 # Move into promtail directory and write the file, preserving SELinux contexts
 os.chdir("promtail")
-with open("config.yml.tmp", "w") as ofile:
-    yaml.dump(config, ofile)
-os.rename("config.yml.tmp", "config.yml")
+with open("config.alloy", "w") as ofile:
+    ofile.write(alloy_config)


### PR DESCRIPTION
Promtail is now deprecated and will be EOL in one year.
This PR allows to test Loki 3.x with the new stack.

Minimize the changes by keeping all file named after promtail.
There are only 2 required changes:
- use the alloy container image
- create the configuration with the new alloy syntax

Tested by generating a converted config file:
```
cd /var/lib/nethserver/node/state/
podman run -ti --rm -v ./promtail:/etc/alloy docker.io/grafana/alloy:v1.8.0 convert --source-format=promtail --bypass-errors --output=/etc/alloy/promtail.alloy /etc/alloy/config.yml
```

To update the core:
```
api-cli run update-core --data '{"core_url":"ghcr.io/nethserver/core:alloy","nodes":[1], "force": true}
```

Ref: NethServer/dev#7401