### PR TITLE
fix(agent): honor check kwarg in run_restic Popen path

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -283,6 +283,7 @@ def run_restic(rdb, repository, repo_path, podman_args, restic_args, progress_ca
     kwargs.setdefault('stdout', sys.stdout)
     kwargs.setdefault('stderr', sys.stderr)
     if progress_callback and '--json' in restic_args:
+        check_wanted = kwargs.pop('check', False)
         kwargs['stdout'] = subprocess.PIPE
         kwargs.setdefault('errors', 'replace')
         kwargs.setdefault('text', True)
@@ -295,6 +296,8 @@ def run_restic(rdb, repository, repo_path, podman_args, restic_args, progress_ca
                     progress_callback(json.loads(line))
                 except Exception as ex:
                     print(SD_DEBUG + "Error decoding Restic status message", ex, file=kwargs['stderr'])
+        if check_wanted and prestic.returncode != 0:
+            raise subprocess.CalledProcessError(prestic.returncode, podman_cmd)
     else:
         prestic = subprocess.run(podman_cmd, **kwargs)
     return prestic


### PR DESCRIPTION
subprocess.Popen() does not accept a check keyword, so passing check=True through to it raised a TypeError instead of running restic, breaking any backup that uses a progress callback (e.g. manual "Run backup now" for rootful modules). Pop check before constructing Popen and raise CalledProcessError manually once the process exits, mirroring subprocess.run(check=True) semantics.

Refs NethServer/dev#8076