### PR TITLE
fix(applications): show the logo shipped with the app

### DIFF
--- a/core/ui/src/views/ApplicationsCenter.vue
+++ b/core/ui/src/views/ApplicationsCenter.vue
@@ -214,13 +214,10 @@
                   <cv-data-table-cell>
                     <a @click="showAppInfo(row.appInfoData)">
                       <img
-                        :src="
-                          row.logo
-                            ? row.logo
-                            : require('@/assets/module_default_logo.png')
-                        "
+                        :src="getLogo(row)"
                         :alt="row.name + ' logo'"
                         class="module-logo"
+                        @error="onLogoError(row)"
                       />
                       <span class="app-name">{{ row.module }}</span>
                     </a>
@@ -623,6 +620,18 @@ export default {
   },
   methods: {
     ...mapActions(["setUpdateInProgressInStore", "setAppDrawerShownInStore"]),
+    getLogo(row) {
+      return (
+        row.logoCandidates[row.logoIndex] ||
+        require("@/assets/module_default_logo.png")
+      );
+    },
+    onLogoError(row) {
+      // walk down to the next candidate, ending on the shipped asset
+      if (row.logoIndex < row.logoCandidates.length) {
+        row.logoIndex++;
+      }
+    },
     showAppInfo(app) {
       this.appInfo.isShown = true;
       this.appInfo.app = app;
@@ -922,11 +931,13 @@ export default {
           const installedData = updateEntry || item;
           extractedModules.push({
             id: installedData.id || "",
-            // Use module logo URL if available, else fallback to instance logo later in the template
-            logo:
-              moduleData.logo && moduleData.logo.startsWith("http")
-                ? moduleData.logo
-                : "",
+            // the repository logo first, then the one the app published with
+            // its own bundle: a candidate can also fail to load, so keep the
+            // whole chain and walk it in getLogo()
+            logoCandidates: [
+              ...new Set([moduleData.logo, installedData.logo].filter(Boolean)),
+            ],
+            logoIndex: 0,
             module: moduleData.name || "", // we want a humanized module name
             node: installedData.node || "",
             node_ui_name: installedData.node_ui_name || "",


### PR DESCRIPTION
The Applications table kept a logo only when it was an absolute URL, which is what a repository serves. An app installed outside any repository publishes its logo with its own UI bundle, and `list-modules` reports that local path, so those rows fell back to the generic logo while the app drawer, fed by the same data, showed the right one.

I keep the whole chain instead: the repository logo first, then the one the app published with its own bundle. A published bundle can disappear, so I walk to the next candidate on a load error and end on the shipped default asset.

Split out of #1247, where the same change is reverted.

https://github.com/NethServer/dev/issues/8139