### PR TITLE
fix: backup .local/state before creating the symlink

### DIFF
--- a/core/imageroot/etc/systemd/system/fix-xdg-state@.service
+++ b/core/imageroot/etc/systemd/system/fix-xdg-state@.service
@@ -6,5 +6,10 @@ Documentation=https://github.com/NethServer/dev/issues/8028
 User=%i
 Type=oneshot
 WorkingDirectory=~
-ExecStart=bash -c 'mkdir -vp .local'
-ExecStart=bash -c '[[ -e .local/state ]] || ln -sfv ../.config .local/state'
+# The ":" prefix disables systemd environment variable substitution, so $
+# signs in the bash script do not need escaping.
+ExecStart=:bash -c 'mkdir -vp .local ; cd .local || exit 1 ; \
+    lnk=$(readlink -v state) ; [[ ${lnk} == ../.config ]] || { \
+        [[ -e state || -L state ]] && mv -vf state state.$$.bak ; \
+        ln -sfv ../.config state ; \
+    }'


### PR DESCRIPTION
Closes https://github.com/NethServer/dev/issues/8028

If \`.local/state\` already exists for any reason, rename it to a \`.bak\`
file to preserve the data rather than silently discarding it.

The new logic handles all pre-existing conditions:

| Pre-existing condition | Backup? | Symlink result |
|---|---|---|
| Symlink already correct (`../.config`) | — | unchanged |
| `state` absent | — | created |
| `state` is a file or directory | yes | created |
| Broken symlink (any target) | yes | created |
| Valid symlink pointing elsewhere | yes | created |

The \`:\` prefix on \`ExecStart\` disables systemd environment variable
substitution, so \`$\` signs in the bash script do not need escaping.