### PR TITLE
feat: run phonehome and send-inventory 3 times per day

### DIFF
--- a/core/imageroot/etc/systemd/system/phonehome.timer
+++ b/core/imageroot/etc/systemd/system/phonehome.timer
@@ -2,9 +2,10 @@
 Description=PhoneHome Trigger
 
 [Timer]
-OnCalendar=daily
-Persistent=true
-RandomizedDelaySec=21600
+OnCalendar=06:00
+OnCalendar=14:00
+OnCalendar=22:00
+RandomizedDelaySec=2h
 
 [Install]
 WantedBy=timers.target

--- a/core/imageroot/etc/systemd/system/send-inventory.service
+++ b/core/imageroot/etc/systemd/system/send-inventory.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Send the system inventory remotely
+Description=System inventory synchronization
 After=apply-updates.service
 
 [Service]

--- a/core/imageroot/etc/systemd/system/send-inventory.timer
+++ b/core/imageroot/etc/systemd/system/send-inventory.timer
@@ -1,14 +1,11 @@
 [Unit]
-Description=Execute send-inventory overnight
+Description=Send-inventory Trigger
 
 [Timer]
-# This timer settings assign a fixed time between 00:00 and 06:00 AM to
-# start the send-inventory.service unit. If the node was powered off at that
-# time the timer should trigger as soon as it gets powered on again.
-OnCalendar=00:00:00
-RandomizedDelaySec=6h
-FixedRandomDelay=true
-Persistent=true
+OnCalendar=06:00
+OnCalendar=14:00
+OnCalendar=22:00
+RandomizedDelaySec=2h
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Schedule phonehome.timer and send-inventory.timer to trigger at 6, 14 and 22 instead of once daily, with 2 hours of randomized delay to distribute load on inventory servers.

Removed Persistent=true since with more frequency a missed run is not a big issue.

Discussion https://mattermost.nethesis.it/nethesis/pl/jciqrpbo1fyotgccr6i8ggm15o