### PR TITLE
fix: concurrent update-core and update-module runs

### DIFF
--- a/core/imageroot/usr/local/agent/actions/update-module/05pullimages
+++ b/core/imageroot/usr/local/agent/actions/update-module/05pullimages
@@ -26,6 +26,19 @@ import sys
 import os
 import signal
 import subprocess
+import fcntl
+
+# Protect update-module from multiple concurrent runs. If the lock cannot
+# be acquired the action fails immediately.
+LOCK_FILE = ".update-module.lock"
+try:
+    # This lock is released by the OS when the process completes (no
+    # matter its exit code):
+    fcntl.flock(os.open(LOCK_FILE, os.O_WRONLY | os.O_CREAT, 0o644), fcntl.LOCK_EX | fcntl.LOCK_NB)
+except OSError:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'','parameter':'','value':'','error':'action_already_running'}],fp=sys.stdout)
+    sys.exit(3)
 
 agent_id = os.environ['AGENT_ID']
 

--- a/core/imageroot/usr/local/agent/actions/update-module/05pullimages
+++ b/core/imageroot/usr/local/agent/actions/update-module/05pullimages
@@ -35,10 +35,11 @@ try:
     # This lock is released by the OS when the process completes (no
     # matter its exit code):
     fcntl.flock(os.open(LOCK_FILE, os.O_WRONLY | os.O_CREAT, 0o644), fcntl.LOCK_EX | fcntl.LOCK_NB)
-except OSError:
+except OSError as ex:
+    print(agent.SD_ERR + f"Action already running. Failed to acquire lock on {LOCK_FILE}:", ex, file=sys.stderr)
     agent.set_status('validation-failed')
     json.dump([{'field':'','parameter':'','value':'','error':'action_already_running'}],fp=sys.stdout)
-    sys.exit(3)
+    sys.exit(2)
 
 agent_id = os.environ['AGENT_ID']
 

--- a/core/imageroot/usr/local/agent/actions/update-module/50run_scriptdir
+++ b/core/imageroot/usr/local/agent/actions/update-module/50run_scriptdir
@@ -23,6 +23,13 @@
 set -e
 exec 1>&2
 
+# Prevent concurrent execution of this script with a lock file opened with
+# an arbitrary high FD number, like 201.
+exec 201>.update-module.lock
+# This lock is released by the OS when the process completes (no matter
+# its exit code). Execution is blocked until lock is acquired:
+flock --verbose 201
+
 # B1-UPGRADE: clean up legacy log_tag.conf before restarting the module
 # containers. A system reboot is recommended, anyway.
 if [[ $EUID != 0 ]]; then

--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-core/50update_core
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-core/50update_core
@@ -10,6 +10,19 @@ import agent
 import agent.tasks
 import sys, os
 import cluster.modules
+import fcntl
+
+# Protect update-core from multiple concurrent runs. If the lock cannot be
+# acquired the action fails immediately.
+LOCK_FILE = ".update-core.lock"
+try:
+    # This lock is released by the OS when the process completes (no
+    # matter its exit code):
+    fcntl.flock(os.open(LOCK_FILE, os.O_WRONLY | os.O_CREAT, 0o644), fcntl.LOCK_EX | fcntl.LOCK_NB)
+except OSError:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'','parameter':'','value':'','error':'action_already_running'}],fp=sys.stdout)
+    sys.exit(3)
 
 request = json.load(sys.stdin)
 core_url = request.get('core_url', '')

--- a/core/imageroot/var/lib/nethserver/cluster/actions/update-core/50update_core
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/update-core/50update_core
@@ -19,10 +19,11 @@ try:
     # This lock is released by the OS when the process completes (no
     # matter its exit code):
     fcntl.flock(os.open(LOCK_FILE, os.O_WRONLY | os.O_CREAT, 0o644), fcntl.LOCK_EX | fcntl.LOCK_NB)
-except OSError:
+except OSError as ex:
+    print(agent.SD_ERR + f"Action already running. Failed to acquire lock on {LOCK_FILE}:", ex, file=sys.stderr)
     agent.set_status('validation-failed')
     json.dump([{'field':'','parameter':'','value':'','error':'action_already_running'}],fp=sys.stdout)
-    sys.exit(3)
+    sys.exit(2)
 
 request = json.load(sys.stdin)
 core_url = request.get('core_url', '')


### PR DESCRIPTION
Software update procedures must be protected from concurrent runs to avoid unexpected behaviors, like sudden service restarts.

Use fcntl flock to ensure only one action runs at a time. If the lock cannot be acquired, the action fails immediately with a validation-failed status.

The lock is enforced by the kernel and is implicitly released when the process terminates, no matter its exit code. The rendez-vous file is created only if it not exists (O_CREAT flag).

Refs  NethServer/dev#7877