### PR TITLE
fix(send-cluster-backup): suppress curl output

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/bin/send-cluster-backup
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/send-cluster-backup
@@ -48,7 +48,7 @@ elif [[ -f "${encrypted_file}" ]]; then
         --location-trusted \
         --user "${system_id}:${auth_token}" \
         "https://backupd.nethesis.it/${type}/api/v2/backup/" \
-        --upload-file "${encrypted_file}"
+        --upload-file "${encrypted_file}" >/dev/null
     # Backup upload successful, update the reference file
     echo "${backup_hash}" > backup/dump.md5
     echo "Backup uploaded to provider ${provider} with hash ${backup_hash}" 1>&2


### PR DESCRIPTION
- Restore previous script behavior: do not write the remote API response payload into system journal

Refs NethServer/dev#7594


With this PR only this message is expected in stderr:

     Backup uploaded to provider nscom with hash 785...
     
Previously it was:

    {"result":"success"}Backup uploaded to provider nscom with hash 785...