### PR TITLE
Improve podman image retrieval and removal logic

### DIFF
--- a/core/imageroot/usr/local/agent/actions/update-module/96cleanup_core_images
+++ b/core/imageroot/usr/local/agent/actions/update-module/96cleanup_core_images
@@ -15,9 +15,15 @@ def get_podman_images():
     image_list = result.stdout.splitlines()
     images = {}
     for img in image_list:
+        if ':' not in img:
+            continue  # Skip invalid entries
         image_name, tag = img.rsplit(':', 1)
-        images[image_name] = tag
-    return images
+        if image_name not in images:
+            images[image_name] = []  # Initialize a list for tags
+        images[image_name].append(tag)  # Add the tag to the list
+    # return a dictionary of image names and their tags: 
+    # podman_images {'ghcr.io/nethserver/restic': ['sdl-7377', '3.6.4', '3.6.3', '3.6.2', '3.6.1'], 'docker.io/library/traefik': ['v3.3.4']}
+    return images 
 
 def parse_core_images(core_images):
     parsed_images = {}
@@ -30,10 +36,13 @@ def parse_core_images(core_images):
 
 def remove_versions(core_images, podman_images):
     for image_name, core_version in core_images.items():
-        podman_version = podman_images.get(image_name)
-        if podman_version and podman_version != core_version:
-            print(f"Removing {image_name}:{podman_version} (differs from {core_version})", file=sys.stderr)
-            agent.run_helper('podman', 'rmi', '--ignore', f'{image_name}:{podman_version}')
+        podman_tags = podman_images.get(image_name, [])
+        for podman_tag in podman_tags:
+            if podman_tag != core_version:
+                # Remove the image if the tag differs from the core version
+                print(f"Removing {image_name}:{podman_tag} (differs from {core_version})", file=sys.stderr)
+                agent.run_helper('podman', 'rmi', '--ignore', f'{image_name}:{podman_tag}')
+
 
 # Read the environment file using the agent module
 version_images = agent.read_envfile('/etc/nethserver/core.env')


### PR DESCRIPTION
Previously the images were not cleaned after a module update, on one tag per image was cleaned, with this fix we clean more tage per image name

before with 
```
[traefik1@R1-pve state]$ podman images 
REPOSITORY                 TAG         IMAGE ID      CREATED       SIZE
ghcr.io/nethserver/restic  sdl-7377    d481b1f166e2  27 hours ago  126 MB
ghcr.io/nethserver/restic  3.6.3       aefe233da801  8 days ago    126 MB
ghcr.io/nethserver/restic  3.6.2       6990eadcb025  3 weeks ago   126 MB
docker.io/library/traefik  v3.3.4      e49b83f3e049  7 weeks ago   191 MB
```
we got
``` 
podman_images {'ghcr.io/nethserver/restic': '3.6.1', 'docker.io/library/traefik': 'v3.3.4'}
```

now we have 

```
podman_images {'ghcr.io/nethserver/restic': ['sdl-7377', '3.6.4', '3.6.3', '3.6.2', '3.6.1'], 'docker.io/library/traefik': ['v3.3.4']}
```

```
Removing ghcr.io/nethserver/restic:3.6.4 (differs from sdl-7377)
<7>podman rmi --ignore ghcr.io/nethserver/restic:3.6.4
Untagged: ghcr.io/nethserver/restic:3.6.4
Deleted: 1ec8ead7d304302f5459f4dd54fabdc1b5415870bd37a2194d0da702065c1222
Removing ghcr.io/nethserver/restic:3.6.3 (differs from sdl-7377)
<7>podman rmi --ignore ghcr.io/nethserver/restic:3.6.3
Untagged: ghcr.io/nethserver/restic:3.6.3
Deleted: aefe233da8019d5514f4f291b92072821d4627ca6695e01df0127910a74fa413
Removing ghcr.io/nethserver/restic:3.6.2 (differs from sdl-7377)
<7>podman rmi --ignore ghcr.io/nethserver/restic:3.6.2
Untagged: ghcr.io/nethserver/restic:3.6.2
Deleted: 6990eadcb0258683970e51e999db975f8d8cfc56e314b8d98d01efd442b88307
Removing ghcr.io/nethserver/restic:3.6.1 (differs from sdl-7377)
<7>podman rmi --ignore ghcr.io/nethserver/restic:3.6.1
Untagged: ghcr.io/nethserver/restic:3.6.1
Deleted: 4c167d2f358c26b31d9215c81ab75bd395ab54f48c6024de7165b950e2907876
```

https://github.com/NethServer/dev/issues/7391