### PR TITLE
fix: disable dnf-automatic on subscribed nodes

### DIFF
--- a/core/imageroot/etc/systemd/system/dnf-automatic-download.service.d/10-ns8.conf
+++ b/core/imageroot/etc/systemd/system/dnf-automatic-download.service.d/10-ns8.conf
@@ -1,0 +1,3 @@
+[Service]
+# An active NS8 subscription is not compatible with dnf-automatic
+ExecCondition=runagent -m node check-unmanaged-updates

--- a/core/imageroot/etc/systemd/system/dnf-automatic-install.service.d/10-ns8.conf
+++ b/core/imageroot/etc/systemd/system/dnf-automatic-install.service.d/10-ns8.conf
@@ -1,0 +1,3 @@
+[Service]
+# An active NS8 subscription is not compatible with dnf-automatic
+ExecCondition=runagent -m node check-unmanaged-updates

--- a/core/imageroot/etc/systemd/system/dnf-automatic-notifyonly.service.d/10-ns8.conf
+++ b/core/imageroot/etc/systemd/system/dnf-automatic-notifyonly.service.d/10-ns8.conf
@@ -1,0 +1,3 @@
+[Service]
+# An active NS8 subscription is not compatible with dnf-automatic
+ExecCondition=runagent -m node check-unmanaged-updates

--- a/core/imageroot/etc/systemd/system/dnf-automatic.service.d/10-ns8.conf
+++ b/core/imageroot/etc/systemd/system/dnf-automatic.service.d/10-ns8.conf
@@ -1,0 +1,3 @@
+[Service]
+# An active NS8 subscription is not compatible with dnf-automatic
+ExecCondition=runagent -m node check-unmanaged-updates

--- a/core/imageroot/var/lib/nethserver/node/bin/check-unmanaged-updates
+++ b/core/imageroot/var/lib/nethserver/node/bin/check-unmanaged-updates
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import agent.facts
+import sys
+
+rdb = agent.redis_connect(use_replica=True)
+
+is_managed = agent.facts.has_subscription(rdb)
+
+quiet_run = False
+if '--quiet' in sys.argv or '-q' in sys.argv:
+    quiet_run = True
+
+if is_managed:
+    if not quiet_run:
+        print(agent.SD_INFO + "[INFO] check-unmanaged-updates: NS8 subscription is active")
+    # Non-zero exit: ExecCondition fails, dnf-automatic is skipped (fail-safe)
+    sys.exit(2)
+else:
+    if not quiet_run:
+        print(agent.SD_INFO + "[INFO] check-unmanaged-updates: NS8 subscription is disabled")
+    # Zero exit: ExecCondition passes, dnf-automatic runs normally
+    sys.exit(0)


### PR DESCRIPTION
Add systemd drop-ins for all dnf-automatic service unit variants. Each drop-in sets ExecCondition= to run check-unmanaged-updates via runagent in the node agent context. When an NS8 subscription is active, the script exits non-zero and systemd skips the service. On unsubscribed nodes the script exits 0 and dnf-automatic runs normally. Unhandled exceptions also exit non-zero (fail-safe).

Refs https://github.com/NethServer/dev/issues/8034