### PR TITLE
fix: do not request date-fns-locale packages on load

### DIFF
--- a/core/ui/src/i18n/index.js
+++ b/core/ui/src/i18n/index.js
@@ -17,26 +17,3 @@ export async function loadLanguage(lang) {
   }
 }
 
-export async function getDateFnsLocale() {
-  const lang = navigator.language;
-  try {
-    const mod = await import(
-      /* webpackChunkName: "date-fns-locale-[request]" */
-      `date-fns/locale/${lang}`
-    );
-    return mod.default || mod;
-  } catch {
-    // try base language (e.g. "it" from "it-IT")
-    const baseLang = lang.split("-")[0];
-    try {
-      const mod = await import(
-        /* webpackChunkName: "date-fns-locale-[request]" */
-        `date-fns/locale/${baseLang}`
-      );
-      return mod.default || mod;
-    } catch {
-      const mod = await import("date-fns/locale/en-US");
-      return mod.default || mod;
-    }
-  }
-}

--- a/core/ui/src/views/settings/SettingsSubscription.vue
+++ b/core/ui/src/views/settings/SettingsSubscription.vue
@@ -351,8 +351,6 @@ import {
   PageTitleService,
   DateTimeService,
 } from "@nethserver/ns8-ui-lib";
-import { intervalToDuration, parseISO, formatDuration } from "date-fns";
-import { getDateFnsLocale } from "@/i18n";
 import { mapGetters } from "vuex";
 
 import NotificationService from "@/mixins/notification";
@@ -397,7 +395,6 @@ export default {
       termsUrl: "",
       agreeTerms: false,
       sessionExpireDate: "",
-      dateFnsLocale: null,
       loading: {
         getSubscription: false,
         setSubscription: false,
@@ -421,11 +418,6 @@ export default {
   created() {
     this.getSubscription();
     this.getSupportSession();
-
-    // load date-fns locale based on user language
-    getDateFnsLocale().then((locale) => {
-      this.dateFnsLocale = locale;
-    });
   },
   beforeRouteEnter(to, from, next) {
     next((vm) => {
@@ -439,11 +431,12 @@ export default {
   },
   methods: {
     formatExpiryDate(dateString) {
-      const parsedDate = parseISO(dateString);
-      const duration = intervalToDuration({
-        start: new Date(),
-        end: parsedDate,
-      });
+      const end = new Date(dateString);
+      const diffMs = Math.max(0, end - Date.now());
+      const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+      const hours = Math.floor(
+        (diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
+      );
 
       const dateTimeStr = new Intl.DateTimeFormat(navigator.language, {
         hour: "2-digit",
@@ -451,12 +444,12 @@ export default {
         day: "2-digit",
         month: "2-digit",
         year: "numeric",
-      }).format(parsedDate);
-      const durationStr = formatDuration(duration, {
-        format: ["days", "hours"],
-        delimiter: ", ",
-        locale: this.dateFnsLocale,
-      });
+      }).format(end);
+
+      const durationStr = new Intl.DurationFormat(navigator.language, {
+        style: "long",
+      }).format({ days, hours });
+
       return `${durationStr} (${dateTimeStr})`;
     },
     showRemoveSubcriptionModal() {


### PR DESCRIPTION
Fixed issue where many hundreds of date-fns-locale-* packages were requested on page load for all languages supported by date-fns

Refs:
- https://github.com/NethServer/dev/issues/8051
- Private conversation with @DavidePrincipi: https://mattermost.nethesis.it/nethesis/pl/sdznkezz1ff83npja9i8f65e7c