### PR TITLE
feat(support): forward cluster-admin 9311 port

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/etc/support/nft.conf
+++ b/core/imageroot/var/lib/nethserver/node/etc/support/nft.conf
@@ -13,7 +13,7 @@ table ip nat {
 
         chain prerouting {
                 type nat hook prerouting priority dstnat; policy accept;
-                iifname tun0 tcp dport { 22, 80, 443, 9090 } dnat to 10.0.2.2
+                iifname tun0 tcp dport { 22, 80, 443, 9090, 9311 } dnat to 10.0.2.2
                 iifname tun0 tcp dport 981 dnat to 10.0.2.2:22
         }
 }


### PR DESCRIPTION
Allow support connections to port 9311 to bypass cluster-admin HTTP route IP restrictions.

This simplifies the operator's port redirection setup when SSH connection starts from sos.nethesis.it.

Refs https://github.com/NethServer/dev/issues/7436