### PR TITLE
Fix user list error with Windows Server 2012

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/ldapclient/ad.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/ldapclient/ad.py
@@ -177,7 +177,11 @@ class LdapclientAd(LdapclientBase):
                 user["mail"] = entry['attributes'].get('mail') if entry['attributes'].get('mail') else ""
                 # In AD, pwdLastSet = 0 means that the user must change the password at next logon
                 # The timestamp 0 in Windows epoch is -11644473600 in Unix epoch
-                user['must_change'] = (pwd_changed_time.timestamp() == -11644473600)
+                # we do a try and catch because old windows servers might be different
+                try:
+                    user['must_change'] = (pwd_changed_time.timestamp() == -11644473600)
+                except Exception:
+                    user['must_change'] = False
             users.append(user)
 
         return users


### PR DESCRIPTION
Handle potential exceptions when determining if a user must change their password at the next logon, ensuring compatibility with older Windows servers.

https://github.com/NethServer/dev/issues/7650