### PR TITLE
feat: new default shell /bin/nologin

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
@@ -103,8 +103,14 @@ else: # rootless
     else:
         # use default base path (see useradd -D)
         module_basedir_args = []
+    if 'LOGIN_SHELL' in os.environ:
+        # assign a custom shell to the module
+        module_login_shell_args = ["-s", os.environ["LOGIN_SHELL"]]
+    else:
+        # default module shell, preventing interactive logins (e.g. from SSH)
+        module_login_shell_args = ["-s", "/bin/nologin"]
     # Create the module dirs structure
-    agent.run_helper('useradd', *module_basedir_args, '-m', '-k', '/etc/nethserver/skel', '-s', '/bin/bash', module_id).check_returncode()
+    agent.run_helper('useradd', *module_basedir_args, '-m', '-k', '/etc/nethserver/skel', *module_login_shell_args, module_id).check_returncode()
     agent.run_helper('chmod', '-c', '0700', os.path.expanduser("~" + module_id)).check_returncode()
     os.chdir(os.path.expanduser("~" + module_id) + '/.config')
     save_environment(module_environment)

--- a/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
+++ b/core/imageroot/var/lib/nethserver/node/actions/add-module/50update
@@ -108,7 +108,7 @@ else: # rootless
         module_login_shell_args = ["-s", os.environ["LOGIN_SHELL"]]
     else:
         # default module shell, preventing interactive logins (e.g. from SSH)
-        module_login_shell_args = ["-s", "/bin/nologin"]
+        module_login_shell_args = ["-s", "/sbin/nologin"]
     # Create the module dirs structure
     agent.run_helper('useradd', *module_basedir_args, '-m', '-k', '/etc/nethserver/skel', *module_login_shell_args, module_id).check_returncode()
     agent.run_helper('chmod', '-c', '0700', os.path.expanduser("~" + module_id)).check_returncode()

--- a/docs/modules/rootless_rootfull.md
+++ b/docs/modules/rootless_rootfull.md
@@ -75,13 +75,27 @@ a command like this:
 runagent -l | xargs -l -t -r -- usermod -s /sbin/nologin
 ```
 
-An interactive shell is not required by NS8. However, if you need to
-enable `/bin/bash` for any reason (for example, to log in as the module
-user and transfer files with `ssh+rsync`), execute:
+Note that the above command may raise harmless errors for `cluster`,
+`node` and other rootfull module names, which have no corresponding Unix
+user.
+
+An interactive shell is not required by NS8 rootless modules. However, if
+you need to enable `/bin/bash` for any reason (for example, to log in as
+the module user and transfer files with `ssh+rsync`), execute:
 
 ```bash
 usermod -s /bin/bash myapp1
 ```
+
+If the new default policy is too strict, customize the shell assigned to
+new modules by `add-module` action. Run this command on each cluster node:
+
+```bash
+runagent -m node python3 -c 'import agent ; agent.set_env("LOGIN_SHELL", "/bin/bash")'
+```
+
+The above command sets the custom shell executable path in the node's
+`LOGIN_SHELL` agent environment.
 
 
 ## Filesystem paths

--- a/docs/modules/rootless_rootfull.md
+++ b/docs/modules/rootless_rootfull.md
@@ -66,6 +66,24 @@ As alternative print the effective user ID with
 
     id -u
 
+To protect against system configuration errors, starting with Core 3.20,
+Unix users created for rootless modules are assigned the `/sbin/nologin`
+shell by default. To upgrade existing modules to the new shell policy, run
+a command like this:
+
+```bash
+runagent -l | xargs -l -t -r -- usermod -s /sbin/nologin
+```
+
+An interactive shell is not required by NS8. However, if you need to
+enable `/bin/bash` for any reason (for example, to log in as the module
+user and transfer files with `ssh+rsync`), execute:
+
+```bash
+usermod -s /bin/bash myapp1
+```
+
+
 ## Filesystem paths
 
 The two types of modules have a similar filesystem structure. Rootless


### PR DESCRIPTION
- create new modules with /bin/nologin, replacing old default /bin/bash
- customize shell of newly added modules with node LOGIN_SHELL enviroment variable
- document the new default shell and how to fix existing systems

Refs NethServer/dev#7844
