### PR TITLE
fix(validation): stop logging raw payloads on unmarshal error

### DIFF
--- a/core/agent/validation/validation.go
+++ b/core/agent/validation/validation.go
@@ -97,7 +97,7 @@ func ValidateJsonString(schemaPath string, data []byte) ([]gojsonschema.ResultEr
 	var ddata interface{}
 	err := json.Unmarshal(data, &ddata)
 	if err != nil {
-		return nil, fmt.Errorf("JSON unmarshal error: %w. Input data: %v", err, data)
+		return nil, fmt.Errorf("JSON unmarshal error: %w", err)
 	}
 	return ValidateGoStruct(schemaPath, ddata)
 }

--- a/core/api-moduled/api-moduled.go
+++ b/core/api-moduled/api-moduled.go
@@ -205,7 +205,6 @@ func apiPostHandler(ginCtx *gin.Context) {
 	jerr := json.Unmarshal(responseBytes, &responsePayload)
 	if jerr != nil {
 		logger.Println(SD_ERR+"JSON Unmarshal() error:", jerr)
-		logger.Println(SD_DEBUG+"Response buffer", string(responseBytes[:]))
 		ginCtx.JSON(http.StatusInternalServerError, gin.H{
 			"code":   http.StatusInternalServerError,
 			"status": "Internal server error",
@@ -233,12 +232,13 @@ func createJwtInstance(baseHandlerDir string) *jwt.GinJWTMiddleware {
 			// INPUT validation
 			//
 			if _, err := os.Stat(baseHandlerDir + "/login/validate-input.json"); err == nil {
+				// Login payloads carry credentials: never log field values.
 				errData, errInfo := validation.ValidatePayload(baseHandlerDir+"/login/validate-input.json", requestBytes)
 				if errInfo != nil {
-					logger.Println(SD_ERR+"Input validation error:", errInfo)
+					logger.Println(SD_ERR + "Input validation error")
 					return nil, jwt.ErrFailedAuthentication
 				} else if len(errData) > 0 {
-					logger.Println(SD_ERR+"Input validation error:", errData)
+					logger.Println(SD_ERR + "Input validation error")
 					return nil, jwt.ErrFailedAuthentication
 				}
 			}

--- a/core/api-moduled/validation/validation.go
+++ b/core/api-moduled/validation/validation.go
@@ -81,7 +81,7 @@
 	 var ddata interface{}
 	 err := json.Unmarshal(data, &ddata)
 	 if err != nil {
-		 return nil, fmt.Errorf("JSON unmarshal error: %w. Input data: %v", err, data)
+		 return nil, fmt.Errorf("JSON unmarshal error: %w", err)
 	 }
 	 errorList, errInfo := validateGoStruct(schemaPath, ddata)
 	 if errInfo != nil {


### PR DESCRIPTION
- Avoid leaking sensitive data to the system log.
- Limitate log flooding.