### PR TITLE
fix(update-os): hide DNF repository credentials in system logs

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -179,14 +179,15 @@ def get_progress_callback(range_low, range_high):
     return cbk
 
 def run_helper(*args, log_command=True, **kwargs):
-    """Run the command in args, writing the command line to stderr with prio DEBUG.
-    Set log_command=False, to suppress the command logging.
-
+    """Run the command in args, writing the command line to stderr with prio INFO.
+    - Set log_command=False, to suppress the command logging.
+    - Set progress_callback=func(p), to capture the task progress data if the
+      helper command generates it.
     The command output is redirected to stderr by default.
     Additional keyword arguments are passed to subprocess.Popen
     """
     if log_command:
-        print(SD_DEBUG + shlex.join(args), file=sys.stderr)
+        print(SD_INFO + shlex.join(args), file=sys.stderr)
 
     progress_callback = kwargs.pop('progress_callback', None)
     start_env = kwargs.pop('env', os.environ)

--- a/core/imageroot/var/lib/nethserver/node/actions/update-os/50update_os
+++ b/core/imageroot/var/lib/nethserver/node/actions/update-os/50update_os
@@ -33,6 +33,6 @@ if hsubscription:
 
 # Apply DNF updates before restarting core services
 try:
-    agent.run_helper("/usr/bin/dnf", "update", "-y", *dnfargs).check_returncode()
+    agent.run_helper("/usr/bin/dnf", "update", "-y", *dnfargs, log_command=False).check_returncode()
 except (FileNotFoundError, PermissionError):
     print(agent.SD_INFO + "Cannot update the node OS: dnf was not found on this system", file=sys.stderr)


### PR DESCRIPTION
Avoid writing the DNF repository credentials in the system logs.

Note that currently:
- the repo password is an hash of the subscription token
- the Porthos server does not enforce credential checks

Refs NethServer/dev#8013