### PR TITLE
Performance: optimize webpack dev rebuild speed

### DIFF
--- a/core/ui/vue.config.js
+++ b/core/ui/vue.config.js
@@ -23,4 +23,12 @@ module.exports = {
       },
     },
   },
+  chainWebpack: (config) => {
+    // Development-only optimizations (no impact on production build)
+    if (process.env.NODE_ENV === "development") {
+      // Remove prefetch/preload plugins, useless in dev
+      config.plugins.delete("prefetch");
+      config.plugins.delete("preload");
+    }
+  },
 };


### PR DESCRIPTION
Remove prefetch and preload plugins in development mode to speed up the emitting phase during webpack rebuilds.

Problem
The project uses splitChunks which generates many small chunks (10–250kb). At every rebuild, the prefetch and preload plugins iterate over all generated chunks to inject <link rel="prefetch/preload"> tags into the HTML, causing a noticeable bottleneck at the 95% emitting HtmlWebpackPlugin step.

Solution
Disable both plugins in development mode only via chainWebpack. They remain active in production where they serve their intended purpose as browser performance hints.

Impact
- Faster hot-reload cycle in development
- No change in production build output
- No dependency added or modified