### PR TITLE
fix(ui): improve warnings when restarting traefik

### DIFF
--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -788,7 +788,10 @@
         "route": "Route",
         "host_pattern": "Invalid host format",
         "cannot_obtain_tls_certificate": "Cannot obtain TLS certificate.",
-        "show_logs": "Show logs"
+        "show_logs": "Show logs",
+        "traefik_will_be_restarted": "Traefik will be restarted",
+        "delete_route_with_certificate_message": "Deleting this route will briefly disconnect HTTP clients connected to {node}.",
+        "revoke_certificate_message": "Revoking the route certificate will briefly disconnect HTTP clients connected to {node}."
     },
     "settings_tls_certificates": {
         "title": "TLS certificates",
@@ -817,7 +820,7 @@
         "chain_file": "Chain file",
         "upload_certs": "Upload certificate",
         "instance_selection_label": "Select instance to upload the file to.",
-        "cannot_obtain_certificate": "Cannot obtain certificate",
+        "cannot_obtain_certificate": "Cannot obtain Let's Encrypt certificate",
         "invalid_identifiers_requested_error": "The provided FQDN is invalid",
         "dns_record_error": "No DNS records found for the provided FQDN",
         "refuses_to_issue_certificate_error": "ACME server refuses to issue a certificate for the provided FQDN",
@@ -843,7 +846,8 @@
         "request_certificate_disabled_message": "All cluster nodes already have a certificate",
         "automatic_cert_warning": "All associated HTTP routes will be reconfigured to no longer require this certificate.",
         "traefik_will_be_restarted": "Traefik will be restarted",
-        "traefik_will_be_restarted_message": "Deleting this certificate will immediately restart Traefik. Any app using this certificate may become temporarily unavailable.",
+        "delete_certificate_message": "Deleting this certificate will briefly disconnect HTTP clients connected to {node}.",
+        "delete_obsolete_certificates_message": "Deleting obsolete certificates will briefly disconnect HTTP clients connected to the selected node.",
         "names_helper": "One FQDN per line. Do not include hostnames already managed by HTTP routes with the Let's Encrypt option enabled.",
         "names_pattern": "Invalid FQDN: {value}",
         "validation_error_message": "Issues detected with one or more FQDNs:",

--- a/core/ui/public/i18n/it/translation.json
+++ b/core/ui/public/i18n/it/translation.json
@@ -382,7 +382,7 @@
         "instance_selection_label": "Selezionare l'istanza su cui effettuare l'upload.",
         "custom": "Caricato",
         "upload": "Carica",
-        "cannot_obtain_certificate": "Non è possibile ottenere il certificato",
+        "cannot_obtain_certificate": "Impossibile ottenere il certificato Let's Encrypt",
         "refuses_to_issue_certificate_error": "Il server ACME rifiuta di rilasciare un certificato per il FQDN fornito",
         "dns_record_error": "Nessun record DNS trovato per il FQDN fornito",
         "ensure_node_matches_fqdn_error": "Assicurarsi che il nodo corrisponda al FQDN, o controllare per i dettagli l'errore 'Richiesta certificato' nel pannello notifiche",
@@ -409,7 +409,8 @@
         "request_certificate_disabled_message": "Tutti i nodi del cluster hanno già un certificato",
         "automatic_cert_warning": "Tutte le rotte HTTP associate verranno riconfigurate per non richiedere più questo certificato.",
         "traefik_will_be_restarted": "Traefik verrà riavviato",
-        "traefik_will_be_restarted_message": "L'eliminazione di questo certificato riavvierà immediatamente Traefik. Qualsiasi app che utilizza questo certificato potrebbe diventare temporaneamente non disponibile.",
+        "delete_certificate_message": "L'eliminazione di questo certificato comporterà una breve disconnessione dei client HTTP connessi a {node}.",
+        "delete_obsolete_certificates_message": "L'eliminazione dei certificati obsoleti comporterà una breve disconnessione dei client HTTP connessi al nodo selezionato.",
         "names_helper": "Un FQDN per riga. Non includere nomi host già gestiti da rotte HTTP con l'opzione Let's Encrypt abilitata.",
         "names_pattern": "FQDN non valido: {value}",
         "validation_error_message": "Sono stati rilevati problemi con uno o più FQDN:",
@@ -1443,7 +1444,10 @@
         "slash_redirect": "Aggiungi lo slash finale al percorso",
         "slash_redirect_tooltip": "Se l'URL della richiesta non finisce con lo slash (/) forza un reindirizzamento all'URL corretto con uno slash finale.",
         "cannot_obtain_tls_certificate": "Impossibile ottenere il certificato TLS.",
-        "show_logs": "Mostra log"
+        "show_logs": "Mostra log",
+        "traefik_will_be_restarted": "Traefik verrà riavviato",
+        "delete_route_with_certificate_message": "L'eliminazione di questa rotta comporterà una breve disconnessione dei client HTTP connessi a {node}.",
+        "revoke_certificate_message": "La revoca del certificato della rotta comporterà una breve disconnessione dei client HTTP connessi a {node}."
     },
     "samba": {
         "choose_samba_admin_username": "Scegli il nome utente dell'amministratore di Samba",

--- a/core/ui/src/components/settings/DeleteObsoleteCertificatesModal.vue
+++ b/core/ui/src/components/settings/DeleteObsoleteCertificatesModal.vue
@@ -39,7 +39,7 @@
           kind="warning"
           :title="$t('settings_tls_certificates.traefik_will_be_restarted')"
           :description="
-            $t('settings_tls_certificates.traefik_will_be_restarted_message')
+            $t('settings_tls_certificates.delete_obsolete_certificates_message')
           "
           :showCloseButton="false"
         />

--- a/core/ui/src/views/Nodes.vue
+++ b/core/ui/src/views/Nodes.vue
@@ -286,9 +286,7 @@
         </template>
       </template>
       <template slot="secondary-button">{{ $t("common.cancel") }}</template>
-      <template slot="primary-button">{{
-        $t("nodes.edit_node_label")
-      }}</template>
+      <template slot="primary-button">{{ $t("common.save") }}</template>
     </NsModal>
     <!-- remove node modal -->
     <RemoveNodeModal

--- a/core/ui/src/views/settings/SettingsHttpRoutes.vue
+++ b/core/ui/src/views/settings/SettingsHttpRoutes.vue
@@ -290,10 +290,27 @@
       :isErrorShown="!!error.deleteRoute"
       :errorTitle="$t('action.delete-route')"
       :errorDescription="error.deleteRoute"
+      :isWarningShown="false"
       @hide="hideDeleteRouteModal"
       @confirmDelete="deleteRoute"
       data-test-id="delete-route-modal"
-    />
+    >
+      <!-- traefik will be restarted if the route requested a certificate -->
+      <template v-if="routeToDelete && routeToDelete.lets_encrypt" #explanation>
+        <div class="mt-4">
+          <NsInlineNotification
+            kind="warning"
+            :title="$t('settings_http_routes.traefik_will_be_restarted')"
+            :description="
+              $t('settings_http_routes.delete_route_with_certificate_message', {
+                node: routeToDelete ? routeToDelete.node : '',
+              })
+            "
+            :showCloseButton="false"
+          />
+        </div>
+      </template>
+    </NsDangerDeleteModal>
   </div>
 </template>
 

--- a/core/ui/src/views/settings/SettingsTlsCertificates.vue
+++ b/core/ui/src/views/settings/SettingsTlsCertificates.vue
@@ -469,7 +469,9 @@
           kind="warning"
           :title="$t('settings_tls_certificates.traefik_will_be_restarted')"
           :description="
-            $t('settings_tls_certificates.traefik_will_be_restarted_message')
+            $t('settings_tls_certificates.delete_certificate_message', {
+              node: currentCertificate.node,
+            })
           "
           :showCloseButton="false"
         />


### PR DESCRIPTION
Improve warnings about Traefik restart in **HTTP routes** and **TLS certificates** pages

Ref:
- https://github.com/NethServer/dev/issues/7548

