### PR TITLE
fix(core): reduce cluster-admin requests and handle 429

### DIFF
--- a/core/api-moduled/AGENTS.md
+++ b/core/api-moduled/AGENTS.md
@@ -82,7 +82,12 @@ All via `AMLD_` prefixed environment variables (uses Viper):
 | `AMLD_ID_KEY` | `uid` | JWT identity claim key |
 | `AMLD_EXPORT_ENV` | — | Extra env vars for handlers |
 | `AMLD_RATE_LIMIT_AVERAGE` | `25` | Per-IP requests/sec across all routes; `0` disables |
-| `AMLD_RATE_LIMIT_BURST` | `100` | Burst allowance above the average |
+| `AMLD_RATE_LIMIT_BURST` | `300` | Burst allowance above the average |
+
+The sustained average is what bounds a flood; the burst only sets how many
+requests may arrive at once, and is sized for a legitimate UI page load. A burst
+below `1` is clamped to `1` by `RateLimiter`; use `AMLD_RATE_LIMIT_AVERAGE=0` to
+disable the limiter.
 
 ## Key differences from api-server
 

--- a/core/api-moduled/README.md
+++ b/core/api-moduled/README.md
@@ -37,7 +37,14 @@ Configuration parameters can be passed as environment variables.
   across all API routes -- default `25`; set to `0` to disable rate limiting
 
 - `AMLD_RATE_LIMIT_BURST`, burst allowance above the average before requests
-  are rejected with HTTP 429 -- default `100`
+  are rejected with HTTP 429 -- default `300`
+
+The sustained average is what bounds a flood; the burst only sets how many
+requests may arrive at once, and is therefore sized for a legitimate UI page
+load.
+
+A burst below `1` is raised to `1`, because a zero-capacity token bucket would
+reject every request; use `AMLD_RATE_LIMIT_AVERAGE=0` to disable the limiter.
 
 ## How to implement the API
 

--- a/core/api-moduled/api-moduled.go
+++ b/core/api-moduled/api-moduled.go
@@ -55,6 +55,12 @@ type rateLimiterVisitor struct {
 // (BodyLimit bounds one request's body, not how many requests run at once).
 // rps is the sustained rate and burst the number of requests allowed instantly.
 func RateLimiter(rps rate.Limit, burst int) gin.HandlerFunc {
+	// A zero-capacity bucket can never accumulate the whole token a request
+	// needs, so it would reject everything: "0 disables" only holds for rps.
+	if burst < 1 {
+		burst = 1
+	}
+
 	visitors := make(map[string]*rateLimiterVisitor)
 	var mu sync.Mutex
 
@@ -85,6 +91,10 @@ func RateLimiter(rps rate.Limit, burst int) gin.HandlerFunc {
 		mu.Unlock()
 
 		if !limiter.Allow() {
+			// The rate is configured as a positive integer, so a token always
+			// refills within a second and Retry-After, which is expressed in
+			// whole seconds, is always 1.
+			c.Header("Retry-After", "1")
 			c.JSON(http.StatusTooManyRequests, gin.H{"code": http.StatusTooManyRequests, "message": "too many requests", "data": nil})
 			c.Abort()
 			return
@@ -118,7 +128,7 @@ func main() {
 	viper.SetDefault("jwt_realm", "api-moduled")
 	viper.SetDefault("export_env", "")
 	viper.SetDefault("rate_limit_average", 25)
-	viper.SetDefault("rate_limit_burst", 100)
+	viper.SetDefault("rate_limit_burst", 300)
 	viper.AutomaticEnv()
 
 	logger = log.New(os.Stderr, "", 0)

--- a/core/api-server/AGENTS.md
+++ b/core/api-server/AGENTS.md
@@ -83,7 +83,13 @@ All via environment variables: `LISTEN_ADDRESS`, `REDIS_ADDRESS`, `REDIS_USER`,
 `REDIS_PASSWORD`, `SECRET` (JWT key), `STATIC_PATH`, `AUDIT_FILE`,
 `SENSITIVE_LIST`, `ISSUER` (TOTP issuer name, default `NethServer`),
 `GLOBAL_RATE_LIMIT_AVERAGE` (per-IP requests/sec across all routes, default
-`25`; `0` disables), `GLOBAL_RATE_LIMIT_BURST` (burst allowance, default `100`).
+`25`; `0` disables), and `GLOBAL_RATE_LIMIT_BURST` (burst allowance, default
+`300`).
+
+The sustained average is what bounds a flood; the burst only sets how many
+requests may arrive at once, and is sized for a legitimate UI page load. A burst
+below `1` is clamped to `1` by `RateLimiter`; use `GLOBAL_RATE_LIMIT_AVERAGE=0`
+to disable the limiter.
 
 ## Conventions
 

--- a/core/api-server/README.md
+++ b/core/api-server/README.md
@@ -28,14 +28,21 @@ REDIS_USER=default
 REDIS_PASSWORD=""
 SECRET=MY_SECRET,11
 GLOBAL_RATE_LIMIT_AVERAGE=25
-GLOBAL_RATE_LIMIT_BURST=100
+GLOBAL_RATE_LIMIT_BURST=300
 ```
 
 - `GLOBAL_RATE_LIMIT_AVERAGE`: max sustained requests per second per client
   IP across all API routes, default is `25`; set to `0` to disable rate
   limiting
 - `GLOBAL_RATE_LIMIT_BURST`: burst allowance above the average before
-  requests are rejected with HTTP 429, default is `100`
+  requests are rejected with HTTP 429, default is `300`
+
+The sustained average is what bounds a flood; the burst only sets how many
+requests may arrive at once, and is therefore sized for a legitimate
+cluster-admin page load (~150 requests: static assets plus task round-trips).
+
+A burst below `1` is raised to `1`, because a zero-capacity token bucket would
+reject every request; use `GLOBAL_RATE_LIMIT_AVERAGE=0` to disable the limiter.
 
 ## Running
 

--- a/core/api-server/configuration/configuration.go
+++ b/core/api-server/configuration/configuration.go
@@ -111,6 +111,6 @@ func Init() {
 	if v, err := strconv.Atoi(os.Getenv("GLOBAL_RATE_LIMIT_BURST")); err == nil {
 		Config.GlobalRateLimitBurst = v
 	} else {
-		Config.GlobalRateLimitBurst = 100
+		Config.GlobalRateLimitBurst = 300
 	}
 }

--- a/core/api-server/middleware/middleware.go
+++ b/core/api-server/middleware/middleware.go
@@ -70,6 +70,12 @@ type rateLimiterVisitor struct {
 // (BodyLimit bounds one request's body, not how many requests run at once).
 // rps is the sustained rate and burst the number of requests allowed instantly.
 func RateLimiter(rps rate.Limit, burst int) gin.HandlerFunc {
+	// A zero-capacity bucket can never accumulate the whole token a request
+	// needs, so it would reject everything: "0 disables" only holds for rps.
+	if burst < 1 {
+		burst = 1
+	}
+
 	visitors := make(map[string]*rateLimiterVisitor)
 	var mu sync.Mutex
 
@@ -100,6 +106,10 @@ func RateLimiter(rps rate.Limit, burst int) gin.HandlerFunc {
 		mu.Unlock()
 
 		if !limiter.Allow() {
+			// The rate is configured as a positive integer, so a token always
+			// refills within a second and Retry-After, which is expressed in
+			// whole seconds, is always 1.
+			c.Header("Retry-After", "1")
 			c.JSON(http.StatusTooManyRequests, gin.H{"code": http.StatusTooManyRequests, "message": "too many requests", "data": nil})
 			c.Abort()
 			return

--- a/core/imageroot/usr/local/agent/pypkg/agent/tasks/apiclient.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/tasks/apiclient.py
@@ -153,7 +153,7 @@ async def _retry_request(request_procedure, *args, **kwargs):
     attempts = kwargs.pop('retry_attempts', 20)
     incfactor = kwargs.pop('retry_incfactor', 2.0)
     kwargs.setdefault('retry_sendlogin', True)
-    http_temporary_errors = [500, 502, 503, 504]
+    http_temporary_errors = [429, 500, 502, 503, 504]
     http_temporary_errors += kwargs.pop('retry_statuscodes', [])
 
     request_name = request_procedure.__name__

--- a/core/ui/src/mixins/notification.js
+++ b/core/ui/src/mixins/notification.js
@@ -7,6 +7,12 @@ import {
 } from "@nethserver/ns8-ui-lib";
 import { v4 as uuidv4 } from "uuid";
 
+// In-flight task-context requests, keyed by task ID. websocket.js dispatches
+// several progress messages per task without awaiting them, so the Vuex
+// taskContextCache, which only fills once a response has landed, cannot dedupe
+// them. Module scope makes that work across every component mixing this in.
+const pendingTaskContexts = new Map();
+
 export default {
   name: "NotificationService",
   mixins: [UtilService, TaskService],
@@ -199,29 +205,51 @@ export default {
       // e.g. get-cluster-status-completed-f5d24fcd-819c-4b1d-98ad-a1b2ebcee8cf
       return `${taskContext.action}-${result}${eventId}`;
     },
+    async fetchTaskContext(taskPath, taskId, payload) {
+      const cachedContext = await this.getTaskContextFromCache(taskId);
+      if (cachedContext) {
+        return cachedContext;
+      }
+
+      let request = pendingTaskContexts.get(taskId);
+      if (!request) {
+        // clear on failure too, so a failed request never blocks later retries
+        request = this.getTaskContext(taskPath).finally(() => {
+          pendingTaskContexts.delete(taskId);
+        });
+        pendingTaskContexts.set(taskId, request);
+      }
+
+      const [err, contextResponse] = await to(request);
+
+      if (err) {
+        console.error("error retrieving task info", err);
+        return null;
+      }
+
+      if (!contextResponse.data.data) {
+        console.warn(
+          "task context not found, skipping",
+          taskId,
+          taskPath,
+          payload
+        );
+        return null;
+      }
+
+      const taskContext = contextResponse.data.data.context;
+      this.setTaskContextInCache({ taskId, taskContext });
+      return taskContext;
+    },
     async handleProgressTaskMessage(taskPath, taskId, payload) {
-      let taskContext = await this.getTaskContextFromCache(taskId);
+      const taskContext = await this.fetchTaskContext(
+        taskPath,
+        taskId,
+        payload
+      );
 
       if (!taskContext) {
-        // fetch task context from API and store it in cache
-        const [err, contextResponse] = await to(this.getTaskContext(taskPath));
-
-        if (err) {
-          console.error("error retrieving task info", err);
-          return;
-        }
-
-        if (!contextResponse.data.data) {
-          console.warn(
-            "task context not found, skipping",
-            taskId,
-            taskPath,
-            payload
-          );
-          return;
-        }
-        taskContext = contextResponse.data.data.context;
-        this.setTaskContextInCache({ taskId, taskContext });
+        return;
       }
 
       let taskResult;
@@ -239,6 +267,7 @@ export default {
             type: "error",
           };
           this.createNotification(notification);
+          return;
         }
 
         taskResult = statusResponse.data.data;
@@ -429,8 +458,30 @@ export default {
               this.getTaskStatus(taskPath)
             );
             if (err) {
-              // If the task status is not found (404), run the message
-              // handler again to activate the timer one more time:
+              // Re-arming immediately would keep adding load while the server
+              // is already throttling us, so back off first.
+              if (err.response?.status === 429) {
+                const retryAfter = Number(
+                  err.response?.headers?.["retry-after"]
+                );
+                const backoff =
+                  Number.isFinite(retryAfter) && retryAfter > 0
+                    ? retryAfter * 1000
+                    : taskProgressPollPeriod * 4;
+
+                // stored so an incoming websocket message can still cancel it
+                const backoffTimeoutId = setTimeout(() => {
+                  this.handleProgressTaskMessage(taskPath, taskId, payload);
+                }, backoff);
+                this.setPollingTimerForTaskInStore({
+                  taskId: taskId,
+                  timeoutId: backoffTimeoutId,
+                });
+                return;
+              }
+
+              // Any other error means the status is not available yet: re-enter
+              // the handler to arm the timer one more time.
               this.handleProgressTaskMessage(taskPath, taskId, payload);
               return;
             }


### PR DESCRIPTION
## Summary

Opening a cluster-admin page issues many requests at once — the app's own assets, then one round trip per card. That is more than the new rate limiter allows in a single burst, so some requests are rejected and the cards behind them never finish loading. What runs out is the limiter's allowance for simultaneous requests, not its limit on sustained traffic.

Six of the eleven fixes analysed in the issue, lettered as they are there:

| | Change | Where |
|---|---|---|
| **A** | Burst default `100` → `300`. `GLOBAL_RATE_LIMIT_AVERAGE` stays at `25`: the sustained rate is what bounds a flood, so over 60 s an attacker gains 12% (1800 vs 1600 requests) while a legitimate page load, needing ~150 at once, stops being rejected. Mirrored in `api-moduled`. | `configuration.go`, `api-moduled.go` |
| **B** | Return after a failed task-status request, instead of dereferencing an undefined response and throwing a `TypeError`. | `notification.js` |
| **C** | Treat `429` as temporary in the agent's retry list. Nested tasks reach the leader through the same rate-limited api-server, so a throttled call aborted the whole task instead of backing off. | `apiclient.py` |
| **D** | Coalesce concurrent task-context requests. `websocket.js` dispatches several progress messages per task without awaiting, so each reached the cache-miss branch and issued its own `GET …/context` — measured 34 requests for 13 tasks, one fetched 4×. | `notification.js` |
| **E** | Send `Retry-After: 1` on a throttled response. | `middleware.go`, `api-moduled.go` |
| **F** | Back off on `429` in the task poll timer instead of re-arming immediately. | `notification.js` |

Also: `RateLimiter` clamps a burst below `1`. A zero-capacity bucket can never hold the whole token a request needs, so `*_BURST=0` rejected everything — an easy misreading, since `0` does disable the limiter on the `_AVERAGE` variable.

## Scope and caveats

- **This does not make the UI recover from a `429` it receives.** A card whose status request fails still needs the request retried, which is **H** and deferred. In particular **B** stops an unhandled promise rejection but does not release a component waiting on `*-completed`; that event is unreachable either way once the request has failed.
- **Deferred:** **H** (429 retry in the axios interceptor), **I** (webpack prefetch, one line, −47 requests, and the only lever that helps a cold load), **J**, **K**.
- **Static assets are deliberately not exempted** from the limiter: `gzip.Gzip` is registered before the static handler and recompresses every asset on every request, so exempting that path would leave an unauthenticated CPU-amplifying endpoint unprotected.
- **`Cache-Control` on static assets was tried and dropped.** `http.FileServer` sets `Last-Modified`, so heuristic freshness already caches them — for more than the `max-age=3600` it added, on any asset older than ten hours. Setting `no-cache` on `index.html` is worth doing, but it targets a pre-existing hazard unrelated to throttling and needs its own change.
- **No automated coverage.** The repository has no Go or UI unit tests and adding the first ones was out of scope.

## Related issue

NethServer/dev#8124
