### PR TITLE
TLS certificates page: count reads upfront and keep partial ACME rows

### DIFF
--- a/core/ui/src/components/settings/AcmeSettings.vue
+++ b/core/ui/src/components/settings/AcmeSettings.vue
@@ -8,6 +8,15 @@
       <cv-grid class="no-padding">
         <cv-row>
           <cv-column>
+            <!-- NsDataTable replaces the rows with its error: report a partial
+                 failure here, so the nodes that did answer stay readable -->
+            <NsInlineNotification
+              v-if="tableError && servers.length"
+              kind="error"
+              :title="tableErrorTitle"
+              :description="tableErrorDescription"
+              :showCloseButton="false"
+            />
             <NsDataTable
               :allRows="servers"
               :columns="i18nTableColumns"
@@ -26,7 +35,7 @@
               "
               :isLoading="loadingServers"
               :skeletonRows="5"
-              :isErrorShown="!!instancesError || !!error.getAcmeServer"
+              :isErrorShown="!!tableError && !servers.length"
               :errorTitle="tableErrorTitle"
               :errorDescription="tableErrorDescription"
               :itemsPerPageLabel="$t('pagination.items_per_page')"
@@ -154,6 +163,9 @@ export default {
     },
     loadingServers() {
       return this.isLoadingInstances || this.loading.getAcmeServerNum > 0;
+    },
+    tableError() {
+      return this.instancesError || this.error.getAcmeServer;
     },
     tableErrorTitle() {
       return this.instancesError

--- a/core/ui/src/components/settings/AcmeSettings.vue
+++ b/core/ui/src/components/settings/AcmeSettings.vue
@@ -218,15 +218,16 @@ export default {
     async getAcmeServer() {
       // a handler of a previous round would decrement the counter of this one
       this.clearTaskListeners();
-      this.loading.getAcmeServerNum = 0;
       this.servers = [];
       // otherwise a transient error sticks after the nodes answer again
       this.clearTableError();
+      // count the whole batch upfront: the counter must not reach zero between
+      // two iterations
+      this.loading.getAcmeServerNum = this.traefikInstances.length;
 
       for (const traefikInstance of this.traefikInstances) {
         const taskAction = "get-acme-server";
         const eventId = this.getUuid();
-        this.loading.getAcmeServerNum++;
 
         // register to task events
 
@@ -262,7 +263,7 @@ export default {
           this.error.getAcmeServer = errMessage;
           this.currentErrorAction = this.$t("action." + taskAction);
           this.currentErrorDescription = errMessage;
-          this.decreaseGetAcmeServerNum();
+          this.loading.getAcmeServerNum--;
         }
       }
     },
@@ -271,7 +272,7 @@ export default {
       this.error.getAcmeServer = this.$t("error.generic_error");
       this.currentErrorAction = this.$t("action." + taskContext.action);
       this.currentErrorDescription = this.$t("error.generic_error");
-      this.decreaseGetAcmeServerNum();
+      this.loading.getAcmeServerNum--;
     },
     getAcmeServerCompleted(taskContext, taskResult) {
       const server = taskResult.output;
@@ -297,14 +298,7 @@ export default {
         this.servers.push(server);
       }
       this.servers.sort(this.sortByProperty("node"));
-      this.decreaseGetAcmeServerNum();
-    },
-    decreaseGetAcmeServerNum() {
-      // never go below zero: a new round resets the counter
-      this.loading.getAcmeServerNum = Math.max(
-        0,
-        this.loading.getAcmeServerNum - 1
-      );
+      this.loading.getAcmeServerNum--;
     },
     onReloadServers() {
       this.getAcmeServer();

--- a/core/ui/src/views/settings/SettingsTlsCertificates.vue
+++ b/core/ui/src/views/settings/SettingsTlsCertificates.vue
@@ -980,6 +980,8 @@ export default {
       this.currentErrorAction = this.$t("action." + taskContext.action);
       this.currentErrorDescription = this.$t("error.generic_error");
       this.loading.listInstalledModules = false;
+      // the certificates chain will not run: release its skeleton rows
+      this.loading.listCertificatesNum = 0;
     },
     listInstalledModulesCompleted(taskContext, taskResult) {
       // init nodes
@@ -1038,12 +1040,13 @@ export default {
       this.clearTaskListeners();
       this.offlineTraefikInstances = [];
       this.listCertificatesErrors = [];
-      this.loading.listCertificatesNum = 0;
+      // count the whole batch upfront: the counter must not reach zero between
+      // two iterations
+      this.loading.listCertificatesNum = this.traefikInstances.length;
 
       for (const traefikInstance of this.traefikInstances) {
         const taskAction = "list-certificates";
         const eventId = this.getUuid();
-        this.loading.listCertificatesNum++;
 
         // register to task events
 
@@ -1109,7 +1112,7 @@ export default {
               )} - ${this.getNodeLabel(traefikInstance)})`,
             });
           }
-          this.decreaseListCertificatesNum();
+          this.loading.listCertificatesNum--;
         }
       }
     },
@@ -1128,7 +1131,7 @@ export default {
           traefikInstance
         )} - ${this.getNodeLabel(traefikInstance)})`,
       });
-      this.decreaseListCertificatesNum();
+      this.loading.listCertificatesNum--;
     },
     listCertificatesCompleted(taskContext, taskResult) {
       const traefikId = taskContext.extra.traefikInstance.id;
@@ -1203,14 +1206,7 @@ export default {
       // $set() is needed for reactivity (see https://v2.vuejs.org/v2/guide/reactivity.html#For-Objects)
       this.$set(this.certificatesByTraefikId, traefikId, certs);
 
-      this.decreaseListCertificatesNum();
-    },
-    decreaseListCertificatesNum() {
-      // never go below zero: a new round resets the counter
-      this.loading.listCertificatesNum = Math.max(
-        0,
-        this.loading.listCertificatesNum - 1
-      );
+      this.loading.listCertificatesNum--;
     },
     getTagKind(status) {
       switch (status) {


### PR DESCRIPTION
Targets `sdl-8099`, the branch of #1257, not `main`.

## Description

A review pass on #1258 (HTTP routes page) raised two issues that apply here as well, since both pages share the same read pattern. This PR brings the two branches to the same shape, so the shared mixin planned as a follow-up on #1257 has one behaviour to extract instead of two.

**Counters are set before the loop.** `listCertificates()` and `getAcmeServer()` incremented inside the loop and decremented through a helper clamped with `Math.max(0, n - 1)`. Two problems hide behind that clamp. The counter reaches zero between two iterations, so `loadingCertificates` / `loadingServers` can go false while the next `createModuleTaskForApp` is still awaited — the table drops out of its loading state with an empty or partial list. And a surplus decrement is swallowed rather than made impossible, which is what let the counter go out of balance in the first place. The counter is now `this.traefikInstances.length` before the loop and the decrements are plain `--`. Nothing is left to clamp: `clearTaskListeners()` already `$off`s the handlers of the previous round, so an event delivered late reaches nothing.

**`listCertificatesNum` is released when the instance lookup is aborted.** `listInstalledModulesAborted` reset `loading.listInstalledModules` but left the certificates counter untouched. On a reconnection the watcher restarts from `listInstalledModules()`, so if that task aborts the certificates chain never runs and whatever the counter held stays there — skeleton rows for good, with no way out but a manual reload.

**One offline node no longer hides the others on the ACME tab.** `error.getAcmeServer` is a single shared string, and `NsDataTable` renders its error notification *instead of* the rows (`v-if="isErrorShown"` … `v-else-if="isLoading"` … in `NsDataTable.vue`). On a cluster where one node is unreachable, the settings of every node that answered were replaced by the banner. The notification now renders above the table when there are rows to keep, and `isErrorShown` is left for the case where there is genuinely nothing to display. The Certificates tab already handles this through `offlineTraefikInstances` and `listCertificatesErrors`, so it needs no change.

## Commits

1. `fix(ui): count ACME and certificate reads upfront`
2. `fix(ui): keep the ACME rows readable when one node fails`

## Testing

`core/ui` has no test runner, so this was checked with lint and a production build, on each commit. Both pass.

To verify on a cluster:

- [ ] Both tables populate normally on a cold load and after a tab switch
- [ ] Save ACME settings on the connected node: the websocket drops, reconnects, and both tables refresh on their own with no skeleton rows left
- [ ] Reload during the Traefik restart and let it settle: neither table stays on skeleton rows
- [ ] Stop one traefik, open the ACME tab: the rows of the healthy nodes are readable, with the error notification above the table
- [ ] Restart it and save on another node: the missing row comes back and the notification clears
- [ ] Stop the leader so `list-installed-modules` aborts after a reconnection: the certificates table shows its error instead of loading for ever
- [ ] No duplicate rows in either table after several reconnections
