### PR TITLE
fix: wait for rclone rc startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,12 @@ target leader node.
 - **`/etc/hosts` handling**: The `set-fqdn` action comments out lines
   containing the old hostname (prefixed with `# commented by set-fqdn #`)
   and appends a new `127.0.1.1` entry for the new hostname.
+- **Entrypoint startup waits**: For container entrypoints, a simple readiness
+  loop is acceptable when the outer service startup is supervised by Systemd.
+  In exceptional failure cases, prefer relying on the Systemd start timeout
+  instead of adding extra in-script liveness handling, as long as the
+  externally visible service (for example, HAProxy) is not started before the
+  dependency is ready.
 - **Branch names**: never use "/" in branch names. Use only chars allowed
   by container registry tags, like "-" and alphanumeric chars. This is a
   requirement for container image uploads.

--- a/core/rclone/usr/local/bin/rclone-gateway-entrypoint.sh
+++ b/core/rclone/usr/local/bin/rclone-gateway-entrypoint.sh
@@ -14,6 +14,11 @@ rclone ${DEBUG:+-vvvv} \
     --rc-no-auth \
     --rc-addr "${RCLONE_UNIX_SOCKET}" \
     &
+sleep 0.2
+until rclone rc core/version >/dev/null 2>&1; do
+    echo "Still waiting for rclone startup..."
+    sleep 1
+done
 echo "Initialize backends..."
 rclone-serve-restart
 echo "Initialize frontend..."


### PR DESCRIPTION
Add a readiness loop to the rclone gateway entrypoint before starting the backends.

Document in AGENTS.md that simple entrypoint readiness waits can rely on the outer Systemd startup timeout when the visible service is not started early.

Refs NethServer/dev#7814