### PR TITLE
fix: restart systemd user sessions

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/actions/update-core/60condrestart_redis
+++ b/core/imageroot/var/lib/nethserver/node/actions/update-core/60condrestart_redis
@@ -1,11 +1,18 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2023 Nethesis S.r.l.
+# Copyright (C) 2026 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-# NOTE: this step is retained to avoid update-core runtime failure until
-# agent ignores missing steps silently
+# Some nodes may run for a very long time without a manual reboot. Stop then
+# start every non-root systemd user session so /run/user/* is recreated and the
+# netns directories get the SELinux labels expected by Podman after the Rocky
+# Linux 9.8 upgrade.
+while read -r uid _; do
+    [[ "$uid" == "0" ]] && continue
+    systemctl stop "user@$uid"
+    systemctl start "user@$uid"
+done < <(loginctl list-users --no-legend)
 
 exit 0


### PR DESCRIPTION
Stop then start all non-root systemd user sessions during the update-core action.

This recreates /run/user/* and works around the SELinux labeling mismatch affecting netns directories after the Rocky Linux 9.8 upgrade.

:information_source:  This temporary workaround restarts systemd user sessions during the update and will be removed in a future core release. Implementation modifies an old script file to ease future removal of this code.