### PR TITLE
feat(restoration): add list exclusion in  restoration replacement logic

### DIFF
--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -602,6 +602,9 @@
         "select_backup_snapshot": "Select backup snapshot",
         "most_recent": "Most recent",
         "no_node_eligible_for_instance_restoration": "No node eligible for instance restoration",
+        "replace_existing_app_is_not_available_tooltip": "Cannot replace the existing application. The application must be removed by the system administrator before the restoration",
+        "replace_existing_app_tooltip": "Replace the existing application. The old application will be removed and the new one will be restored",
+        "replace_existing_app_select_an_app_tooltip": "Select an application to replace",
         "wrong_password_or_no_key_found": "Wrong data encryption key or no key found"
     },
     "calendar": {

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -602,8 +602,8 @@
         "select_backup_snapshot": "Select backup snapshot",
         "most_recent": "Most recent",
         "no_node_eligible_for_instance_restoration": "No node eligible for instance restoration",
-        "replace_existing_app_is_not_available_tooltip": "Cannot replace the existing application. The application must be removed by the system administrator before the restoration",
-        "replace_existing_app_tooltip": "Replace the existing application. The old application will be removed and the new one will be restored",
+        "replace_existing_app_is_not_available_tooltip": "Cannot replace the existing app. The app must be removed before the restoration",
+        "replace_existing_app_tooltip": "Replace the existing app. The old app instance will be removed and the new one will be restored",
         "replace_existing_app_select_an_app_tooltip": "Select an application to replace",
         "wrong_password_or_no_key_found": "Wrong data encryption key or no key found"
     },

--- a/core/ui/src/components/backup/RestoreSingleInstanceModal.vue
+++ b/core/ui/src/components/backup/RestoreSingleInstanceModal.vue
@@ -44,7 +44,7 @@
             </cv-row>
             <cv-row>
               <cv-column>
-                <cv-checkbox
+                <NsCheckbox
                   :label="
                     $t('backup.replace_existing_app', {
                       app: instanceToReplace,
@@ -54,7 +54,33 @@
                   :disabled="!instanceToReplace || replaceExistingDisabled"
                   value="checkReplaceExistingApp"
                   class="mg-top-xlg"
-                />
+                  tooltipAlignment="start"
+                  tooltipDirection="right"
+                >
+                  <template slot="tooltip">
+                    <div
+                      v-if="
+                        selectedInstance &&
+                        instanceToReplace &&
+                        replaceExistingDisabled
+                      "
+                    >
+                      {{
+                        $t(
+                          "backup.replace_existing_app_is_not_available_tooltip"
+                        )
+                      }}
+                    </div>
+                    <div v-else-if="!selectedInstance">
+                      {{
+                        $t("backup.replace_existing_app_select_an_app_tooltip")
+                      }}
+                    </div>
+                    <div v-else>
+                      {{ $t("backup.replace_existing_app_tooltip") }}
+                    </div>
+                  </template>
+                </NsCheckbox>
               </cv-column>
             </cv-row>
           </cv-grid>
@@ -214,7 +240,7 @@ export default {
     },
     replaceExistingDisabled() {
       //check if the selected instance is not in an array ['loki']
-      const notAllowed = ["loki", "mail", "ejabberd","nethvoice-proxy"];
+      const notAllowed = ["loki", "mail", "ejabberd", "nethvoice-proxy"];
       return notAllowed.includes(this.selectedInstance.name) ? true : false;
     },
     nodesInfo() {

--- a/core/ui/src/components/backup/RestoreSingleInstanceModal.vue
+++ b/core/ui/src/components/backup/RestoreSingleInstanceModal.vue
@@ -51,7 +51,7 @@
                     })
                   "
                   v-model="replaceExistingApp"
-                  :disabled="!instanceToReplace"
+                  :disabled="!instanceToReplace || replaceExistingDisabled"
                   value="checkReplaceExistingApp"
                   class="mg-top-xlg"
                 />
@@ -211,6 +211,11 @@ export default {
       } else {
         return this.selectedInstance.installed_instance;
       }
+    },
+    replaceExistingDisabled() {
+      //check if the selected instance is not in an array ['loki']
+      const notAllowed = ["loki"];
+      return notAllowed.includes(this.selectedInstance.name) ? true : false;
     },
     nodesInfo() {
       const nodesInfo = {};

--- a/core/ui/src/components/backup/RestoreSingleInstanceModal.vue
+++ b/core/ui/src/components/backup/RestoreSingleInstanceModal.vue
@@ -214,7 +214,7 @@ export default {
     },
     replaceExistingDisabled() {
       //check if the selected instance is not in an array ['loki']
-      const notAllowed = ["loki"];
+      const notAllowed = ["loki", "mail", "ejabberd","nethvoice-proxy"];
       return notAllowed.includes(this.selectedInstance.name) ? true : false;
     },
     nodesInfo() {


### PR DESCRIPTION
Implement logic to disable the option to replace existing applications for certain instances, specifically excluding 'loki' and other module with static ports.


https://github.com/user-attachments/assets/8df2a279-c96c-4ae3-b94d-8001466e313d




Refs: https://github.com/NethServer/dev/issues/7405 and https://github.com/NethServer/dev/issues/7396