### PR TITLE
fix(runagent): forward runtime agent vars into rootless exec

### DIFF
--- a/core/imageroot/usr/local/bin/runagent
+++ b/core/imageroot/usr/local/bin/runagent
@@ -90,7 +90,13 @@ else:
 
     xdg_runtime_dir=f"/run/user/{module_uid}"
     if os.path.isdir(xdg_runtime_dir):
-        os.execvp("/usr/sbin/runuser", ["runuser", "-s", "/usr/bin/env", "-l", mid, "--", f"XDG_RUNTIME_DIR={xdg_runtime_dir}"] + sys.argv)
+        # "runuser -l" resets the environment, so runtime agent vars (see
+        # core/agent/README.md) must be forwarded explicitly to survive it.
+        env_overrides = [f"XDG_RUNTIME_DIR={xdg_runtime_dir}"]
+        for varname in ['AGENT_COMFD', 'AGENT_TASK_ID', 'AGENT_TASK_ACTION', 'AGENT_TASK_USER']:
+            if varname in os.environ:
+                env_overrides.append(f"{varname}={os.environ[varname]}")
+        os.execvp("/usr/sbin/runuser", ["runuser", "-s", "/usr/bin/env", "-l", mid, "--"] + env_overrides + sys.argv)
     else:
         print(f"runagent: [FATAL] Cannot find runtime directory for {mid}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary

`runuser -l` resets the environment before handing off to a rootless
module's own user, so `AGENT_TASK_ID` and the other runtime agent vars
documented in `core/agent/README.md` (`AGENT_COMFD`, `AGENT_TASK_ACTION`,
`AGENT_TASK_USER`) were silently dropped whenever `runagent` switched
into a rootless module's context (e.g. `run-backup` → `runagent -m
<module_id> module-backup`). `runagent` now forwards them explicitly,
alongside `XDG_RUNTIME_DIR`.

This is the rootless counterpart of #1252. For rootful modules, no
user switch is needed, so `AGENT_TASK_ID` was always inherited and
`module-backup` correctly took its `progress_callback` branch — which
is exactly the code path that crashed with `Popen.__init__() got an
unexpected keyword argument 'check'` before #1252. Rootless modules
never hit that crash only because they never reached the
`progress_callback` branch in the first place: with `AGENT_TASK_ID`
missing, `module-backup` silently fell back to the plain
`run_restic(...).check_returncode()` path, so manual "Run backup now"
backups for rootless apps completed but never reported progress.

With this fix, rootless modules now also take the `progress_callback`
branch during task-driven backups, exercising the same
`run_restic` code path that #1252 fixed. Since #1252 is already
merged, that path should be safe, but this PR is the change that
newly exposes it to rootless modules and restores progress reporting
there.

## Related issue

NethServer/dev#8076

## How to test

- Install a rootless module and schedule/enable a backup that includes it.
- Trigger "Run backup now" from the Backup and Restore UI.
- Verify the backup completes and progress is reported (previously it
  completed silently with no progress updates for rootless apps).

## Dependencies

Builds on #1252 (already merged) — that PR fixed the `check` kwarg
crash in `run_restic`'s `Popen` path; this PR is what makes rootless
modules actually reach that code path.