### PR TITLE
feat: handle create-cluster network_check_failed

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/tasks/redisclient.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/tasks/redisclient.py
@@ -236,8 +236,8 @@ async def _retry_request(request_procedure, *args, **kwargs):
             return retval
         except aioredis.ConnectionError as exredis:
             retry_error = str(exredis)
-        except TaskRetryPubSubDisconnect as extask:
-            retry_error = str(exredis)
+        except (TaskRetryPubSubDisconnect, TaskStatusNotFound) as extask:
+            retry_error = str(extask)
         except Exception as ex:
             if attempt > 1:
                 frameback = sys.exc_info()[2].tb_frame.f_back

--- a/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/10validate_network
+++ b/core/imageroot/var/lib/nethserver/cluster/actions/create-cluster/10validate_network
@@ -9,6 +9,8 @@ import json
 import sys
 import agent
 import ipaddress
+import socket
+import concurrent.futures
 
 request = json.load(sys.stdin)
 
@@ -39,4 +41,35 @@ def is_valid_and_private(ip):
 if not is_valid_and_private(network):
     agent.set_status('validation-failed')
     json.dump([{'field':'network', 'parameter':'network','value': request['network'], 'error':'not_a_private_network'}], fp=sys.stdout)
+    sys.exit(2)
+
+def network_sanity_check():
+    """Check the system DNS and gateway settings with a bunch of network
+    connection attempts to external web sites. If at least one succeeds the
+    check passes. If all fail, the check fails."""
+    hosts = [
+        "phonehome.nethserver.org",
+        "ghcr.io",
+        "docker.io",
+        "quay.io",
+    ]
+    def try_connect(host):
+        try:
+            for af, socktype, proto, _, sockaddr in socket.getaddrinfo(host, 443, type=socket.SOCK_STREAM)[:2]:
+                try:
+                    with socket.socket(af, socktype, proto) as sock:
+                        sock.settimeout(3)
+                        sock.connect(sockaddr)
+                    return True
+                except OSError as ex:
+                    print(f"Connection {host} {sockaddr} check error:", ex, file=sys.stderr)
+        except OSError as ex:
+            print(f"Connection {host} check error:", ex, file=sys.stderr)
+        return False
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        return any(executor.map(try_connect, hosts))
+
+if not network_sanity_check():
+    agent.set_status('validation-failed')
+    json.dump([{'field':'', 'parameter':'','value': '', 'error':'network_check_failed'}], fp=sys.stdout)
     sys.exit(2)

--- a/core/ui/public/i18n/en/translation.json
+++ b/core/ui/public/i18n/en/translation.json
@@ -270,6 +270,7 @@
         "review_worker_fqdn_description": "Set the fully qualified domain name (FQDN) of this cluster worker",
         "not_a_private_network": "Must be included in the private IPv4 network addresses: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16",
         "not_a_valid_ipv4_network": "Invalid IPv4 network address",
+        "network_check_failed": "Network connectivity check failed. Ensure the node can access Internet and DNS resolution is working",
         "network_pattern": "Invalid network format",
         "domain_format": "Invalid domain format",
         "hostname_format": "Invalid hostname format",

--- a/core/ui/src/views/InitializeCluster.vue
+++ b/core/ui/src/views/InitializeCluster.vue
@@ -186,6 +186,16 @@
               <WelcomeLogo />
             </cv-column>
           </cv-row>
+          <cv-row v-if="error.networkCheckCreateCluster">
+            <cv-column>
+              <NsInlineNotification
+                kind="error"
+                :title="$t('action.create-cluster')"
+                :description="error.networkCheckCreateCluster"
+                :showCloseButton="false"
+              />
+            </cv-column>
+          </cv-row>
           <cv-row v-if="!isCreatingCluster">
             <cv-column>
               <NsInlineNotification
@@ -994,6 +1004,7 @@ export default {
         readBackupRepositories: "",
         restoreModules: "",
         createCluster: "",
+        networkCheckCreateCluster: "",
         getDefaults: "",
         restore: {
           url: "",
@@ -1140,6 +1151,8 @@ export default {
     onFqdnSet() {
       const action = this.$route.query.action; // "create" or "join"
 
+      this.error.networkCheckCreateCluster = "";
+      this.error.createCluster = "";
       this.$router.push({
         path: "/init",
         query: { page: action, action: action },
@@ -1459,6 +1472,8 @@ export default {
       const taskAction = "create-cluster";
       const eventId = this.getUuid();
       this.createClusterProgress = 0;
+      this.error.networkCheckCreateCluster = "";
+      this.error.createCluster = "";
 
       // register to task validation
       this.$root.$once(
@@ -1521,16 +1536,19 @@ export default {
 
       for (const validationError of validationErrors) {
         const param = validationError.parameter;
-
-        // set i18n error message
-        this.error[param] = this.getI18nStringWithFallback(
+        const errorMessage = this.getI18nStringWithFallback(
           "init." + validationError.error,
           "error." + validationError.error
         );
+        if (validationError.error === "network_check_failed") {
+          this.error.networkCheckCreateCluster = errorMessage;
+        } else if (param) {
+          this.error[param] = errorMessage;
 
-        if (!focusAlreadySet) {
-          this.focusElement(param);
-          focusAlreadySet = true;
+          if (!focusAlreadySet) {
+            this.focusElement(param);
+            focusAlreadySet = true;
+          }
         }
       }
     },


### PR DESCRIPTION
Validate network configuration before create-cluster alters Redis state. Show an UI notification error if network check fails.

Refs NethServer/dev#8021