### PR TITLE
fix(alloy): revert samba-specific drop rule

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/bin/generate-promtail-config
+++ b/core/imageroot/var/lib/nethserver/node/bin/generate-promtail-config
@@ -115,16 +115,6 @@ relabel_rules.append("""
     }
 """)
 
-# Work around samba log flooding from NethServer/dev#7375
-# Drop "Decryption has failed" messages from samba-dc container
-relabel_rules.append("""
-    rule {
-        source_labels = ["__journal_syslog_identifier", "__journal_message"]
-        regex         = "samba-dc;.*TLS source4/lib/tls/tls_tstream.c:1449 - Decryption has failed.*"
-        action        = "drop"
-    }
-""")
-
 # Set label category=security for messages from sshd, PAM, Polkit, etc.
 # that are often written to /var/log/secure or equivalent.
 # Regex matches RFC3164 Syslog facility codes for security events


### PR DESCRIPTION
Revert "Suppress samba decryption error (#1145)"

This reverts commit 53b6a16fd06c279110322bac2892d24b29dd0c30.

The log noise disappears by disabling Dovecot LDAP referral chasing

Requires NethServer/ns8-mail#280

Refs NethServer/dev#8097