### PR TITLE
fix(promtail): disable Alloy usage-report telemetry

### DIFF
--- a/core/imageroot/etc/systemd/system/promtail.service
+++ b/core/imageroot/etc/systemd/system/promtail.service
@@ -24,7 +24,8 @@ ExecStart=/usr/bin/podman run \
     --volume=./journal:/var/log/journal \
     --volume=./promtail:/etc/alloy:z \
     --volume=alloy-data:/var/lib/alloy/data:z \
-    ${PROMTAIL_IMAGE}
+    ${PROMTAIL_IMAGE} \
+    run /etc/alloy/config.alloy --storage.path=/var/lib/alloy/data --disable-reporting
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%N.cid -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%N.cid
 PIDFile=%t/%N.pid


### PR DESCRIPTION
## Summary

Grafana Alloy (running under the legacy `promtail.service` unit) sends
anonymous usage stats to `stats.grafana.org` every ~4h. On offline /
air-gapped clusters this call times out and spams the journal with
retry/failure noise.

Passes `--disable-reporting` explicitly on the `podman run` command
(instead of relying on the image's default CMD) to stop the beacon.
The internal Loki log-shipping path is unaffected.

## Related issue

NethServer/dev#8088

## How to test

1. Deploy the updated `promtail.service` unit.
2. `systemctl daemon-reload && systemctl restart promtail`
3. `podman inspect promtail --format '{{json .Args}}'` — confirm `--disable-reporting` is present.
4. `journalctl -u promtail -f` — confirm no `"reporting Alloy stats"` / `"usage report"` lines appear (previously fired every ~4h).
5. Confirm log shipping to Loki still works (`loki.write.default` node evaluates without error at startup; `logcli` query returns fresh entries).

Validated live on `rl1.leader.default.gs.nethserver.net`.