### PR TITLE
fix(volumes.py): ignore Podman-managed volumes

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/volumes.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/volumes.py
@@ -64,6 +64,8 @@ def get_base_paths() -> list:
             continue # ignore bind mounts
         elif ofs["target"].startswith("/boot"):
             continue # ignore /boot* mountpoints
+        elif ofs["target"].endswith("/_data"):
+            continue # ignore Podman volumes
         elif ofs["target"] in ["/", home_basedir]:
             continue # ignore HOME_BASEDIR and root volume
         opath = {


### PR DESCRIPTION
The documented configuration of the rclone-webdav.service unit recommends using a rootful named volume. When mounted, it appears as an additional volume to regular applications.

Filter out Podman-managed volumes, identified by mount points ending with "/_data", from the additional volumes list.

Refs NethServer/dev#7960