### PR TITLE
feat(transfer-state): support Samba ACLs cloning

### DIFF
--- a/core/imageroot/usr/local/agent/actions/transfer-state/10sendpayload
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/10sendpayload
@@ -44,6 +44,7 @@ podman_cmd = [
 rsync_cmd = [
     'rsync',
     '-a',
+    '--xattrs',
     '--info=progress2',
 
     # high-priority, harcoded filter rules: they cannot be overriden

--- a/core/imageroot/usr/local/agent/actions/transfer-state/50sendstate
+++ b/core/imageroot/usr/local/agent/actions/transfer-state/50sendstate
@@ -62,6 +62,7 @@ podman_cmd = [
 rsync_cmd = [
     'rsync',
     '-a',
+    '--xattrs',
     '--info=progress2',
     '--delete-after',
 


### PR DESCRIPTION
Enable transfer of extended-attributes, which is not included by Rsync "-a" flag.

Refs NethServer/dev#7384