### PR TITLE
Add URL format validation for address in CloudLogManagerConfigureModal

### DIFF
--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -88,7 +88,6 @@
         "terms_and_conditions": "Terms and Conditions",
         "terms_required": "Please read and agree to @:common.terms_and_conditions",
         "not_available": "Not available",
-        "invalid_url": "Invalid value or format",
         "release_notes": "Release notes"
     },
     "error": {
@@ -123,6 +122,8 @@
         "warning_mail_subject_required": "Mail subject is required",
         "warning_mail_template_content_required": "Mail template content is required",
         "warning_days_required": "Warning days are required",
+        "invalid_url": "Invalid value or format",
+        "invalid_fqdn": "Invalid fully qualified domain name",
         "warning_days_range": "Warning days must be between 1 and 1000"
     },
     "websocket": {

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -88,6 +88,7 @@
         "terms_and_conditions": "Terms and Conditions",
         "terms_required": "Please read and agree to @:common.terms_and_conditions",
         "not_available": "Not available",
+        "invalid_url": "Invalid value or format",
         "release_notes": "Release notes"
     },
     "error": {

--- a/core/ui/src/components/settings/CloudLogManagerConfigureModal.vue
+++ b/core/ui/src/components/settings/CloudLogManagerConfigureModal.vue
@@ -236,6 +236,27 @@ export default {
       if (!this.address) {
         this.error.address = this.$t("common.required");
         isValidationOk = false;
+      } else if (
+        !this.address.startsWith("http://") &&
+        !this.address.startsWith("https://")
+      ) {
+        this.error.address = this.$t("common.invalid_url");
+        isValidationOk = false;
+      } else {
+        // Extract the hostname from the address
+        try {
+          const urlObj = new URL(this.address);
+          const hostname = urlObj.hostname;
+          // Regular expression for a valid FQDN
+          const fqdnRegex = /^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}$/;
+          if (!fqdnRegex.test(hostname)) {
+            this.error.address = this.$t("common.invalid_fqdn");
+            isValidationOk = false;
+          }
+        } catch (e) {
+          this.error.address = this.$t("common.invalid_url");
+          isValidationOk = false;
+        }
       }
       if (!this.tenant) {
         this.error.tenant = this.$t("common.required");

--- a/core/ui/src/components/settings/CloudLogManagerConfigureModal.vue
+++ b/core/ui/src/components/settings/CloudLogManagerConfigureModal.vue
@@ -240,7 +240,7 @@ export default {
         !this.address.startsWith("http://") &&
         !this.address.startsWith("https://")
       ) {
-        this.error.address = this.$t("common.invalid_url");
+        this.error.address = this.$t("error.invalid_url");
         isValidationOk = false;
       } else {
         // Extract the hostname from the address
@@ -250,11 +250,11 @@ export default {
           // Regular expression for a valid FQDN
           const fqdnRegex = /^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}$/;
           if (!fqdnRegex.test(hostname)) {
-            this.error.address = this.$t("common.invalid_fqdn");
+            this.error.address = this.$t("error.invalid_fqdn");
             isValidationOk = false;
           }
         } catch (e) {
-          this.error.address = this.$t("common.invalid_url");
+          this.error.address = this.$t("error.invalid_url");
           isValidationOk = false;
         }
       }


### PR DESCRIPTION
Implement validation to ensure the address starts with "http://" or "https://", enhancing user input accuracy. Update translations to include an error message for invalid URLs.

NethServer/dev#7577