### PR TITLE
feat(backup): dual-send cluster backup to my-new proxy

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/bin/send-cluster-backup
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/send-cluster-backup
@@ -49,6 +49,21 @@ elif [[ -f "${encrypted_file}" ]]; then
         --user "${system_id}:${auth_token}" \
         "https://backupd.nethesis.it/${type}/api/v2/backup/" \
         --upload-file "${encrypted_file}" >/dev/null
+
+    # Temporary dual-send to new my.nethesis.it via the translation
+    # proxy, same pattern used by send-heartbeat / send-inventory.
+    # Enterprise only; best-effort (|| :) so a proxy outage does not
+    # block the primary upload already completed above.
+    # To be removed once the migration is complete.
+    if [[ "${provider}" == "nsent" ]]; then
+        /usr/bin/curl -m 900 --retry 3 -L -s -X POST \
+            --user "${system_id}:${auth_token}" \
+            -H "Content-Type: application/octet-stream" \
+            -H "X-Filename: $(basename "${encrypted_file}")" \
+            --data-binary "@${encrypted_file}" \
+            https://my.nethesis.it/proxy/backup >/dev/null || :
+    fi
+
     # Backup upload successful, update the reference file
     echo "${backup_hash}" > backup/dump.md5
     echo "Backup uploaded to provider ${provider} with hash ${backup_hash}" 1>&2


### PR DESCRIPTION
## Summary

Add a second upload to `https://my.nethesis.it/proxy/backup` after the existing upload to `backupd.nethesis.it`, mirroring the transitional pattern already used by `send-heartbeat` and `send-inventory`.

## Context

The new **my.nethesis.it** platform ships a first-class configuration-backup subsystem (ingest on `collect`, managed reads on `backend`, S3-compatible storage) — see the referenced issues. During the migration window NS8 and NethSecurity keep uploading to the legacy backupd *and* dual-send to my-new via a translation proxy (`nethinfra` role), so nothing changes appliance-side in terms of registration or credentials.

The proxy accepts the legacy `system_id:auth_token` Basic Auth pair, looks up the matching `system_key:system_secret` in its mapping table, and streams the body to `collect`. From the appliance's point of view the dual-send is just one extra `curl` at the end of the send function.

## What changes

`core/imageroot/var/lib/nethserver/cluster/bin/send-cluster-backup`:

- After the existing upload to backupd completes successfully, if `provider == nsent` the script POSTs the same encrypted blob to `https://my.nethesis.it/proxy/backup` with HTTP Basic auth using the cluster subscription credentials.
- `X-Filename` is propagated so the user-facing filename lands as S3 object metadata on my-new.
- The proxy call is best-effort (`|| :`): a proxy outage does not block the primary upload that already completed against backupd.

Same guard style as the other dual-send scripts — enterprise-only, same `-m 900 --retry 3 -L -s` flags, same fall-through pattern.

## Not included

- Rewriting the legacy upload path — out of scope; will happen in a later cycle once the new platform is promoted.
- MY registration on the appliance — not needed: the proxy absorbs the credential difference.

Refs: NethServer/my#82 NethServer/my#83