### PR TITLE
fix(api): allow restore if repo is not available

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/actions/determine-restore-eligibility/50determine_restore_eligibility
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/determine-restore-eligibility/50determine_restore_eligibility
@@ -28,11 +28,12 @@ module_source, _ = original_environment['IMAGE_URL'].rsplit(':', 1)
 # Reduce the list to one element, matching the original source:
 available = list(filter(lambda omod: omod["source"] == module_source, cluster.modules.list_available(rdb, skip_core_modules = False)))
 if not available:
-    agent.set_status('validation-failed')
-    json.dump([{'field':'none', 'parameter':'none','value': '', 'error':'module_not_available'}], fp=sys.stdout)
-    sys.exit(2)
-cluster.modules.decorate_with_installed(rdb, available)
-cluster.modules.decorate_with_install_destinations(rdb, available)
+    # Can't find correct eligibility module, just log it and return the first node
+    print(agent.SD_WARNING + f"Can't determine restore eligibility for {module_source}", file=sys.stderr)
+    available = [{"install_destinations": [{"node_id": 1, "instances": 0, "eligible": True, "reject_reason": None}]}]
+else:
+    cluster.modules.decorate_with_installed(rdb, available)
+    cluster.modules.decorate_with_install_destinations(rdb, available)
 json.dump({
     "image_url": original_environment['IMAGE_URL'],
     "install_destinations": available[0]["install_destinations"],


### PR DESCRIPTION
Previously, if a backupped module was not present
inside a software repository, the restore process
could not be started because determine-restore-eligibility was failing.

NethServer/dev#7509