### PR TITLE
Add unique constraints to TCP and UDP tables in ports manager

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/node/ports_manager.py
+++ b/core/imageroot/usr/local/agent/pypkg/node/ports_manager.py
@@ -28,21 +28,25 @@ class InvalidPortRequestError(PortError):
         super().__init__(self.message)
 
 def create_tables(cursor: sqlite3.Cursor):
-    # Create TCP table if it doesn't exist
+    # Create TCP table if it doesn't exist, with unique constraints
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS TCP_PORTS (
             start INT NOT NULL,
             end INT NOT NULL,
-            module CHAR(255) NOT NULL
+            module CHAR(255) NOT NULL,
+            UNIQUE(start),
+            UNIQUE(end)
         );
     """)
 
-    # Create UDP table if it doesn't exist
+    # Create UDP table if it doesn't exist, with unique constraints
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS UDP_PORTS (
             start INT NOT NULL,
             end INT NOT NULL,
-            module CHAR(255) NOT NULL
+            module CHAR(255) NOT NULL,
+            UNIQUE(start),
+            UNIQUE(end)
         );
     """)
 


### PR DESCRIPTION
Introduce unique constraints on the `start` and `end` columns in the TCP and UDP tables to prevent duplicate entries.

https://github.com/NethServer/dev/issues/7412