### PR TITLE
fix(ui): disable Replace existing app checkbox

### DIFF
--- a/core/ui/src/components/backup/RestoreSingleInstanceModal.vue
+++ b/core/ui/src/components/backup/RestoreSingleInstanceModal.vue
@@ -240,7 +240,7 @@ export default {
     },
     replaceExistingDisabled() {
       //check if the selected instance is not in an array ['loki']
-      const notAllowed = ["loki", "mail", "ejabberd", "nethvoice-proxy"];
+      const notAllowed = ["samba", "loki", "mail", "ejabberd", "nethvoice-proxy"];
       return notAllowed.includes(this.selectedInstance.name) ? true : false;
     },
     nodesInfo() {


### PR DESCRIPTION
The Samba app cannot be restored if the node hosts another Samba instance.

See also https://github.com/NethServer/ns8-core/pull/862

Refs NethServer/dev#7384