### PR TITLE
fix: work around systemd %S path change on Rocky 9.8

### DIFF
--- a/core/imageroot/etc/systemd/system/fix-xdg-state@.service
+++ b/core/imageroot/etc/systemd/system/fix-xdg-state@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Create User-State-Private link
+Documentation=https://github.com/NethServer/dev/issues/8028
+
+[Service]
+User=%i
+Type=oneshot
+ExecStart=bash -c '! [[ -e ~/.local/state ]] && ln -sfv ../.config ~/.local/state'
+RemainAfterExit=true

--- a/core/imageroot/etc/systemd/system/fix-xdg-state@.service
+++ b/core/imageroot/etc/systemd/system/fix-xdg-state@.service
@@ -8,4 +8,3 @@ Type=oneshot
 WorkingDirectory=~
 ExecStart=bash -c '! [[ -d .local ]] && mkdir -vp .local'
 ExecStart=bash -c '! [[ -e .local/state ]] && ln -sfv ../.config .local/state'
-RemainAfterExit=true

--- a/core/imageroot/etc/systemd/system/fix-xdg-state@.service
+++ b/core/imageroot/etc/systemd/system/fix-xdg-state@.service
@@ -5,5 +5,7 @@ Documentation=https://github.com/NethServer/dev/issues/8028
 [Service]
 User=%i
 Type=oneshot
-ExecStart=bash -c '! [[ -e ~/.local/state ]] && ln -sfv ../.config ~/.local/state'
+WorkingDirectory=~
+ExecStart=bash -c '! [[ -d .local ]] && mkdir -vp .local'
+ExecStart=bash -c '! [[ -e .local/state ]] && ln -sfv ../.config .local/state'
 RemainAfterExit=true

--- a/core/imageroot/etc/systemd/system/fix-xdg-state@.service
+++ b/core/imageroot/etc/systemd/system/fix-xdg-state@.service
@@ -6,5 +6,5 @@ Documentation=https://github.com/NethServer/dev/issues/8028
 User=%i
 Type=oneshot
 WorkingDirectory=~
-ExecStart=bash -c '! [[ -d .local ]] && mkdir -vp .local'
-ExecStart=bash -c '! [[ -e .local/state ]] && ln -sfv ../.config .local/state'
+ExecStart=bash -c 'mkdir -vp .local'
+ExecStart=bash -c '[[ -e .local/state ]] || ln -sfv ../.config .local/state'

--- a/core/imageroot/etc/systemd/system/user@.service.d/30-fix-xdg-state.conf
+++ b/core/imageroot/etc/systemd/system/user@.service.d/30-fix-xdg-state.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=fix-xdg-state@%i.service
+Wants=fix-xdg-state@%i.service

--- a/core/imageroot/etc/systemd/user.conf.d/01-xdg-state.conf
+++ b/core/imageroot/etc/systemd/user.conf.d/01-xdg-state.conf
@@ -1,3 +1,0 @@
-# This setting is required by Debian 13 and may raise a harmless warning in other distros.
-[Manager]
-ManagerEnvironment=XDG_STATE_HOME=%h/.config

--- a/core/imageroot/etc/systemd/user/agent.service
+++ b/core/imageroot/etc/systemd/user/agent.service
@@ -4,12 +4,12 @@ Documentation=https://nethserver.github.io/ns8-core/modules/agent/
 
 [Service]
 Type=simple
-Environment=AGENT_INSTALL_DIR=%S
-Environment=AGENT_STATE_DIR=%S/state
+Environment=AGENT_INSTALL_DIR=%E
+Environment=AGENT_STATE_DIR=%E/state
 Environment=AGENT_ID=module/%u
 EnvironmentFile=/etc/nethserver/agent.env
-EnvironmentFile=-%S/state/agent.env
-WorkingDirectory=%S/state
+EnvironmentFile=-%E/state/agent.env
+WorkingDirectory=%E/state
 # Fix bogus permissions for NethServer/dev#7915
 ExecStartPre=-/usr/bin/chmod -c 644 environment
 ExecStart=/usr/local/bin/agent \

--- a/core/imageroot/etc/systemd/user/api-moduled.service
+++ b/core/imageroot/etc/systemd/user/api-moduled.service
@@ -1,15 +1,15 @@
 [Unit]
 Description=API Module Daemon (AMLD)
-ConditionPathExists=%S/state/api-moduled.env
+ConditionPathExists=%E/state/api-moduled.env
 
 [Service]
 Type=simple
-Environment=AMLD_HANDLER_DIR=%S/api-moduled/handlers
-Environment=AMLD_PUBLIC_DIR=%S/api-moduled/public
+Environment=AMLD_HANDLER_DIR=%E/api-moduled/handlers
+Environment=AMLD_PUBLIC_DIR=%E/api-moduled/public
 Environment=AMLD_JWT_REALM=%u
 Environment=GIN_MODE=release
-EnvironmentFile=%S/state/api-moduled.env
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/api-moduled.env
+WorkingDirectory=%E/state
 ExecStart=/usr/local/bin/runagent /usr/local/bin/api-moduled
 Restart=always
 SyslogIdentifier=%N


### PR DESCRIPTION
Rocky Linux 9.8 ships a systemd version where the `%S` specifier now expands to `~/.local/state` instead of `~/.config`, breaking rootless module agent and container startup due to path mismatch.

Replace `%S` with `%E` (`XDG_CONFIG_HOME`, `~/.config`) in agent.service and api-moduled.service. Add `fix-xdg-state@.service`, a one-shot unit that creates a `~/.local/state` -> `../.config` symlink before `user@.service` starts, preserving compatibility with any path already hardcoded elsewhere.

Remove the superseded `01-xdg-state.conf` `ManagerEnvironment=` override, which is no longer needed.

The symlink is created on the next user session restart, (i.e. next node reboot, or forced application restart). Until that happens the running Systemd session manager keeps the previous %S assignment and the bug is not present.

The symlink is also created when a new module is added to the system (systemd user session starts early), covering all possible creation paths.

Fixes NethServer/dev#8028