### PR TITLE
fix(get-certificate): improve TLS client compatibility

### DIFF
--- a/core/imageroot/usr/local/agent/bin/get-certificate
+++ b/core/imageroot/usr/local/agent/bin/get-certificate
@@ -111,8 +111,12 @@ def generate_self_signed_cert(cert_file: str, key_file: str, fqdn: str) -> tuple
         .issuer_name(subject)
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
+        .not_valid_before(datetime.utcnow() - timedelta(minutes=60))
         .not_valid_after(datetime.utcnow() + timedelta(days=365))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(fqdn)]),
+            critical=False,
+        )
         .sign(key, hashes.SHA256())
     )
     cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()


### PR DESCRIPTION
- Add SAN extension to avoid client certificate warnings
- Set validity start 1 hour earlier to tolerate clock skew