### PR TITLE
feat(modules): add update-module CLI command

### DIFF
--- a/core/imageroot/usr/local/sbin/update-module
+++ b/core/imageroot/usr/local/sbin/update-module
@@ -1,0 +1,39 @@
+#!/usr/local/bin/runagent python3
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import agent
+import agent.tasks
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('module_url')
+parser.add_argument('instances', nargs='+')
+parser.add_argument('--force', help='force update even if module_url is already present locally', action='store_true')
+parser.add_argument('--verbose', help='show update-module action stderr on success', action='store_true')
+args = parser.parse_args()
+
+result = agent.tasks.run(
+    agent_id='cluster',
+    action='update-module',
+    data={
+        'module_url': args.module_url,
+        'instances': args.instances,
+        'force': args.force,
+    },
+    extra={
+        'title': "cluster/update-module",
+        'description': "update-module command",
+        'isNotificationHidden': False,
+    },
+    endpoint="redis://cluster-leader",
+)
+
+if result['exit_code'] != 0 or args.verbose:
+    print(result['error'], file=sys.stderr, end='')
+print(result['output'])
+sys.exit(result['exit_code'])

--- a/core/imageroot/usr/local/sbin/update-module
+++ b/core/imageroot/usr/local/sbin/update-module
@@ -17,6 +17,17 @@ parser.add_argument('--force', help='force update even if module_url is already 
 parser.add_argument('--verbose', help='show update-module action stderr on success', action='store_true')
 args = parser.parse_args()
 
+rdb = agent.redis_connect()
+new_image_name = agent.get_image_name_from_url(args.module_url)
+for module_id in args.instances:
+    current_image_url = rdb.hget(f'module/{module_id}/environment', 'IMAGE_URL')
+    current_image_name = agent.get_image_name_from_url(current_image_url) if current_image_url else None
+    if current_image_name is not None and current_image_name != new_image_name:
+        print(f'Module instance "{module_id}" is of type "{current_image_name}", '
+              f'cannot update it with an image of type "{new_image_name}" ({args.module_url})',
+              file=sys.stderr)
+        sys.exit(1)
+
 result = agent.tasks.run(
     agent_id='cluster',
     action='update-module',

--- a/docs/modules/updates.md
+++ b/docs/modules/updates.md
@@ -52,14 +52,13 @@ pass `--force`:
 
     update-module ghcr.io/nethserver/mymodule:1.0.0 mymodule1 --force
 
-To update one or more module instances to their latest available version
-without knowing the exact tag, use the `update-modules` action instead,
-which resolves the latest valid version on its own. See
-[Updates]({{site.baseurl}}/core/updates#module-updates).
+The `update-module` command refuses to update an instance with an image of
+a different module (e.g. updating `nextcloud1` with a `mattermost` image),
+even with `--force`. This check is enforced by the CLI only: it can be
+bypassed by invoking the `cluster/update-module` action directly, e.g. via
+`api-cli` (see below).
 
 The same action can also be invoked directly with `api-cli`, e.g. to script
 around it:
-
-     api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/mymodule:1.0.0","instances":["mymodule1"]}'
 
     api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/mymodule:1.0.0","instances":["mymodule1"],"force":true}'

--- a/docs/modules/updates.md
+++ b/docs/modules/updates.md
@@ -39,11 +39,27 @@ Make sure the `20restart` is executable, otherwise it is ignored.
 
 To update an instance from command line, use:
 
-     api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/mymodule:latest","instances":["mymodule1"]}'
+    update-module ghcr.io/nethserver/mymodule:1.0.0 mymodule1
+
+Multiple instances of the same module can be updated together:
+
+    update-module ghcr.io/nethserver/mymodule:1.0.0 mymodule1 mymodule2
 
 If the given `module_url` is already present in the local Podman storage,
 no remote download occurs and the local image is used instead. During
 development this might be unwanted and to work around this behavior
-set the flag `"force": true` to the `update-module` action:
+pass `--force`:
 
-    api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/mymodule:latest","instances":["mymodule1"],"force":true}'
+    update-module ghcr.io/nethserver/mymodule:1.0.0 mymodule1 --force
+
+To update one or more module instances to their latest available version
+without knowing the exact tag, use the `update-modules` action instead,
+which resolves the latest valid version on its own. See
+[Updates]({{site.baseurl}}/core/updates#module-updates).
+
+The same action can also be invoked directly with `api-cli`, e.g. to script
+around it:
+
+     api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/mymodule:1.0.0","instances":["mymodule1"]}'
+
+    api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/mymodule:1.0.0","instances":["mymodule1"],"force":true}'


### PR DESCRIPTION
## Summary
- Add `core/imageroot/usr/local/sbin/update-module`, a CLI wrapper around the existing `cluster/update-module` action, mirroring `add-module`'s style.
- Update `docs/modules/updates.md` to document the new shorthand alongside the existing `api-cli run update-module` examples.

## Test plan
- [x] `python3 -m py_compile` syntax check
- [x] Manual run on a live node: `update-module <image> <instance>` and compare against `api-cli run update-module`