### PR TITLE
Simplify grafana_path assignment logic in SettingsMetrics

### DIFF
--- a/core/ui/src/views/settings/SettingsMetrics.vue
+++ b/core/ui/src/views/settings/SettingsMetrics.vue
@@ -627,13 +627,7 @@ export default {
         this.createModuleTaskForApp(this.metricsId, {
           action: taskAction,
           data: {
-            grafana_path: this.enable_grafana
-              ? [...Array(4)]
-                  .map(() =>
-                    (~~(Math.random() * 0x10000)).toString(16).padStart(4, "0")
-                  )
-                  .join("-")
-              : "",
+            grafana_path: this.enable_grafana ? "grafana" : "",
             prometheus_path: "",
           },
           extra: {


### PR DESCRIPTION
Refactor the logic for assigning grafana_path to streamline the code and improve readability. The assignment now directly uses a static string when Grafana is enabled.