### PR TITLE
feat(api-server): add X-Auth-User header

### DIFF
--- a/core/api-server/methods/auth.go
+++ b/core/api-server/methods/auth.go
@@ -428,6 +428,7 @@ func BasicAuthModule(c *gin.Context) {
 	}
 
 	// response
+	c.Header("X-Auth-User", username)
 	c.JSON(http.StatusOK, structs.Map(response.StatusOK{
 		Code:    200,
 		Message: "basic auth ok",


### PR DESCRIPTION
This header could be used by downstream applications to grant access for users.
See Grafana as an example.

Required by: https://github.com/NethServer/ns8-metrics/pull/25
