### PR TITLE
feat(ui): colorize log levels and process tag in System logs

### DIFF
--- a/core/ui/src/components/system-logs/LogHighlightMark.vue
+++ b/core/ui/src/components/system-logs/LogHighlightMark.vue
@@ -1,5 +1,5 @@
 <!--
-  Copyright (C) 2023 Nethesis S.r.l.
+  Copyright (C) 2026 Nethesis S.r.l.
   SPDX-License-Identifier: GPL-3.0-or-later
 -->
 <template>

--- a/core/ui/src/components/system-logs/LogHighlightMark.vue
+++ b/core/ui/src/components/system-logs/LogHighlightMark.vue
@@ -1,0 +1,112 @@
+<!--
+  Copyright (C) 2023 Nethesis S.r.l.
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+<template>
+  <mark :class="levelClass"
+    ><span v-if="beforeTag" class="log-timestamp"
+      ><template v-for="(part, i) in beforeParts"
+        ><mark v-if="part.isMatch" :key="'b' + i" class="log-search-match">{{
+          part.text
+        }}</mark
+        ><template v-else>{{ part.text }}</template></template
+      ></span
+    ><span v-if="tagText" class="log-process-tag"
+      ><template v-for="(part, i) in tagParts"
+        ><mark v-if="part.isMatch" :key="'t' + i" class="log-search-match">{{
+          part.text
+        }}</mark
+        ><template v-else>{{ part.text }}</template></template
+      ></span
+    ><template v-for="(part, i) in restParts"
+      ><mark v-if="part.isMatch" :key="'r' + i" class="log-search-match">{{
+        part.text
+      }}</mark
+      ><template v-else>{{ part.text }}</template></template
+    ></mark
+  >
+</template>
+
+<script>
+// "contains" check: a chunk can be a single keyword or a whole matching line
+const LOG_LEVEL_CLASSIFIERS = [
+  {
+    class: "log-level-error",
+    pattern: /\b(?:error|err|fatal|crit|critical)\b/i,
+  },
+  { class: "log-level-warn", pattern: /\b(?:warn|warning)\b/i },
+  { class: "log-level-info", pattern: /\b(?:info|information|notice)\b/i },
+  { class: "log-level-debug", pattern: /\b(?:debug|trace)\b/i },
+];
+
+// leading timestamp followed by the "[node_id:module_id:syslog_id]" tag
+// added by the backend's LogQL line_format, e.g.
+// "2026-07-05T12:03:17+02:00 [1:traefik1:traefik] ..."
+const PROCESS_TAG_PATTERN = /^(\S+\s+)(\[[^\]]*\])/;
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export default {
+  name: "LogHighlightMark",
+  props: {
+    text: {
+      type: String,
+      required: true,
+    },
+    searchTerm: {
+      type: String,
+      default: "",
+    },
+  },
+  computed: {
+    levelClass() {
+      const level = LOG_LEVEL_CLASSIFIERS.find((l) =>
+        l.pattern.test(this.text)
+      );
+      return level ? level.class : "";
+    },
+    tagMatch() {
+      return PROCESS_TAG_PATTERN.exec(this.text);
+    },
+    beforeTag() {
+      return this.tagMatch ? this.tagMatch[1] : "";
+    },
+    tagText() {
+      return this.tagMatch ? this.tagMatch[2] : "";
+    },
+    afterTag() {
+      return this.tagMatch
+        ? this.text.slice(this.tagMatch[0].length)
+        : this.text;
+    },
+    beforeParts() {
+      return this.splitBySearchTerm(this.beforeTag);
+    },
+    tagParts() {
+      return this.splitBySearchTerm(this.tagText);
+    },
+    restParts() {
+      return this.splitBySearchTerm(this.afterTag);
+    },
+  },
+  methods: {
+    // splits a piece of text so the search term keeps its own clickable
+    // mark, even when the whole containing line is also colorized by level
+    splitBySearchTerm(text) {
+      if (!this.searchTerm) {
+        return [{ text, isMatch: false }];
+      }
+      const re = new RegExp(`(${escapeRegExp(this.searchTerm)})`, "gi");
+      return text
+        .split(re)
+        .filter((part) => part !== "")
+        .map((part) => ({
+          text: part,
+          isMatch: part.toLowerCase() === this.searchTerm.toLowerCase(),
+        }));
+    },
+  },
+};
+</script>

--- a/core/ui/src/components/system-logs/LogOutput.vue
+++ b/core/ui/src/components/system-logs/LogOutput.vue
@@ -200,7 +200,7 @@ mark.log-level-error {
 
 mark.log-level-warn {
   background: transparent;
-  color: #f1c21b;
+  color: $inverse-support-03;
   font-weight: 600;
 }
 

--- a/core/ui/src/components/system-logs/LogOutput.vue
+++ b/core/ui/src/components/system-logs/LogOutput.vue
@@ -212,7 +212,7 @@ mark.log-level-info {
 
 mark.log-level-debug {
   background: transparent;
-  color: #fff;
+  color: $ui-02;
   font-weight: 600;
 }
 

--- a/core/ui/src/components/system-logs/LogOutput.vue
+++ b/core/ui/src/components/system-logs/LogOutput.vue
@@ -151,7 +151,7 @@ export default {
   max-width: none;
   min-height: 4rem;
   max-height: 35rem;
-  background-color: #000 !important;
+  background-color: #161616 !important;
   color: #f4f4f4 !important;
 }
 

--- a/core/ui/src/components/system-logs/LogOutput.vue
+++ b/core/ui/src/components/system-logs/LogOutput.vue
@@ -194,7 +194,7 @@ mark.text__highlight {
 // highlighting keeps its default native <mark> look, still legible on black)
 mark.log-level-error {
   background: transparent;
-  color: #ff8389;
+  color: $inverse-support-01;
   font-weight: 600;
 }
 

--- a/core/ui/src/components/system-logs/LogOutput.vue
+++ b/core/ui/src/components/system-logs/LogOutput.vue
@@ -206,7 +206,7 @@ mark.log-level-warn {
 
 mark.log-level-info {
   background: transparent;
-  color: #78a9ff;
+  color: $inverse-support-04;
   font-weight: 600;
 }
 

--- a/core/ui/src/components/system-logs/LogOutput.vue
+++ b/core/ui/src/components/system-logs/LogOutput.vue
@@ -40,7 +40,11 @@
       :ref="'logsContainer-' + searchId"
       :key="'logsContainer-' + searchId"
     >
-      <pre><text-highlight :queries="highlightQueries">{{ logText }}</text-highlight></pre>
+      <pre><text-highlight
+        :queries="highlightQueries"
+        :highlight-component="highlightComponent"
+        :search-term="highlight"
+      >{{ logText }}</text-highlight></pre>
     </div>
   </div>
 </template>
@@ -48,6 +52,21 @@
 <script>
 import { carbonPrefixMixin, themeMixin } from "@carbon/vue/src/mixins";
 import { UtilService, LottieService } from "@nethserver/ns8-ui-lib";
+import LogHighlightMark from "./LogHighlightMark.vue";
+
+// match the whole line containing a level keyword (not just the keyword),
+// case-insensitive: layered on top of the user's search query, purely for
+// visual colorization, they don't affect what gets matched by it
+const LOG_LEVEL_QUERIES = [
+  /^.*\b(?:ERROR|ERR|FATAL|CRIT(?:ICAL)?)\b.*$/im,
+  /^.*\b(?:WARN(?:ING)?)\b.*$/im,
+  /^.*\b(?:INFO(?:RMATION)?|NOTICE)\b.*$/im,
+  /^.*\b(?:DEBUG|TRACE)\b.*$/im,
+];
+
+// ensures every line's leading timestamp + "[node:module:syslog_id]" tag
+// gets its own highlighted chunk, even on lines with no level keyword
+const PROCESS_TAG_QUERY = /^\S+\s+\[[^\]]*\]/im;
 
 export default {
   name: "LogOutput",
@@ -80,12 +99,17 @@ export default {
     noLogsFound: Boolean,
   },
   mixins: [carbonPrefixMixin, themeMixin, UtilService, LottieService],
+  data() {
+    return {
+      highlightComponent: LogHighlightMark,
+    };
+  },
   computed: {
     logText() {
       return this.outputLines.join("\n");
     },
     highlightQueries() {
-      return [this.highlight];
+      return [this.highlight, ...LOG_LEVEL_QUERIES, PROCESS_TAG_QUERY];
     },
   },
   watch: {
@@ -127,6 +151,8 @@ export default {
   max-width: none;
   min-height: 4rem;
   max-height: 35rem;
+  background-color: #000 !important;
+  color: #f4f4f4 !important;
 }
 
 .logs-output.reduced-output-height.bx--snippet--multi {
@@ -155,5 +181,46 @@ export default {
 // show scrollbar
 .system-logs .logs-output.bx--snippet--multi .bx--snippet-container {
   overflow-y: auto !important;
+}
+
+// every line is wrapped in a <mark> (for level/tag detection), so clear the
+// native browser <mark> yellow background on that wrapper; nested
+// mark.log-search-match keeps its own default look, still legible on black
+mark.text__highlight {
+  background: transparent;
+}
+
+// log level colorization on the dark log viewer background (search-match
+// highlighting keeps its default native <mark> look, still legible on black)
+mark.log-level-error {
+  background: transparent;
+  color: #ff8389;
+  font-weight: 600;
+}
+
+mark.log-level-warn {
+  background: transparent;
+  color: #f1c21b;
+  font-weight: 600;
+}
+
+mark.log-level-info {
+  background: transparent;
+  color: #78a9ff;
+  font-weight: 600;
+}
+
+mark.log-level-debug {
+  background: transparent;
+  color: #fff;
+  font-weight: 600;
+}
+
+// leading timestamp and "[node:module:syslog_id]" tag, set off from the
+// rest of the line
+.log-timestamp,
+.log-process-tag {
+  color: #fff;
+  font-weight: 700;
 }
 </style>

--- a/core/ui/src/components/system-logs/LogOutput.vue
+++ b/core/ui/src/components/system-logs/LogOutput.vue
@@ -25,7 +25,7 @@
     <NsEmptyState
       v-else-if="noLogsFound"
       :title="$t('system_logs.no_log_found')"
-      :animationData="GhostLottie"
+      :animationData="GhostDarkBgLottie"
       animationTitle="ghost"
       :loop="1"
       class="margin-auto"
@@ -183,44 +183,46 @@ export default {
   overflow-y: auto !important;
 }
 
-// every line is wrapped in a <mark> (for level/tag detection), so clear the
-// native browser <mark> yellow background on that wrapper; nested
-// mark.log-search-match keeps its own default look, still legible on black
-mark.text__highlight {
-  background: transparent;
-}
+.logs-output {
+  // every line is wrapped in a <mark> (for level/tag detection), so clear
+  // the native browser <mark> yellow background on that wrapper; nested
+  // mark.log-search-match keeps its own default look, still legible on black
+  mark.text__highlight {
+    background: transparent;
+  }
 
-// log level colorization on the dark log viewer background (search-match
-// highlighting keeps its default native <mark> look, still legible on black)
-mark.log-level-error {
-  background: transparent;
-  color: $inverse-support-01;
-  font-weight: 600;
-}
+  // log level colorization on the dark log viewer background (search-match
+  // highlighting keeps its default native <mark> look, still legible on black)
+  mark.log-level-error {
+    background: transparent;
+    color: $inverse-support-01;
+    font-weight: 600;
+  }
 
-mark.log-level-warn {
-  background: transparent;
-  color: $inverse-support-03;
-  font-weight: 600;
-}
+  mark.log-level-warn {
+    background: transparent;
+    color: $inverse-support-03;
+    font-weight: 600;
+  }
 
-mark.log-level-info {
-  background: transparent;
-  color: $inverse-support-04;
-  font-weight: 600;
-}
+  mark.log-level-info {
+    background: transparent;
+    color: $inverse-support-04;
+    font-weight: 600;
+  }
 
-mark.log-level-debug {
-  background: transparent;
-  color: $ui-02;
-  font-weight: 600;
-}
+  mark.log-level-debug {
+    background: transparent;
+    color: $ui-02;
+    font-weight: 600;
+  }
 
-// leading timestamp and "[node:module:syslog_id]" tag, set off from the
-// rest of the line
-.log-timestamp,
-.log-process-tag {
-  color: $ui-02;
-  font-weight: 700;
+  // leading timestamp and "[node:module:syslog_id]" tag, set off from the
+  // rest of the line
+  .log-timestamp,
+  .log-process-tag {
+    color: $ui-02;
+    font-weight: 700;
+  }
 }
 </style>

--- a/core/ui/src/components/system-logs/LogOutput.vue
+++ b/core/ui/src/components/system-logs/LogOutput.vue
@@ -220,7 +220,7 @@ mark.log-level-debug {
 // rest of the line
 .log-timestamp,
 .log-process-tag {
-  color: #fff;
+  color: $ui-02;
   font-weight: 700;
 }
 </style>


### PR DESCRIPTION
## Summary
Adds per-line color coding (ERROR/WARN/INFO/DEBUG) and a distinguished timestamp/process tag on a dark log viewer background (Carbon gray-100), layered on top of the existing vue-text-highlight search behavior without changing it.

## Security & performance
Discussed in detail on the forum: no XSS risk (no v-html/innerHTML anywhere in the change), and no measurable browser overload even under a 2000-line dump / high-throughput follow session (sustained 60fps in testing - on powerful machine however).

## Known limitation
Colorization relies on parsing level keywords from the log text rather than journald PRIORITY, since PRIORITY is not reliably populated by most real modules (tested against production data) - see [forum thread](https://community.nethserver.org/t/feature-proposal-logs-highlighting-in-ns8-ui/28010/13) for details.

Ref:
- https://github.com/NethServer/dev/issues/8103