### PR TITLE
fix: /etc/fstab instructions

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/migrate-home-disk.sh
+++ b/core/imageroot/var/lib/nethserver/node/migrate-home-disk.sh
@@ -50,4 +50,4 @@ echo
 eval $(blkid $device -o export)
 echo "Add this line to fstab:"
 echo
-echo "UUID=$UUID /home $TYPE rw,errors=remount-ro 0 1"
+echo "UUID=$UUID /home $TYPE defaults 0 1"


### PR DESCRIPTION
The errors option is not accepted by xfs.

Refs NethServer/dev#7493