### PR TITLE
fix(backup): stop the BackupFailed alert from flapping

### DIFF
--- a/core/imageroot/var/lib/nethserver/node/bin/run-backup
+++ b/core/imageroot/var/lib/nethserver/node/bin/run-backup
@@ -248,6 +248,9 @@ def main():
         failed.append(module_id)
 
     if failed:
+        # Modules that never became available are a failure too, and no verdict
+        # has been recorded for them yet: do not leave a stale status behind
+        write_backup_prom(backup_id, backup_name, PROM_FAILED)
         print(f"Backup {backup_id} finished with failures: {', '.join(failed)}", file=sys.stderr)
         sys.exit(1)
 

--- a/core/imageroot/var/lib/nethserver/node/bin/run-backup
+++ b/core/imageroot/var/lib/nethserver/node/bin/run-backup
@@ -21,10 +21,8 @@ RETRY_INTERVAL = 60   # seconds between retries
 RETRY_TIMEOUT = 3600  # total retry window in seconds
 
 PROM_DIR = "/run/node_exporter"
-PROM_UNKNOWN = -1
 PROM_FAILED = 0
 PROM_SUCCESS = 1
-PROM_CONFLICT = 2
 
 def prometheus_escape_label_value(value: str) -> str:
     return (
@@ -38,7 +36,7 @@ def write_backup_prom(backup_id, backup_name, status):
     """Write a Prometheus .prom file for this backup's status."""
     output_file = os.path.join(PROM_DIR, f"backup{backup_id}.prom")
     content = (
-        '# HELP node_backup_status Status of the backup (0 = failure, 1 = success, 2 = conflict, -1 = unknown)\n'
+        '# HELP node_backup_status Status of the backup (0 = failure, 1 = success)\n'
         '# TYPE node_backup_status gauge\n'
         f'node_backup_status{{id="{backup_id}",name="{prometheus_escape_label_value(backup_name)}"}} {status}\n'
     )
@@ -208,9 +206,6 @@ def main():
         print(f"No local modules for backup {backup_id}", file=sys.stderr)
         return
 
-    # Initialize prom file to UNKNOWN
-    write_backup_prom(backup_id, backup_name, PROM_UNKNOWN)
-
     failed = []
     retry_queue = []
 
@@ -220,8 +215,6 @@ def main():
         if rc == 0:
             print(f"{module_id}: backup {backup_id} completed", file=sys.stderr)
         elif rc == EXIT_ALREADY_RUNNING:
-            if len(failed) == len(retry_queue) == 0:
-                write_backup_prom(backup_id, backup_name, PROM_CONFLICT)
             print(f"{module_id}: already running, queued for retry", file=sys.stderr)
             retry_queue.append(module_id)
         else:


### PR DESCRIPTION
## Summary

The `BackupFailed` alert kept clearing and re-firing on its own while the backup stayed broken. Two things caused that, both fixed here:

- The status gauge was reset to "unknown" at the start of every run, and to "conflict" when another run of the same backup was still in progress, before the outcome was known. `node_backup_status` now only ever carries the verdict of a completed run (`0` = failure, `1` = success): the gauge is left untouched while a run is in progress, so a genuinely broken backup keeps its `0` for the whole cycle instead of bouncing through a transient value.
- A run whose modules stayed busy for the whole retry window exited with a failure but wrote no verdict, leaving the gauge on a stale success. It now records the failure.

## How to test

Verified on a single-node dev cluster (backup `3`, one application, metrics module installed):

```bash
# the flap: seed a failure, run again, the gauge must never leave 0
printf 'node_backup_status{id="3",name="BKrepro"} 0\n' > /run/node_exporter/backup3.prom
runagent -m node run-backup --backup=3 &
while sleep 0.5; do grep -o 'node_backup_status.*' /run/node_exporter/backup3.prom; done
# -> stays 0 for the whole run, whether or not a second run collides with it

# retries give up (shorten RETRY_INTERVAL/RETRY_TIMEOUT to test) while the
# application lock is held: exit 1 and node_backup_status 0, not a stale 1
flock -x /home/<module_id>/.config/state/.module-backup.lock -c 'sleep 40' &
runagent -m node run-backup --backup=3
```

The metric scrapes cleanly (`node_textfile_scrape_error 0`) and reaches Prometheus with the usual `id`/`name`/`node` labels.

## Not covered here

The `.prom` file lives under `/run`, a tmpfs: it's wiped at every reboot and nothing rebuilds it, so the status disappears from monitoring until the next run completes, silently clearing any active alert. Tracked separately as NethServer/dev#8127.

Refs NethServer/dev#8125
