### PR TITLE
feat(ns8-sendmail): log SMTP submission status and details

### DIFF
--- a/core/imageroot/usr/local/agent/bin/ns8-sendmail
+++ b/core/imageroot/usr/local/agent/bin/ns8-sendmail
@@ -13,6 +13,7 @@ import ssl
 import sys
 import agent
 import smtplib
+import syslog
 import argparse
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -85,20 +86,6 @@ def main():
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
 
-    # Setup connection based on encrypt_smtp value.
-    # Possible values: none, starttls, tls
-    if smtp_config['encrypt_smtp'] == 'tls':
-        smtp = smtplib.SMTP_SSL(smtp_config['host'], smtp_config['port'], context=ctx)
-    elif smtp_config['encrypt_smtp'] == 'starttls':
-        smtp = smtplib.SMTP(smtp_config['host'], smtp_config['port'])
-        smtp.starttls(context=ctx)
-    else:
-        smtp = smtplib.SMTP(smtp_config['host'], smtp_config['port'])
-
-    # Authenticate if needed
-    if smtp_config['username'] and smtp_config['password']:
-        smtp.login(smtp_config['username'], smtp_config['password'])
-
     # Create a multipart message and set headers
     message = MIMEMultipart()
     message["From"] = args.from_addr
@@ -109,9 +96,44 @@ def main():
     type = get_content_type(body)
     message.attach(MIMEText(body, type))
 
-    # Send the message via the configured SMTP server
-    smtp.sendmail(args.from_addr, ','.join(args.recipients), message.as_string())
-    smtp.quit()
+    syslog.openlog('ns8-sendmail', syslog.LOG_PID, syslog.LOG_MAIL)
+    log_context = (
+        f"from={args.from_addr} to={args.recipients[0]}"
+        f" subject=\"{args.subject}\""
+        f" server={smtp_config['host']}:{smtp_config['port']}"
+    )
+    try:
+        # Setup connection based on encrypt_smtp value.
+        # Possible values: none, starttls, tls
+        if smtp_config['encrypt_smtp'] == 'tls':
+            smtp = smtplib.SMTP_SSL(smtp_config['host'], smtp_config['port'], context=ctx)
+        elif smtp_config['encrypt_smtp'] == 'starttls':
+            smtp = smtplib.SMTP(smtp_config['host'], smtp_config['port'])
+            smtp.starttls(context=ctx)
+        else:
+            smtp = smtplib.SMTP(smtp_config['host'], smtp_config['port'])
+
+        # Authenticate if needed
+        if smtp_config['username'] and smtp_config['password']:
+            smtp.login(smtp_config['username'], smtp_config['password'])
+
+        # Send the message via the configured SMTP server
+        smtp.sendmail(args.from_addr, ','.join(args.recipients), message.as_string())
+        smtp.quit()
+        syslog.syslog(syslog.LOG_INFO, f"status=sent {log_context} code=250")
+    except smtplib.SMTPException as e:
+        code = getattr(e, 'smtp_code', -1)
+        raw = getattr(e, 'smtp_error', str(e))
+        msg = raw.decode('utf-8', errors='replace') if isinstance(raw, bytes) else str(raw)
+        syslog.syslog(syslog.LOG_ERR, f"status=error {log_context} code={code} message=\"{msg}\"")
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        syslog.syslog(syslog.LOG_ERR, f"status=error {log_context} code=-1 message=\"{e}\"")
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        syslog.closelog()
 
 
 main()


### PR DESCRIPTION
## Summary

Add syslog logging to ns8-sendmail to track email submission activity with structured records. When a message is submitted, a record is written to system logs (LOG_MAIL facility) containing sender, first recipient, subject, server address, and SMTP status code/message.

## Related issue

NethServer/dev#7983

## How to test

1. Start an SMTP debugging server (e.g., smtp4dev):
   ```bash
   podman run -d -p 127.0.0.1:2525:25 docker.io/rnwood/smtp4dev:v3
   ```

2. Configure the ns8 smarthost to use localhost:2525 (no auth, no TLS):
   ```bash
   redis-cli HSET cluster/smarthost host 127.0.0.1 port 2525 enabled 1 encrypt_smtp none
   ```

3. Send a test email:
   ```bash
   export REDIS_ADDRESS=cluster-leader:6379
   export REDIS_REPLICA_ADDRESS=127.0.0.1:6379
   echo 'Test body' | /usr/local/agent/pyenv/bin/python3 /usr/local/agent/bin/ns8-sendmail -s 'Test subject' user@example.com
   ```

4. Check the syslog for success:
   ```bash
   journalctl -t ns8-sendmail
   ```
   
   Expected output on success:
   ```
   ns8-sendmail[PID]: status=sent from=... to=... subject="..." server=host:port code=250
   ```

5. To test error logging, configure an invalid port and verify the error is logged:
   ```bash
   redis-cli HSET cluster/smarthost port 9999
   echo 'Test' | /usr/local/agent/pyenv/bin/python3 /usr/local/agent/bin/ns8-sendmail -s 'Test' user@example.com 2>&1
   journalctl -t ns8-sendmail -n 5
   ```

   Expected error output:
   ```
   ns8-sendmail[PID]: status=error from=... to=... subject="..." server=host:port code=-1 message="..."
   ```

## Changes

- Added `syslog` import and LOG_MAIL facility logging
- Wrapped SMTP operations (connect, auth, send) in try/except/finally
- Log success with code=250 (LOG_INFO)
- Log SMTP exceptions with extracted error code and message (LOG_ERR)
- Log general exceptions with code=-1 (LOG_ERR)
- Ensure syslog is closed in all execution paths
