### PR TITLE
feat(facts): count software repositories by URL

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/cluster/inventory.py
+++ b/core/imageroot/usr/local/agent/pypkg/cluster/inventory.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-import os
 import agent
+import urllib.parse
 
 def fact_subscription(rdb):
     # Get subscription status
@@ -32,7 +32,12 @@ def fact_repositories(rdb):
     for m in rdb.scan_iter('cluster/repository/*'):
         repo = rdb.hgetall(m)
         if repo.get("status") == "1":
-            ret.append(os.path.basename(m))
+            try:
+                parsed_url = urllib.parse.urlparse(repo['url'])
+                canonicalized_url = (parsed_url.hostname + parsed_url.path.rstrip('/')).lower()
+            except:
+                canonicalized_url = None
+            ret.append(canonicalized_url or m.removeprefix('cluster/repository/'))
     return ret
 
 def fact_smarthost(rdb):


### PR DESCRIPTION
Canonicalize repository URLs to improve counting accuracy.

The canonicalization drops the URL scheme, port, credentials, query string, and fragment, focusing on returning the non-sensitive parts useful to uniquely and unambiguously identify the repository.