### PR TITLE
fix(ui): prevent foreign Vue observers from freezing the cluster-admin SPA

### DIFF
--- a/core/ui/src/main.js
+++ b/core/ui/src/main.js
@@ -95,6 +95,21 @@ Vue.config.productionTip = false;
 import VueI18n from "vue-i18n";
 import { loadLanguage } from "./i18n";
 
+// Module UIs run in same-origin iframes with their own copy of Vue and can
+// keep references to core component instances in their reactive state (e.g.
+// `window.parent.core` ends up in a module Vuex store). A foreign Vue >= 2.7
+// observer cannot recognize instances of another Vue copy (its checks are
+// realm-local) and would deep-observe the whole core component tree,
+// rewriting its internals into foreign reactive getters and freezing the
+// entire SPA on the next render. Vue 2.7 and Vue 3 observers skip any value
+// marked with __v_skip, so mark every core instance explicitly (Vue 2.6 sets
+// only _isVue, which foreign Vue 2.7 observers do not check).
+Vue.mixin({
+  beforeCreate() {
+    this.__v_skip = true;
+  },
+});
+
 loadI18n();
 
 async function loadI18n() {

--- a/core/ui/src/mixins/notification.js
+++ b/core/ui/src/mixins/notification.js
@@ -6,6 +6,7 @@ import {
   TaskService,
 } from "@nethserver/ns8-ui-lib";
 import { v4 as uuidv4 } from "uuid";
+import { toPlainCopy } from "@/store";
 
 // In-flight task-context requests, keyed by task ID. websocket.js dispatches
 // several progress messages per task without awaiting them, so the Vuex
@@ -321,15 +322,17 @@ export default {
         if (!subTask) {
           // add subtask to subTasks list
 
+          // parentTask lives inside the reactive notifications store: insert
+          // private copies of context and result (see toPlainCopy)
           const subTask = {
-            context: taskContext,
+            context: toPlainCopy(taskContext),
             status: taskStatus,
             progress: payload.progress,
             subTasks: [],
           };
 
           if (taskResult) {
-            subTask.result = taskResult;
+            subTask.result = toPlainCopy(taskResult);
           }
 
           parentTask.subTasks.push(subTask);
@@ -340,7 +343,7 @@ export default {
           subTask.progress = payload.progress;
 
           if (taskResult) {
-            subTask.result = taskResult;
+            subTask.result = toPlainCopy(taskResult);
           }
         }
       } else {

--- a/core/ui/src/store/index.js
+++ b/core/ui/src/store/index.js
@@ -4,6 +4,76 @@ import _merge from "lodash/merge";
 
 Vue.use(Vuex);
 
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+
+function isVueInternal(value) {
+  return (
+    value._isVue === true || // Vue 2 component instance
+    value.__v_isVNode === true || // Vue 3 VNode
+    // Vue 2 VNode, duck-typed: `instanceof VNode` fails for objects created
+    // by the Vue copy bundled in a module UI iframe
+    (hasOwn(value, "tag") &&
+      hasOwn(value, "isComment") &&
+      hasOwn(value, "componentOptions"))
+  );
+}
+
+// Objects reaching `state.notifications` (task contexts, task results,
+// module-provided notifications) are shared by reference with module UIs,
+// which run in iframes with their own Vue runtime. Vue 2 detects prior
+// observation with realm-local checks (`__ob__ instanceof Observer`,
+// `value instanceof VNode`), so when both the core and a module observe the
+// same object graph each side keeps re-observing and re-wrapping the other's
+// getters until the whole SPA freezes. Storing a private plain copy breaks
+// the identity sharing. Functions (e.g. notification action callbacks) and
+// non-plain leaves (e.g. Date) are kept by reference: Vue does not observe
+// them.
+export function toPlainCopy(value, seen = new WeakMap()) {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  if (isVueInternal(value)) {
+    return undefined;
+  }
+
+  if (seen.has(value)) {
+    return seen.get(value);
+  }
+
+  if (Array.isArray(value)) {
+    const copy = [];
+    seen.set(value, copy);
+
+    for (const item of value) {
+      const plainItem = toPlainCopy(item, seen);
+
+      // drop discarded Vue internals
+      if (plainItem !== undefined || item === undefined) {
+        copy.push(plainItem);
+      }
+    }
+    return copy;
+  }
+
+  if (Object.prototype.toString.call(value) !== "[object Object]") {
+    return value;
+  }
+
+  const copy = {};
+  seen.set(value, copy);
+
+  for (const key of Object.keys(value)) {
+    const plainValue = toPlainCopy(value[key], seen);
+
+    // drop discarded Vue internals
+    if (plainValue !== undefined || value[key] === undefined) {
+      copy[key] = plainValue;
+    }
+  }
+  return copy;
+}
+
 export default new Vuex.Store({
   state: {
     notifications: [],
@@ -97,7 +167,7 @@ export default new Vuex.Store({
       state.taskPollingTimers[obj.taskId] = obj.timeoutId;
     },
     createNotification(state, notification) {
-      state.notifications.unshift(notification);
+      state.notifications.unshift(toPlainCopy(notification));
     },
     setNotificationDrawerShown(state, value) {
       state.isNotificationDrawerShown = value;
@@ -147,7 +217,7 @@ export default new Vuex.Store({
       );
 
       if (notificationFound) {
-        notificationFound = _merge(notificationFound, notification);
+        _merge(notificationFound, toPlainCopy(notification));
       }
     },
     setLoggedUser(state, username) {


### PR DESCRIPTION
## Summary

Fixes the whole-SPA browser freeze triggered by module UI pages (see the linked issue for the full analysis and captured stacks).

Module UIs run in same-origin iframes with their own bundled copy of Vue and receive the live core root instance via `window.parent.core`; several module UIs keep it in their reactive state. Vue recognizes "do not observe" values only with realm- and version-local checks (Vue 2.6 skips `_isVue`, Vue 2.7 skips `__v_skip`), so a module bundling Vue 2.7 deep-observes a Vue 2.6 core component tree and rewrites its internals into foreign reactive getters; from then on every core render triggers a full foreign observation walk, freezing the whole tab until reload.

Changes:

- `core/ui/src/main.js`: global mixin marking every core instance with `__v_skip = true`, honored by Vue 2.7 and Vue 3 observers regardless of realm. Vue 2.6 does not read the flag and Vue 2.7 sets it natively on its own instances, so this is a cross-version guarantee with no behavior change for the core itself. This is the change that fixes the freeze.
- `core/ui/src/store/index.js` and `core/ui/src/mixins/notification.js`: hardening of the opposite direction. Task contexts and results were inserted into the reactive notifications store by reference while the same objects are handed to module UIs through the `$root.$emit` bridge; a new `toPlainCopy` helper (cycle-safe deep plain copy; keeps functions such as notification action callbacks and non-plain leaves such as `Date`; discards Vue instances and VNodes with duck-typed checks) is applied in the `createNotification`/`updateNotification` mutations and in the subtask insertion path, which mutates the store directly.

## Related issue

NethServer/dev#8147

## How to test

1. Cluster with a Vue 2.6 based core build and a module UI bundling Vue 2.7 that stores `window.parent.core` in its Vuex state (e.g. current NethVoice UI).
2. Without the fix, navigating the module pages (settings/status/hotel) freezes the tab within a few page loads (reproduced deterministically via headless browser + CDP stack capture).
3. With the fix, the freeze no longer reproduces (verified empirically: 30 consecutive module page transitions on the affected test cluster, plus manual navigation and settings save).
4. Verify regular notification behavior still works: toast on task completion, notification drawer, task error details modal, the "Reload" action of the websocket-disconnected notification, subtask progress rendering.

## Dependencies

None.
