### PR TITLE
fix(ui): consistent web-socket protocol

### DIFF
--- a/core/ui/public/config/config.production.js
+++ b/core/ui/public/config/config.production.js
@@ -12,7 +12,7 @@ window.CONFIG = {
     "api",
   API_SCHEME: window.location.protocol + "//",
   WS_ENDPOINT:
-    "wss://" +
+    (window.location.protocol == "http:" ? "ws://" : "wss://") +
     window.location.hostname +
     (window.location.port ? ":" + window.location.port : "") +
     window.location.pathname +


### PR DESCRIPTION
Disable TLS in web-socket if api-server is accessed without TLS (http://). Direct access to api-server backend on port 9311 without encryption is useful during a support session if the cluster-admin HTTP route is not accessible for whatever reason.

Refs NethServer/dev#7436