### PR TITLE
Add gettext package to Debian installation script

### DIFF
--- a/core/install.sh
+++ b/core/install.sh
@@ -84,7 +84,7 @@ elif [[ "${ID}" == "debian" && "${VERSION_ID}" == "12" ]]; then
     apt-get update
     apt-get -y install gnupg2
     apt-get update
-    apt-get -y install python3-venv podman wireguard uuid-runtime curl jq openssl psmisc firewalld pciutils wget
+    apt-get -y install python3-venv podman wireguard uuid-runtime curl jq openssl psmisc firewalld pciutils wget gettext-base
 else
     echo "System not supported"
     exit 1


### PR DESCRIPTION
Include the gettext package in the Debian installation process to ensure `envsubst` is installed.

The `envsubst` command is used by Crowdsec and Webtop.