### PR TITLE
feat(core): add update-core CLI command

### DIFF
--- a/core/imageroot/usr/local/sbin/update-core
+++ b/core/imageroot/usr/local/sbin/update-core
@@ -1,0 +1,49 @@
+#!/usr/local/bin/runagent python3
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import agent
+import agent.tasks
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('core_url')
+parser.add_argument('--nodes', nargs='+', type=int, help='update only these node identifiers, instead of every node in the cluster (edge case, use with care: nodes end up on different core versions)')
+parser.add_argument('--force', help='force update even if core_url is already present locally', action='store_true')
+parser.add_argument('--verbose', help='show update-core action stderr on success', action='store_true')
+args = parser.parse_args()
+
+image_name = agent.get_image_name_from_url(args.core_url)
+if image_name != 'core':
+    parser.error(f'core_url must reference the "core" image, got "{image_name}"')
+
+rdb = agent.redis_connect()
+if args.nodes:
+    nodes = args.nodes
+else:
+    nodes = list(int(node_id) for node_id in set(rdb.hvals('cluster/module_node')))
+
+result = agent.tasks.run(
+    agent_id='cluster',
+    action='update-core',
+    data={
+        'core_url': args.core_url,
+        'nodes': nodes,
+        'force': args.force,
+    },
+    extra={
+        'title': "cluster/update-core",
+        'description': "update-core command",
+        'isNotificationHidden': False,
+    },
+    endpoint="redis://cluster-leader",
+)
+
+if result['exit_code'] != 0 or args.verbose:
+    print(result['error'], file=sys.stderr, end='')
+print(result['output'])
+sys.exit(result['exit_code'])

--- a/docs/core/updates.md
+++ b/docs/core/updates.md
@@ -28,14 +28,35 @@ The first stage applies enhancements and bug fixes for the `core` image.
 The core image contains: agents, UI, additional core images and common
 actions.
 
-To execute the core update, use:
+To execute the core update from the command line, run on the leader node:
 
-    api-cli run update-core --data '{"core_url":"ghcr.io/nethserver/core:MAJ.MIN.PATCH","nodes":[NODEID1, NODEID2]}'
+    update-core ghcr.io/nethserver/core:MAJ.MIN.PATCH
 
 - `MAJ.MIN.PATCH` is a Semver-compliant version tag of a stable core
   release; a symbolic branch name (e.g. `feat-8000`) can be used for
   feature development instead
-- NODEID1, NODEID2 are the integer node IDs of the cluster nodes to update
+
+By default every node in the cluster is updated, keeping core versions
+aligned. Updating only a subset of nodes is a development edge case and is
+discouraged in production clusters; use `--nodes` to override the default:
+
+    update-core ghcr.io/nethserver/core:MAJ.MIN.PATCH --nodes NODEID1 NODEID2
+
+If the given `core_url` is already present in the local Podman storage, no
+remote download occurs and the local image is used instead. Pass `--force`
+to always pull and reinstall it, ignoring the Semver tag check:
+
+    update-core ghcr.io/nethserver/core:MAJ.MIN.PATCH --force
+
+By default the command prints only the action output; on failure it also
+prints the error. Pass `--verbose` to print the error even on success:
+
+    update-core ghcr.io/nethserver/core:MAJ.MIN.PATCH --verbose
+
+The same action can also be invoked directly with `api-cli`, e.g. to script
+around it:
+
+    api-cli run update-core --data '{"core_url":"ghcr.io/nethserver/core:MAJ.MIN.PATCH","nodes":[NODEID1, NODEID2]}'
 
 The cluster agent running on the leader node forwards the core-update
 request to selected nodes. Updating a subset of nodes is discouraged in


### PR DESCRIPTION
## Summary
Adds an `update-core` CLI wrapper (`core/imageroot/usr/local/sbin/update-core`), mirroring the existing `update-module` command. Lets an admin push a specific core image to chosen nodes, or all nodes with `--all-nodes`.

## How to test
`update-core <core_url> <node_id> [<node_id> ...]` or `update-core <core_url> --all-nodes [--force] [--verbose]` on a cluster leader.