### PR TITLE
feat(agent): add sortby to list_service_providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,9 @@ target leader node.
   `10`, `20`, `30`) are commonly used. Each step is a separate executable
   (Python 3 or Bash).
 - **JSON Schema validation**: Actions define `validate-input.json` /
-  `validate-output.json` for automatic request/response validation.
+  `validate-output.json` for automatic request/response validation. Whenever
+  an action's input or output attributes change, update the matching schema
+  file in the same commit/PR.
 - **Redis as state store**: All persistent state is in Redis, not on the
   filesystem. Actions use `agent.redis_connect()` to read/write state.
 - **UI design system**: Carbon Design System (`@carbon/vue`). Use Carbon

--- a/core/imageroot/usr/local/agent/actions/list-service-providers/10list_service_providers
+++ b/core/imageroot/usr/local/agent/actions/list-service-providers/10list_service_providers
@@ -17,6 +17,7 @@ rdb = agent.redis_connect()
 
 json.dump(agent.list_service_providers(rdb,
     request['service'],
-    transport=request.get('transport', '*'), 
+    transport=request.get('transport', '*'),
     filters=request.get('filter', {}),
+    sortby=request.get('sortby', 'node_proximity'),
 ), fp=sys.stdout)

--- a/core/imageroot/usr/local/agent/actions/list-service-providers/validate-input.json
+++ b/core/imageroot/usr/local/agent/actions/list-service-providers/validate-input.json
@@ -38,6 +38,13 @@
             "title": "Filter clauses",
             "description": "Return entries matching all the given clauses",
             "type": "object"
+        },
+        "sortby": {
+            "title": "Sorting rule",
+            "description": "Sort the returned entries with the given rule",
+            "type": "string",
+            "enum": ["node_proximity", "module_seq_asc", "module_seq_desc"],
+            "default": "node_proximity"
         }
     }
 }

--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -551,9 +551,15 @@ def get_module_seq(module_id : str) -> int:
     except (TypeError, ValueError):
         return -1
 
-def list_service_providers(rdb, service, transport='*', filters={}):
+def list_service_providers(rdb, service, transport='*', filters={}, sortby='node_proximity'):
     """Look up the endpoint information about a given service. Filter
-    results by transport protocol or any other exact attribute value"""
+    results by transport protocol or any other exact attribute value.
+    Sort results with sortby, one of:
+    - 'node_proximity' (default): services on the local node first,
+      then on the leader node, then on other worker nodes
+    - 'module_seq_asc': lower sequence number first
+    - 'module_seq_desc': higher sequence number first
+    """
 
     results = []
 
@@ -591,6 +597,26 @@ def list_service_providers(rdb, service, transport='*', filters={}):
     if 'module_uuid' in filters and len(results) > 1:
         results.sort(key=lambda e: e['module_seq'])
         results = [results[-1]] # Return last item only
+
+    if sortby == 'module_seq_asc':
+        results.sort(key=lambda e: e.get('module_seq', -1))
+    elif sortby == 'module_seq_desc':
+        results.sort(key=lambda e: e.get('module_seq', -1), reverse=True)
+    elif sortby == 'node_proximity':
+        local_node = os.environ.get('NODE_ID')
+        leader_node = rdb.hget('cluster/environment', 'NODE_ID')
+
+        def node_priority(record):
+            node = record.get('node')
+            if node == local_node:
+                priority = 0
+            elif node == leader_node:
+                priority = 1
+            else:
+                priority = 2
+            return (priority, record.get('module_seq', -1))
+
+        results.sort(key=node_priority)
 
     return results
 

--- a/core/tests/10__cluster_sanity/80__userdomain_openldap.robot
+++ b/core/tests/10__cluster_sanity/80__userdomain_openldap.robot
@@ -3,7 +3,9 @@ Library            SSHLibrary
 Resource           api.resource
 Resource           userdomain.resource
 Suite Setup        Start the client tool container
-Suite Teardown     Stop the client tool container
+Suite Teardown     Run keywords
+...                    Stop the client tool container
+...                    Wait until uid is free
 
 *** Variables ***
 ${domain}    openldap.nethserver.test
@@ -82,3 +84,8 @@ Start the client tool container
 
 Stop the client tool container
     Execute Command    podman kill ldapclient
+
+Wait until uid is free
+    [Documentation]    Avoid concurrent run with Samba DC installation started by the next test suite
+    Execute Command    bash -c 'while id ${mid1} ; do sleep 1 ; done'    timeout=60s
+    Execute Command    bash -c 'while id ${mid2} ; do sleep 1 ; done'    timeout=60s

--- a/docs/modules/service_providers.md
+++ b/docs/modules/service_providers.md
@@ -92,6 +92,15 @@ The input JSON object attributes are:
     - `module_uuid` copy of `HGET module/{id}/environment MODULE_UUID`
     - `ui_name`, copy of `GET module/{id}/ui_name`)
     - `transport`, copy of `transport` of the Redis key name
+    - `module_seq`, the module sequential number parsed from `module_id`
+      (e.g. `mail1` has sequence `1`)
+- `sortby` (optional): sorting rule applied to the results. One of:
+    - `node_proximity` (default): services on the local node first, then on
+      the leader node, then on other worker nodes; `module_seq` is used as
+      a stable secondary key
+    - `module_seq_asc`: order by increasing module sequence number (e.g.
+      `mail1` before `mail2`)
+    - `module_seq_desc`: order by decreasing module sequence number
 
 The following Python code snippet invokes `agent.list_service_providers()`
 to discover an IMAP server. It connects to the local Redis replica, so it
@@ -102,4 +111,13 @@ startup more robust.
 import agent
 rdb = agent.redis_connect(use_replica=True) # connect the local Redis replica
 print(agent.list_service_providers(rdb, 'imap', 'tcp'))
+```
+
+By default, results are sorted by node proximity to the caller (local node
+first, leader node second, other worker nodes third). Pass `sortby` to
+select a different rule, e.g. to order candidates by module sequence
+number:
+
+```python
+print(agent.list_service_providers(rdb, 'imap', 'tcp', sortby='module_seq_desc'))
 ```


### PR DESCRIPTION
## Summary
- Add an optional `sortby` argument to `list_service_providers()` in the agent Python package.
- Default rule `node_proximity` ranks results with services on the local node first, the leader node second, and other worker nodes third, using `module_seq` as a stable secondary key.
- `module_seq_asc` / `module_seq_desc` allow sorting purely by module sequence number, ascending or descending.
- fixed flaky openlodap/samba test suite. A uid handoff race occasionally leads to Samba systemd lingering session block.

Related: NethServer/dev#7999

## Test plan
- [ ] Manually verify `agent.list_service_providers()` ordering on a cluster with services on the local node, leader node, and other worker nodes
- [ ] Verify `sortby='module_seq_asc'` / `'module_seq_desc'` order results correctly