### PR TITLE
fix: add i18n string used by modules & upgrade node

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/javascript-node
 {
   "name": "ns8-core",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:dev-22",
   // Configure tool-specific properties.
   "customizations": {
     // Configure properties specific to VS Code.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/javascript-node
 {
   "name": "ns8-core",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:dev-22",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22-bookworm",
   // Configure tool-specific properties.
   "customizations": {
     // Configure properties specific to VS Code.

--- a/core/ui/Containerfile
+++ b/core/ui/Containerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:22-bookworm-slim
 WORKDIR /app
 ENV NODE_OPTIONS=--openssl-legacy-provider
 EXPOSE 8080

--- a/core/ui/Containerfile
+++ b/core/ui/Containerfile
@@ -1,4 +1,4 @@
-FROM node:18-slim
+FROM node:22-slim
 WORKDIR /app
 ENV NODE_OPTIONS=--openssl-legacy-provider
 EXPOSE 8080

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -911,6 +911,7 @@
         "bugs": "Bugs",
         "source_code": "Source code",
         "authors": "Author | Authors",
+        "source_package": "App image",
         "app_installation": "Install {app}",
         "choose_node_for_installation": "Select installation node for {app} {version}:",
         "about_to_install_app": "{app} {version} will be installed on {node}.",

--- a/core/ui/src/mixins/notification.js
+++ b/core/ui/src/mixins/notification.js
@@ -249,41 +249,38 @@ export default {
         // subtask
 
         const parentTask = this.getTaskById(taskContext.parent);
-
         if (!parentTask) {
-          console.warn("parentTask not found, ignoring");
-          console.warn("  taskContext", taskContext);
-          console.warn("  payload", payload);
+          return;
+        }
+
+        // check if subTask has already been added to subTasks list
+        const subTask = parentTask.subTasks.find(
+          (subTask) => subTask.context.id === taskContext.id
+        );
+
+        if (!subTask) {
+          // add subtask to subTasks list
+
+          const subTask = {
+            context: taskContext,
+            status: taskStatus,
+            progress: payload.progress,
+            subTasks: [],
+          };
+
+          if (taskResult) {
+            subTask.result = taskResult;
+          }
+
+          parentTask.subTasks.push(subTask);
         } else {
-          // check if subTask has already been added to subTasks list
-          const subTask = parentTask.subTasks.find(
-            (subTask) => subTask.context.id === taskContext.id
-          );
+          // update subtask in subtasks list
 
-          if (!subTask) {
-            // add subtask to subTasks list
+          subTask.status = taskStatus;
+          subTask.progress = payload.progress;
 
-            const subTask = {
-              context: taskContext,
-              status: taskStatus,
-              progress: payload.progress,
-              subTasks: [],
-            };
-
-            if (taskResult) {
-              subTask.result = taskResult;
-            }
-
-            parentTask.subTasks.push(subTask);
-          } else {
-            // update subtask in subtasks list
-
-            subTask.status = taskStatus;
-            subTask.progress = payload.progress;
-
-            if (taskResult) {
-              subTask.result = taskResult;
-            }
+          if (taskResult) {
+            subTask.result = taskResult;
           }
         }
       } else {

--- a/docs/ui/core.md
+++ b/docs/ui/core.md
@@ -181,7 +181,7 @@ Remember to [prepare your development environment](#core-ui-development) before 
 Developing NS8 UI inside a container is the recommended way, but if you want to do it on your workstation:
 
 - Install development tools:
-  - Node.js and npm (LTS version, currently v18)
+  - Node.js and npm (LTS version, currently v22)
   - Yarn
 - Run a web server on your workstation (hot reloading enabled):
   - `cd core/ui`

--- a/docs/ui/library.md
+++ b/docs/ui/library.md
@@ -70,7 +70,7 @@ Dev container configuration is contained inside `.devcontainer/devcontainer.json
 
 Developing NS8 UI library inside a container is the recommended way, but if you want to do it on your workstation:
 
-- Install Node.js 18 and npm
+- Install Node.js 22 and npm
 - `npm install`: project setup, needed only the first time
 - `npm run build`: compile and minify for production
 - `npm run build-pack`: create a tarball

--- a/docs/ui/modules.md
+++ b/docs/ui/modules.md
@@ -88,7 +88,7 @@ Container configuration is contained inside `.devcontainer/devcontainer.json`.
 
 Developing NS8 modules UI inside a container is the recommended way, but if you want to do it on your workstation:
 
-- Install Node.js and npm (LTS version, currently v18)
+- Install Node.js and npm (LTS version, currently v22)
 - Change directory to `ui`
 - `yarn install`: project setup, needed only the first time
 - `yarn watch`: compile sources and watch for changes


### PR DESCRIPTION
- Add i18n string `software_center.source_package`: it is used by NS8 modules and was deleted by mistake
- Upgrade to Node 22
- Remove useless debug print