### PR TITLE
fix(agent): validation-failed status passthrough

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -795,3 +795,19 @@ def get_route(route_id, agent_id=None):
     if response['exit_code'] != 0:
         return dict()
     return response['output'] or dict()
+
+def get_certificate(fqdn, agent_id=None):
+    """Call get-certificate action on the node's Traefik instance.
+    The result is a dictionary corresponding to the action's output
+    format. If an error occurs an empty dict is returned."""
+    if not agent_id:
+        agent_id = resolve_agent_id('traefik@node')
+    response = agent.tasks.run(
+        agent_id=agent_id,
+        action='get-certificate',
+        data={"fqdn": fqdn},
+        extra={'isNotificationHidden': True},
+    )
+    if response['exit_code'] != 0:
+        return dict()
+    return response['output'] or dict()


### PR DESCRIPTION
Set the task status to "validation-failed" if set-route or set-default-certificate actions return exit_code > 1.

NethServer/dev#7669