### PR TITLE
Update date formatting in LokiCard component

### DIFF
--- a/core/ui/src/components/settings/LokiCard.vue
+++ b/core/ui/src/components/settings/LokiCard.vue
@@ -150,11 +150,17 @@ export default {
   computed: {
     activeFromFormatted() {
       return this.activeFrom
-        ? this.formatDate(new Date(this.activeFrom), "P")
+        ? new Intl.DateTimeFormat(navigator.language).format(
+            new Date(this.activeFrom)
+          )
         : "";
     },
     activeToFormatted() {
-      return this.activeTo ? this.formatDate(new Date(this.activeTo), "P") : "";
+      return this.activeTo
+        ? new Intl.DateTimeFormat(navigator.language).format(
+            new Date(this.activeTo)
+          )
+        : "";
     },
     activeText() {
       return this.$t("system_logs.loki.active");


### PR DESCRIPTION
Refactor date formatting in the LokiCard component to utilize `Intl.DateTimeFormat` for improved localization based on the user's language settings.

when EN-US is used we use MM-DD-YY
when IT-IT or FR-FR is used we return DD-MM-YY

it seems english people are smart they use with EN-GB DD-MM-YY

https://github.com/NethServer/dev/issues/7453


https://github.com/user-attachments/assets/6f8b4b0b-55ac-4e7e-a375-01cbece6ea61


