### PR TITLE
Prevent Restic "permission denied" errors during restore

### DIFF
--- a/core/imageroot/usr/local/agent/actions/restore-module/10restore
+++ b/core/imageroot/usr/local/agent/actions/restore-module/10restore
@@ -40,6 +40,7 @@ podman_args.extend(agent.get_state_volume_args()) # get volumes from state-inclu
 restic_args = ["restore", "--json", snapshot,
     "--target", ".", # workdir should be /srv
     "--exclude", "state/environment", # special core file exception
+    "--exclude-xattr", "security.*", # ignore privileged xattr namespace
 ]
 
 # Prepare progress callback function that captures non-progress messages too:


### PR DESCRIPTION
If the source system has no xattr support, do not attempt to remove local extended attributes that require root privileges.

This PR requires Restic 0.18 (Alpine 3.22). See upstream issue that recently implemented the new `--exclude-xattr` option: https://github.com/restic/restic/issues/5089


Refs NethServer/dev#7598 #896