### PR TITLE
fix: keep node_exporter metrics across a reboot

### DIFF
--- a/core/imageroot/etc/systemd/system/node_exporter.service
+++ b/core/imageroot/etc/systemd/system/node_exporter.service
@@ -13,7 +13,7 @@ TimeoutStartSec=120
 # node_exporter exits with 143 on SIGTERM:
 SuccessExitStatus=143
 ExecStartPre=/bin/rm -f %t/%N.pid %t/%N.cid
-ExecStartPre=/usr/bin/mkdir -p /run/node_exporter
+ExecStartPre=/usr/bin/mkdir -p ./node_exporter
 ExecStart=/usr/bin/podman run \
     --conmon-pidfile %t/%N.pid \
     --cidfile %t/%N.cid \
@@ -24,10 +24,11 @@ ExecStart=/usr/bin/podman run \
     --pid=host \
     -d \
     -v /:/host:ro,rslave \
+    --volume=./node_exporter:/srv/node_exporter:z \
     ${NODE_EXPORTER_IMAGE} \
     --collector.cpu.info \
     --collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run)($|/) \
-    --collector.textfile.directory=/host/run/node_exporter \
+    --collector.textfile.directory=/srv/node_exporter \
     --path.rootfs=/host
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%N.cid -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%N.cid

--- a/core/imageroot/etc/systemd/system/refresh-node-info.service
+++ b/core/imageroot/etc/systemd/system/refresh-node-info.service
@@ -5,6 +5,8 @@ BindsTo=node_exporter.service
 
 [Service]
 Type=simple
+WorkingDirectory=/var/lib/nethserver/node/state
+ExecStartPre=/bin/rm -f ./node_exporter/node-info.prom
 ExecStart=runagent -m node refresh-node-info -l 60
-ExecStopPost=rm -f /run/node_exporter/node-info.prom
+ExecStopPost=/bin/rm -f ./node_exporter/node-info.prom
 SyslogIdentifier=%N

--- a/core/imageroot/var/lib/nethserver/node/bin/refresh-node-info
+++ b/core/imageroot/var/lib/nethserver/node/bin/refresh-node-info
@@ -9,7 +9,10 @@ set -e
 
 function write_prom_file()
 {
-    outfile="/run/node_exporter/node-info.prom"
+    # Relative to the agent working directory, and shared with the
+    # node_exporter container as its textfile collector directory
+    mkdir -p ./node_exporter
+    outfile="./node_exporter/node-info.prom"
     main4=$(ip -4 -j route get 255.0 2>/dev/null | jq -r '.[0].prefsrc')
     main6=$(ip -6 -j route get 2000:: 2>/dev/null | jq -r '.[0].prefsrc')
     fqdn=$(hostname -f)

--- a/core/imageroot/var/lib/nethserver/node/bin/run-backup
+++ b/core/imageroot/var/lib/nethserver/node/bin/run-backup
@@ -20,7 +20,9 @@ EXIT_ALREADY_RUNNING = 3
 RETRY_INTERVAL = 60   # seconds between retries
 RETRY_TIMEOUT = 3600  # total retry window in seconds
 
-PROM_DIR = "/run/node_exporter"
+# Relative to the agent working directory, and shared with the node_exporter
+# container as its textfile collector directory
+PROM_DIR = "./node_exporter"
 PROM_FAILED = 0
 PROM_SUCCESS = 1
 

--- a/core/imageroot/var/lib/nethserver/node/events/backup-schedule-changed/20purge_backup_prom
+++ b/core/imageroot/var/lib/nethserver/node/events/backup-schedule-changed/20purge_backup_prom
@@ -9,10 +9,12 @@ import os
 import agent
 import glob
 
+PROM_DIR = "./node_exporter"
+
 def purge_backup_prom_files(keep_bids):
     """Remove stale backup*.prom files."""
     keep_files = [f'backup{bid}.prom' for bid in keep_bids]
-    for prom_file in glob.glob('/run/node_exporter/backup*.prom'):
+    for prom_file in glob.glob(os.path.join(PROM_DIR, 'backup*.prom')):
         if os.path.basename(prom_file) not in keep_files:
             os.unlink(prom_file)
             print("Removed", prom_file)

--- a/docs/core/backup_restore.md
+++ b/docs/core/backup_restore.md
@@ -41,7 +41,11 @@ and a procedure tailored for single node cluster disaster recovery.
   impersonation. The `run-backup` command also updates the backup status
   of every application in Redis key `node/<node ID>/backup_status/<backup
   ID>`, and writes an overall backup status into
-  `/run/node_exporter/backup<backup ID>.prom` files. It also uploads
+  `/var/lib/nethserver/node/state/node_exporter/backup<backup ID>.prom`
+  files. That file holds the last known verdict of the backup, and is read
+  by the `node_exporter` textfile collector. It is stored on a persistent
+  path, so the metric survives a node reboot and keeps feeding any alert
+  based on it until the next scheduled run overwrites it. It also uploads
   `.json` files with backup repositories metadata. When executed on the
   leader node, uploads a copy of the encrypted cluster backup.
 


### PR DESCRIPTION
## Summary

The node_exporter textfile directory lived in `/run`, a tmpfs, so every metric
written there was lost at boot. A failed backup stopped being reported until the
next scheduled run, silently clearing any alert on it. The directory is now
`./node_exporter`, relative to the node agent working directory
(`/var/lib/nethserver/node/state`), which survives a reboot.

Podman receives it as a dedicated volume outside the `/host` bindmount, with
`:z`, so SELinux relabelling is left to Podman instead of an explicit `chcon`.
The two writers and the `node_exporter` unit each create the directory if it is
missing, so start order does not matter and none of them fails.

No migration of the old `/run/node_exporter` files is done: they are on a tmpfs
and disappear at the next reboot anyway.

Related issue: NethServer/dev#8127

## How to test

On an updated node, with at least one enabled backup:

```
ls -ldZ /var/lib/nethserver/node/state/node_exporter   # container_file_t
podman inspect node_exporter --format '{{.Config.Cmd}}' | grep /srv/node_exporter
curl -s localhost:9100/metrics | grep -E 'ns8_node_info|node_backup_status|node_textfile_scrape_error'
```

`node_textfile_scrape_error` must be 0 and the two series must be there — that is
the check that the container can still read the files. Then write a failed status
and reboot:

```
printf 'node_backup_status{id="1",name="t"} 0\n' > /var/lib/nethserver/node/state/node_exporter/backup1.prom
reboot
curl -s localhost:9100/metrics | grep node_backup_status   # still 0
```

Deleting the directory and restarting `node_exporter.service` must recreate it
with the right label, and the metrics must come back.