### PR TITLE
Per-container and per-volume node metrics

### DIFF
--- a/core/imageroot/etc/systemd/system/node_exporter.service
+++ b/core/imageroot/etc/systemd/system/node_exporter.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Prometheus node_exporter
 Wants=refresh-node-info.service
+Wants=refresh-container-metrics.service
+Wants=refresh-volume-metrics.service
 
 [Service]
 Type=forking

--- a/core/imageroot/etc/systemd/system/node_exporter.service
+++ b/core/imageroot/etc/systemd/system/node_exporter.service
@@ -2,7 +2,7 @@
 Description=Prometheus node_exporter
 Wants=refresh-node-info.service
 Wants=refresh-container-metrics.service
-Wants=refresh-volume-metrics.service
+Wants=refresh-volume-metrics.timer
 
 [Service]
 Type=forking

--- a/core/imageroot/etc/systemd/system/refresh-container-metrics.service
+++ b/core/imageroot/etc/systemd/system/refresh-container-metrics.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Container metrics textfile collector runner
+After=node_exporter.service
+BindsTo=node_exporter.service
+
+[Service]
+Type=simple
+WorkingDirectory=/var/lib/nethserver/node/state
+ExecStartPre=/bin/rm -f ./node_exporter/containers.prom ./node_exporter/containers.prom.tmp
+ExecStart=runagent -m node refresh-container-metrics -l 60
+ExecStopPost=/bin/rm -f ./node_exporter/containers.prom ./node_exporter/containers.prom.tmp
+# The collector is a loop that is meant to outlive transient failures, so
+# a dead process must be replaced rather than left dead. ExecStopPost
+# removes the .prom file, which means process death takes every series with
+# it -- including the last_success timestamp that is supposed to be the
+# staleness signal -- so there would be nothing left to alert on.
+Restart=always
+RestartSec=10s
+SyslogIdentifier=%N

--- a/core/imageroot/etc/systemd/system/refresh-volume-metrics.service
+++ b/core/imageroot/etc/systemd/system/refresh-volume-metrics.service
@@ -1,24 +1,12 @@
 [Unit]
-Description=Volume disk usage textfile collector runner
+Description=Volume disk usage textfile collector
 After=node_exporter.service
-BindsTo=node_exporter.service
 
 [Service]
-Type=simple
+Type=oneshot
 WorkingDirectory=/var/lib/nethserver/node/state
-# The walk reads every inode of every module tree. Give way to anything that
-# is doing real work: a monitoring pass must never be what makes a mail or
-# file server feel slow.
+# Keep the job with low prio to avoid hammering an already loaded machine
 Nice=10
 IOSchedulingClass=idle
-ExecStartPre=/bin/rm -f ./node_exporter/volumes.prom ./node_exporter/volumes.prom.tmp
-ExecStart=runagent -m node refresh-volume-metrics -l 900
-ExecStopPost=/bin/rm -f ./node_exporter/volumes.prom ./node_exporter/volumes.prom.tmp
-# The collector is a loop that is meant to outlive transient failures, so
-# a dead process must be replaced rather than left dead. ExecStopPost
-# removes the .prom file, which means process death takes every series with
-# it -- including the last_success timestamp that is supposed to be the
-# staleness signal -- so there would be nothing left to alert on.
-Restart=always
-RestartSec=10s
+ExecStart=runagent -m node refresh-volume-metrics
 SyslogIdentifier=%N

--- a/core/imageroot/etc/systemd/system/refresh-volume-metrics.service
+++ b/core/imageroot/etc/systemd/system/refresh-volume-metrics.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Volume disk usage textfile collector runner
+After=node_exporter.service
+BindsTo=node_exporter.service
+
+[Service]
+Type=simple
+WorkingDirectory=/var/lib/nethserver/node/state
+# The walk reads every inode of every module tree. Give way to anything that
+# is doing real work: a monitoring pass must never be what makes a mail or
+# file server feel slow.
+Nice=10
+IOSchedulingClass=idle
+ExecStartPre=/bin/rm -f ./node_exporter/volumes.prom ./node_exporter/volumes.prom.tmp
+ExecStart=runagent -m node refresh-volume-metrics -l 900
+ExecStopPost=/bin/rm -f ./node_exporter/volumes.prom ./node_exporter/volumes.prom.tmp
+# The collector is a loop that is meant to outlive transient failures, so
+# a dead process must be replaced rather than left dead. ExecStopPost
+# removes the .prom file, which means process death takes every series with
+# it -- including the last_success timestamp that is supposed to be the
+# staleness signal -- so there would be nothing left to alert on.
+Restart=always
+RestartSec=10s
+SyslogIdentifier=%N

--- a/core/imageroot/etc/systemd/system/refresh-volume-metrics.timer
+++ b/core/imageroot/etc/systemd/system/refresh-volume-metrics.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Volume disk usage collection trigger
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=3600
+
+[Install]
+WantedBy=timers.target

--- a/core/imageroot/etc/systemd/system/user@.service.d/50-ns8-delegate.conf
+++ b/core/imageroot/etc/systemd/system/user@.service.d/50-ns8-delegate.conf
@@ -5,20 +5,5 @@
 # Delegate the io controller to module user managers, so rootless
 # containers expose io.stat like rootfull ones under machine.slice.
 #
-# Delegate= in a drop-in adds to what the unit already delegates, it does
-# not replace it. The vendor set differs by distro, so the result does too:
-#
-#   Rocky 9    systemd 252  Delegate=pids memory      -> io memory pids
-#   Debian 13  systemd 257  Delegate=pids memory cpu  -> cpu io memory pids
-#
-# Check the outcome in the user manager's cgroup.subtree_control, not with
-# "systemctl show -p Delegate": that property prints only the boolean and
-# says nothing about which controllers are delegated.
-#
-# Only io is added here. Adding cpu where the vendor unit does not already
-# delegate it would need care: on a kernel with CONFIG_RT_GROUP_SCHED=y, a
-# cgroup with cpu delegated can't run SCHED_FIFO/SCHED_RR tasks, so a
-# future per-module CPU limit must handle that separately.
-#
 [Service]
 Delegate=io

--- a/core/imageroot/etc/systemd/system/user@.service.d/50-ns8-delegate.conf
+++ b/core/imageroot/etc/systemd/system/user@.service.d/50-ns8-delegate.conf
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Delegate the io controller to module user managers, so rootless
+# containers expose io.stat like rootfull ones under machine.slice.
+#
+# Delegate= in a drop-in adds to what the unit already delegates, it
+# does not replace it: on Rocky 9 the vendor user@.service ships
+# "Delegate=pids memory", so the effective set becomes "io memory pids".
+#
+# Only io is added here. Adding cpu too would need care: on a kernel with
+# CONFIG_RT_GROUP_SCHED=y, a cgroup with cpu delegated can't run
+# SCHED_FIFO/SCHED_RR tasks, so a future per-module CPU limit must handle
+# that separately.
+#
+[Service]
+Delegate=io

--- a/core/imageroot/etc/systemd/system/user@.service.d/50-ns8-delegate.conf
+++ b/core/imageroot/etc/systemd/system/user@.service.d/50-ns8-delegate.conf
@@ -5,14 +5,20 @@
 # Delegate the io controller to module user managers, so rootless
 # containers expose io.stat like rootfull ones under machine.slice.
 #
-# Delegate= in a drop-in adds to what the unit already delegates, it
-# does not replace it: on Rocky 9 the vendor user@.service ships
-# "Delegate=pids memory", so the effective set becomes "io memory pids".
+# Delegate= in a drop-in adds to what the unit already delegates, it does
+# not replace it. The vendor set differs by distro, so the result does too:
 #
-# Only io is added here. Adding cpu too would need care: on a kernel with
-# CONFIG_RT_GROUP_SCHED=y, a cgroup with cpu delegated can't run
-# SCHED_FIFO/SCHED_RR tasks, so a future per-module CPU limit must handle
-# that separately.
+#   Rocky 9    systemd 252  Delegate=pids memory      -> io memory pids
+#   Debian 13  systemd 257  Delegate=pids memory cpu  -> cpu io memory pids
+#
+# Check the outcome in the user manager's cgroup.subtree_control, not with
+# "systemctl show -p Delegate": that property prints only the boolean and
+# says nothing about which controllers are delegated.
+#
+# Only io is added here. Adding cpu where the vendor unit does not already
+# delegate it would need care: on a kernel with CONFIG_RT_GROUP_SCHED=y, a
+# cgroup with cpu delegated can't run SCHED_FIFO/SCHED_RR tasks, so a
+# future per-module CPU limit must handle that separately.
 #
 [Service]
 Delegate=io

--- a/core/imageroot/etc/systemd/system/user@0.service.d/50-ns8-delegate.conf
+++ b/core/imageroot/etc/systemd/system/user@0.service.d/50-ns8-delegate.conf
@@ -1,0 +1,3 @@
+#
+# Empty file placeholder, just for uid 0 (root)
+#

--- a/core/imageroot/var/lib/nethserver/node/bin/refresh-container-metrics
+++ b/core/imageroot/var/lib/nethserver/node/bin/refresh-container-metrics
@@ -1,0 +1,823 @@
+#!/usr/local/agent/pyenv/bin/python3
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+"""Write per-container metrics for the node_exporter textfile collector.
+
+Podman starts NS8 containers with ``--cgroups=no-conmon``, so the systemd unit
+cgroup accounts only for the conmon supervisor. The container itself lives in a
+``libpod-<CID>.scope`` cgroup, which is what this collector reads.
+"""
+
+import argparse
+import datetime
+import glob
+import json
+import os
+import os.path
+import pwd
+import re
+import sys
+import time
+import traceback
+
+DEFAULT_OUTPUT = "./node_exporter/containers.prom"
+
+DEFAULT_CGROUP_ROOT = "/sys/fs/cgroup"
+DEFAULT_PROC_ROOT = "/proc"
+DEFAULT_SYS_DEV_BLOCK = "/sys/dev/block"
+ROOTFULL_STORAGE_ROOT = "/var/lib/containers/storage"
+
+# Container cgroups turn up at several depths and under several shapes, so
+# discovery is recursive rather than a set of fixed paths:
+#
+#   machine.slice/libpod-<cid>.scope                       rootfull
+#   user@<uid>.service/user.slice/libpod-<cid>.scope       rootless
+#   .../user-libpod_pod_<pod>.slice/libpod-<cid>.scope     rootless, in a pod
+#   system.slice/<unit>.service/libpod-payload-<cid>       --cgroups=split
+#
+# A fixed-depth glob silently missed the last two, which made every
+# pod-based module invisible.
+_SCOPE_GLOB = os.path.join("**", "libpod-*")
+
+_SCOPE_RE = re.compile(r"/libpod-(?:payload-)?([0-9a-f]{64})(?:\.scope)?$")
+_UID_RE = re.compile(r"/user-(\d+)\.slice/")
+# A pod's slice carries the pod id, prefixed "user-" when rootless and
+# "machine-" when rootfull. The id is what names the pod's infra container,
+# so it is the one pod identifier available without reading podman's index.
+_POD_RE = re.compile(r"libpod_pod_([0-9a-f]{64})\.slice")
+
+
+def _read_text(path):
+    """Read a small file, returning None when it does not exist."""
+    try:
+        with open(path) as fp:
+            return fp.read()
+    except OSError:
+        return None
+
+
+def discover_scopes(cgroup_root=DEFAULT_CGROUP_ROOT):
+    """Return the live container scopes found under cgroup_root."""
+    scopes = []
+    seen = set()
+    for path in glob.glob(os.path.join(cgroup_root, _SCOPE_GLOB), recursive=True):
+        match = _SCOPE_RE.search(path)
+        if match is None or not os.path.isdir(path):
+            continue
+        cid = match.group(1)
+        # A container reached by two paths would render two samples carrying
+        # identical labels, which invalidates the whole textfile. glob's "**"
+        # follows directory symlinks, so keep this independent of what the
+        # cgroup mount happens to contain.
+        if cid in seen:
+            continue
+        seen.add(cid)
+        uid_match = _UID_RE.search(path)
+        pod_match = _POD_RE.search(path)
+        scopes.append(
+            {
+                "cid": cid,
+                "path": path,
+                "rootless": uid_match is not None,
+                "uid": int(uid_match.group(1)) if uid_match else None,
+                "pod": pod_match.group(1) if pod_match else None,
+            }
+        )
+    scopes.sort(key=lambda scope: scope["path"])
+    return scopes
+
+
+def unit_from_split_path(path):
+    """Return the owning unit of a --cgroups=split payload cgroup.
+
+    Such a container's payload sits inside its unit's own cgroup, as
+    <unit>.service/libpod-payload-<cid>. Once that child exists, cgroup v2's
+    no-internal-processes rule empties <unit>.service/cgroup.procs, so the
+    conmon walk in map_units() can never attribute it. The unit name is the
+    parent directory, so read it from there instead.
+    """
+    parent = os.path.basename(os.path.dirname(path))
+    return parent if parent.endswith(".service") else ""
+
+
+def container_index_files(storage_root):
+    """Return podman's container index files under a storage root.
+
+    Neither the directory nor the file name is fixed. Podman names the
+    directory after the active storage driver -- overlay-containers,
+    vfs-containers -- and keeps transient containers, the ones created with
+    --rm, in volatile-containers.json rather than containers.json. Reading
+    only one of them leaves those containers out of the index, and their
+    "container" label then falls back to the short id, which changes on
+    every restart and breaks rate() across it.
+    """
+    paths = []
+    for directory in sorted(glob.glob(os.path.join(storage_root, "*-containers"))):
+        for basename in ("containers.json", "volatile-containers.json"):
+            paths.append(os.path.join(directory, basename))
+    return paths
+
+
+def read_containers_json(storage_root):
+    """Map container id to name and image, from podman's storage indexes."""
+    index = {}
+    for path in container_index_files(storage_root):
+        _index_container_file(path, index)
+    return index
+
+
+def _index_container_file(path, index):
+    """Merge one podman container index file into index."""
+    try:
+        with open(path) as fp:
+            entries = json.load(fp)
+    except (OSError, ValueError):
+        return
+    if not isinstance(entries, list):
+        return
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        cid = entry.get("id")
+        if not isinstance(cid, str) or not cid:
+            continue
+        names = entry.get("names")
+        if not isinstance(names, list):
+            names = []
+        try:
+            metadata = json.loads(entry.get("metadata") or "{}")
+        except (ValueError, TypeError):
+            metadata = {}
+        if not isinstance(metadata, dict):
+            metadata = {}
+        # Both values become label values in the exposition, so anything that
+        # is not a string is treated as absent: a non-string reaching
+        # escape_label() would raise inside render(), long after collect()
+        # succeeded, and would then fail identically on every later cycle.
+        name = names[0] if names else ""
+        image = metadata.get("image-name", "")
+        created = entry.get("created")
+        index[cid] = {
+            "name": name if isinstance(name, str) else "",
+            "image": image if isinstance(image, str) else "",
+            "created": created if isinstance(created, str) else "",
+        }
+
+
+def parse_created(value):
+    """Turn podman's RFC 3339 "created" stamp into a Unix timestamp.
+
+    Podman writes nanosecond precision and a trailing "Z", neither of which
+    datetime.fromisoformat() accepts before Python 3.11, so the fraction is
+    cut to microseconds and the zone spelled out.
+    """
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    head, dot, rest = text.partition(".")
+    if dot:
+        digits = ""
+        for character in rest:
+            if not character.isdigit():
+                break
+            digits += character
+        text = "%s.%s%s" % (head, digits[:6], rest[len(digits):])
+    try:
+        return int(datetime.datetime.fromisoformat(text).timestamp())
+    except ValueError:
+        return None
+
+
+def storage_roots(uids, rootfull_storage_root=ROOTFULL_STORAGE_ROOT, passwd_lookup=pwd.getpwuid):
+    """Rootfull storage root first, then one per distinct module user."""
+    roots = [rootfull_storage_root]
+    for uid in sorted(set(uids)):
+        try:
+            home = passwd_lookup(uid).pw_dir
+        except KeyError:
+            continue
+        roots.append(os.path.join(home, ".local/share/containers/storage"))
+    return roots
+
+
+NETHSERVER_ROOT = "/var/lib/nethserver"
+
+# A rootfull module directory is <name><number>, as created by add-module,
+# which is the same rule refresh-volume-metrics and uninstall.sh apply. The
+# core's own directories -- cluster, node, api-server -- carry no trailing
+# digits, so the shape alone tells them apart and no list of reserved names
+# has to be kept in sync. A denylist would turn any future core directory
+# into a candidate module id here while the volume collector still called
+# it "core", leaving the module label un-joinable across the two families.
+_MODULE_DIR_RE = re.compile(r"^[a-z][a-z0-9-]*[0-9]+$")
+
+# What makes a local user an NS8 module, as runagent decides it too. The
+# presence of a container storage directory is not enough: any account that
+# has ever run podman by hand has one, and would then be reported as a
+# module of its own.
+MODULE_MARKER = ".config/state/agent.env"
+
+_UNIT_PATTERNS = (
+    "system.slice/*.service",
+    "user.slice/user-*.slice/user@*.service/app.slice/*.service",
+)
+
+_CONMON_CID_RE = re.compile(r"\x00-c\x00([0-9a-f]{64})\x00")
+
+
+def map_units(cgroup_root=DEFAULT_CGROUP_ROOT, proc_root=DEFAULT_PROC_ROOT):
+    """Map container id to the systemd unit whose conmon supervises it."""
+    units = {}
+    for pattern in _UNIT_PATTERNS:
+        for unit_path in glob.glob(os.path.join(cgroup_root, pattern)):
+            unit = os.path.basename(unit_path)
+            procs = _read_text(os.path.join(unit_path, "cgroup.procs"))
+            if not procs:
+                continue
+            for pid in procs.split():
+                try:
+                    with open(os.path.join(proc_root, pid, "cmdline"), "rb") as fp:
+                        cmdline = fp.read().decode("utf-8", "replace")
+                except OSError:
+                    continue
+                if "conmon" not in cmdline.split("\x00")[0]:
+                    continue
+                match = _CONMON_CID_RE.search(cmdline)
+                if match is not None:
+                    units[match.group(1)] = unit
+    return units
+
+
+def list_module_ids(nethserver_root=NETHSERVER_ROOT):
+    """Rootfull module ids, longest first so prefix matching is unambiguous."""
+    try:
+        names = os.listdir(nethserver_root)
+    except OSError:
+        return []
+    ids = [
+        name
+        for name in names
+        if _MODULE_DIR_RE.match(name)
+        and os.path.isdir(os.path.join(nethserver_root, name))
+    ]
+    ids.sort(key=lambda name: (-len(name), name))
+    return ids
+
+
+def resolve_module(scope, unit, module_ids, passwd_lookup=pwd.getpwuid):
+    """Return the NS8 module id owning this container.
+
+    Core containers that belong to no module are "core"; a container whose
+    owning unit could not be determined at all is "unknown".
+
+    An empty unit means attribution failed outright -- the conmon was not
+    found, because the container is exiting or was started outside a service
+    unit -- and yields "unknown". Reporting it as "core" instead would make it
+    indistinguishable from a genuine core container such as redis, and would
+    break rate() continuity every time a container flipped between the two.
+    """
+    if scope["rootless"]:
+        try:
+            entry = passwd_lookup(scope["uid"])
+        except KeyError:
+            return "unknown"
+        if not os.path.isfile(os.path.join(entry.pw_dir, MODULE_MARKER)):
+            return "unknown"
+        return entry.pw_name
+    if not unit:
+        return "unknown"
+    name = unit[: -len(".service")] if unit.endswith(".service") else unit
+    for module_id in module_ids:
+        if name == module_id or name.startswith(module_id + "-"):
+            return module_id
+    return "core"
+
+
+def network_owner(scope, meta):
+    """Return the container label the scope's network counters belong to.
+
+    Every container in a pod shares the pod's network namespace and so reads
+    the very same counters. They are reported once, against the pod rather
+    than against whichever member happened to be collected first: podman
+    names a pod's infra container after the pod id, so the pod slice in the
+    cgroup path yields that same name without consulting podman's index.
+
+    Deriving the label from the path rather than electing a member matters
+    for stability. An election has to be redone every cycle, and any cycle
+    that picked a different member -- one that had just been restarted, or
+    whose name was missing from the index -- would move the series and read
+    as a counter reset. The pod id changes only when the pod itself is
+    recreated, which is exactly when those counters really do restart.
+    """
+    if scope["pod"]:
+        return "%s-infra" % scope["pod"][:12]
+    return meta.get("name") or scope["cid"][:12]
+
+
+def _read_int(path):
+    """Read a single-value cgroup file. "max" and missing files give None."""
+    text = _read_text(path)
+    if text is None:
+        return None
+    text = text.strip()
+    if text == "max":
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _read_keyed(path):
+    """Read a "key value" cgroup file into a dict of ints."""
+    text = _read_text(path)
+    if text is None:
+        return {}
+    values = {}
+    for line in text.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        try:
+            values[fields[0]] = int(fields[1])
+        except ValueError:
+            continue
+    return values
+
+
+def read_stats(scope_path, created=None):
+    """Read the CPU, memory, PID and OOM counters of one container scope.
+
+    ``created`` is podman's own creation timestamp, used for the start time
+    when the index supplied one. The cgroup directory mtime is only a
+    fallback: a cgroup's mtime advances whenever a child cgroup appears or
+    goes away, so nested-cgroup churn under the scope would push the start
+    time forward and read as a restart that never happened.
+    """
+    cpu = _read_keyed(os.path.join(scope_path, "cpu.stat"))
+    memory = _read_keyed(os.path.join(scope_path, "memory.stat"))
+    events = _read_keyed(os.path.join(scope_path, "memory.events"))
+    start_time = created
+    if start_time is None:
+        try:
+            start_time = int(os.stat(scope_path).st_mtime)
+        except OSError:
+            start_time = None
+    return {
+        "cpu_user_usec": cpu.get("user_usec"),
+        "cpu_system_usec": cpu.get("system_usec"),
+        "memory_current": _read_int(os.path.join(scope_path, "memory.current")),
+        "memory_peak": _read_int(os.path.join(scope_path, "memory.peak")),
+        "memory_max": _read_int(os.path.join(scope_path, "memory.max")),
+        "memory_swap": _read_int(os.path.join(scope_path, "memory.swap.current")),
+        "memory_anon": memory.get("anon"),
+        "memory_file": memory.get("file"),
+        "pids_current": _read_int(os.path.join(scope_path, "pids.current")),
+        "pids_max": _read_int(os.path.join(scope_path, "pids.max")),
+        "oom_kills": events.get("oom_kill"),
+        "start_time": start_time,
+    }
+
+
+_IO_FIELDS = ("rbytes", "wbytes", "rios", "wios")
+
+
+def resolve_block_device(devno, sys_dev_block=DEFAULT_SYS_DEV_BLOCK):
+    """Turn a "major:minor" pair into a kernel device name, e.g. "vda"."""
+    try:
+        return os.path.basename(os.readlink(os.path.join(sys_dev_block, devno)))
+    except OSError:
+        return devno
+
+
+def read_io(scope_path, sys_dev_block=DEFAULT_SYS_DEV_BLOCK):
+    """Per-device block I/O counters, or None when io.stat is absent."""
+    text = _read_text(os.path.join(scope_path, "io.stat"))
+    if text is None:
+        return None
+    devices = []
+    for line in text.splitlines():
+        fields = line.split()
+        if not fields:
+            continue
+        counters = {}
+        for field in fields[1:]:
+            key, _, value = field.partition("=")
+            if key not in _IO_FIELDS:
+                continue
+            try:
+                counters[key] = int(value)
+            except ValueError:
+                continue
+        if len(counters) != len(_IO_FIELDS):
+            continue
+        counters["device"] = resolve_block_device(fields[0], sys_dev_block)
+        devices.append(counters)
+    return devices
+
+
+def container_pids(scope_path):
+    """PIDs of the container payload, innermost cgroup first."""
+    pids = []
+    for name in ("container/cgroup.procs", "cgroup.procs"):
+        text = _read_text(os.path.join(scope_path, name))
+        if text:
+            pids.extend(text.split())
+    return pids
+
+
+def _read_link(path):
+    try:
+        return os.readlink(path)
+    except OSError:
+        return None
+
+
+def parse_net_dev(text):
+    """Parse /proc/<pid>/net/dev into per-interface counters.
+
+    Loopback is left out. It is not traffic in or out of the container, it
+    is the container talking to itself, and it dwarfs everything else: on a
+    test node it was 98% of all bytes received, which makes any "top talkers
+    by module" view show nothing but lo.
+    """
+    interfaces = []
+    for line in text.splitlines()[2:]:
+        name, separator, rest = line.partition(":")
+        if not separator:
+            continue
+        if name.strip() == "lo":
+            continue
+        fields = rest.split()
+        if len(fields) < 16:
+            continue
+        try:
+            interfaces.append(
+                {
+                    "device": name.strip(),
+                    "receive_bytes": int(fields[0]),
+                    "receive_packets": int(fields[1]),
+                    "transmit_bytes": int(fields[8]),
+                    "transmit_packets": int(fields[9]),
+                }
+            )
+        except ValueError:
+            continue
+    return interfaces
+
+
+def read_network(scope_path, proc_root=DEFAULT_PROC_ROOT, seen_netns=None):
+    """Interface counters, or None when they must not be reported here.
+
+    Every container of a pod shares the pod's network namespace, so each one
+    reads the very same /proc/<pid>/net/dev. Reporting all of them would
+    multiply a pod's traffic by its container count in any aggregation.
+    Pass a set as ``seen_netns`` to keep one sample per namespace: the first
+    container reached owns the counters, and collect() reaches the infra
+    container first, so the owner stays the same from one cycle to the next.
+    """
+    host_ns = _read_link(os.path.join(proc_root, "1", "ns", "net"))
+    if host_ns is None:
+        # Without a trustworthy comparison basis, a private-looking
+        # namespace can't be told apart from the host's: treat the sample
+        # as absent rather than risk reporting the host's own counters.
+        return None
+    for pid in container_pids(scope_path):
+        container_ns = _read_link(os.path.join(proc_root, pid, "ns", "net"))
+        if container_ns is None:
+            continue
+        if container_ns == host_ns:
+            return None
+        text = _read_text(os.path.join(proc_root, pid, "net", "dev"))
+        if text is None:
+            continue
+        if seen_netns is not None:
+            if container_ns in seen_netns:
+                return None
+            seen_netns.add(container_ns)
+        return parse_net_dev(text)
+    return None
+
+
+def collect(
+    cgroup_root=DEFAULT_CGROUP_ROOT,
+    proc_root=DEFAULT_PROC_ROOT,
+    sys_dev_block=DEFAULT_SYS_DEV_BLOCK,
+    rootfull_storage_root=ROOTFULL_STORAGE_ROOT,
+    nethserver_root=NETHSERVER_ROOT,
+    passwd_lookup=pwd.getpwuid,
+    skipped=None,
+):
+    """Build one record per live container on this node.
+
+    Pass a list as ``skipped`` to receive the id of every container that could
+    not be collected, so the caller can publish how many were lost.
+    """
+    scopes = discover_scopes(cgroup_root)
+    units = map_units(cgroup_root, proc_root)
+    module_ids = list_module_ids(nethserver_root)
+
+    uids = [scope["uid"] for scope in scopes if scope["uid"] is not None]
+    names = {}
+    for root in storage_roots(uids, rootfull_storage_root, passwd_lookup):
+        names.update(read_containers_json(root))
+
+    seen_netns = set()
+    records = []
+    for scope in scopes:
+        # One unreadable container must never cost us the whole node's
+        # metrics: log it, skip it, keep collecting the rest.
+        try:
+            unit = units.get(scope["cid"], "") or unit_from_split_path(scope["path"])
+            meta = names.get(scope["cid"], {})
+            records.append(
+                {
+                    "cid": scope["cid"],
+                    "name": meta.get("name") or scope["cid"][:12],
+                    "image": meta.get("image", ""),
+                    "unit": unit,
+                    "rootless": scope["rootless"],
+                    "network_owner": network_owner(scope, meta),
+                    "module": resolve_module(scope, unit, module_ids, passwd_lookup),
+                    "stats": read_stats(scope["path"], parse_created(meta.get("created"))),
+                    "io": read_io(scope["path"], sys_dev_block),
+                    "network": read_network(scope["path"], proc_root, seen_netns),
+                }
+            )
+        except Exception:
+            if skipped is not None:
+                skipped.append(scope["cid"])
+            # Full traceback: the message alone would not say which of the
+            # readers failed.
+            print(
+                "collect(): skipping container %s:\n%s"
+                % (scope["cid"][:12], traceback.format_exc()),
+                file=sys.stderr,
+                end="",
+            )
+    records.sort(key=lambda record: (record["module"], record["name"]))
+    return records
+
+
+def escape_label(value):
+    """Escape a label value for the Prometheus text exposition format."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+class _Exposition(object):
+    """Accumulate samples, keeping every family's samples contiguous."""
+
+    def __init__(self):
+        self._families = {}
+        self._order = []
+
+    def add(self, name, kind, help_text, labels, value):
+        if name not in self._families:
+            self._families[name] = {"kind": kind, "help": help_text, "samples": []}
+            self._order.append(name)
+        if labels:
+            rendered = ",".join(
+                '%s="%s"' % (key, escape_label(val)) for key, val in labels
+            )
+            sample = "%s{%s} %s" % (name, rendered, value)
+        else:
+            sample = "%s %s" % (name, value)
+        self._families[name]["samples"].append(sample)
+
+    def render(self):
+        lines = []
+        for name in self._order:
+            family = self._families[name]
+            lines.append("# HELP %s %s" % (name, family["help"]))
+            lines.append("# TYPE %s %s" % (name, family["kind"]))
+            lines.extend(family["samples"])
+        return "\n".join(lines) + "\n"
+
+
+_GAUGES = (
+    ("memory_current", "ns8_container_memory_usage_bytes", "Container memory usage"),
+    ("memory_peak", "ns8_container_memory_peak_bytes", "Container peak memory usage"),
+    ("memory_max", "ns8_container_memory_limit_bytes", "Container memory limit"),
+    ("memory_swap", "ns8_container_memory_swap_bytes", "Container swap usage"),
+    ("memory_anon", "ns8_container_memory_anon_bytes", "Container anonymous memory"),
+    ("memory_file", "ns8_container_memory_file_bytes", "Container page cache memory"),
+    ("pids_current", "ns8_container_pids", "Processes running in the container"),
+    ("pids_max", "ns8_container_pids_limit", "Container process limit"),
+    ("start_time", "ns8_container_start_time_seconds", "Container start time"),
+)
+
+
+def render(records, duration_seconds, timestamp, skipped=0):
+    """Render collected records as a Prometheus text exposition document."""
+    exposition = _Exposition()
+
+    for record in records:
+        base = (("module", record["module"]), ("container", record["name"]))
+        stats = record["stats"]
+        for mode, key in (("user", "cpu_user_usec"), ("system", "cpu_system_usec")):
+            if stats[key] is None:
+                continue
+            exposition.add(
+                "ns8_container_cpu_seconds_total",
+                "counter",
+                "Container CPU time spent, in seconds",
+                base + (("mode", mode),),
+                "%.6f" % (stats[key] / 1000000.0),
+            )
+
+    for record in records:
+        base = (("module", record["module"]), ("container", record["name"]))
+        for device in record["io"] or []:
+            labels = base + (("device", device["device"]),)
+            for op, key in (("read", "rbytes"), ("write", "wbytes")):
+                exposition.add(
+                    "ns8_container_blkio_bytes_total",
+                    "counter",
+                    "Container block I/O transferred, in bytes",
+                    labels + (("op", op),),
+                    "%d" % device[key],
+                )
+        for device in record["io"] or []:
+            labels = base + (("device", device["device"]),)
+            for op, key in (("read", "rios"), ("write", "wios")):
+                exposition.add(
+                    "ns8_container_blkio_ops_total",
+                    "counter",
+                    "Container block I/O operations",
+                    labels + (("op", op),),
+                    "%d" % device[key],
+                )
+
+    for direction, help_text in (
+        ("receive", "Container bytes received"),
+        ("transmit", "Container bytes transmitted"),
+    ):
+        for record in records:
+            base = (
+                ("module", record["module"]),
+                ("container", record["network_owner"]),
+            )
+            for interface in record["network"] or []:
+                exposition.add(
+                    "ns8_container_network_%s_bytes_total" % direction,
+                    "counter",
+                    help_text,
+                    base + (("device", interface["device"]),),
+                    "%d" % interface["%s_bytes" % direction],
+                )
+
+    for direction, help_text in (
+        ("receive", "Container packets received"),
+        ("transmit", "Container packets transmitted"),
+    ):
+        for record in records:
+            base = (
+                ("module", record["module"]),
+                ("container", record["network_owner"]),
+            )
+            for interface in record["network"] or []:
+                exposition.add(
+                    "ns8_container_network_%s_packets_total" % direction,
+                    "counter",
+                    help_text,
+                    base + (("device", interface["device"]),),
+                    "%d" % interface["%s_packets" % direction],
+                )
+
+    for record in records:
+        if record["stats"]["oom_kills"] is None:
+            continue
+        exposition.add(
+            "ns8_container_oom_kills_total",
+            "counter",
+            "Processes killed by the container OOM killer",
+            (("module", record["module"]), ("container", record["name"])),
+            "%d" % record["stats"]["oom_kills"],
+        )
+
+    for key, name, help_text in _GAUGES:
+        for record in records:
+            value = record["stats"][key]
+            if value is None:
+                continue
+            exposition.add(
+                name,
+                "gauge",
+                help_text,
+                (("module", record["module"]), ("container", record["name"])),
+                "%d" % value,
+            )
+
+    for record in records:
+        exposition.add(
+            "ns8_container_info",
+            "gauge",
+            "Container metadata, always 1",
+            (
+                ("module", record["module"]),
+                ("container", record["name"]),
+                ("id", record["cid"][:12]),
+                ("image", record["image"]),
+                ("unit", record["unit"]),
+                ("rootless", "true" if record["rootless"] else "false"),
+            ),
+            "1",
+        )
+
+    exposition.add(
+        "ns8_container_collector_duration_seconds",
+        "gauge",
+        "Duration of the last container metrics collection",
+        (),
+        "%.6f" % duration_seconds,
+    )
+    # Without this, a fault that skips every container looks identical to a
+    # node with no containers: collect() returns [], the file is still valid
+    # and the success timestamp keeps advancing, so nothing alerts.
+    exposition.add(
+        "ns8_container_collector_skipped_containers",
+        "gauge",
+        "Containers that could not be collected in the last collection",
+        (),
+        "%d" % skipped,
+    )
+    exposition.add(
+        "ns8_container_collector_last_success_timestamp_seconds",
+        "gauge",
+        "Unix timestamp of the last successful collection",
+        (),
+        "%d" % timestamp,
+    )
+    return exposition.render()
+
+
+def write_atomic(path, text):
+    """Write text to path through a temporary file, then rename it in place.
+
+    The temporary name is fixed rather than carrying the pid: a process
+    killed between the write and the rename leaves it behind, and the unit
+    can only clean up a name it knows. It stays outside node_exporter's
+    *.prom glob either way, so it is never scraped.
+    """
+    temporary = "%s.tmp" % path
+    with open(temporary, "w") as fp:
+        fp.write(text)
+    os.rename(temporary, path)
+
+
+def refresh(output):
+    os.makedirs(os.path.dirname(output) or ".", exist_ok=True)
+    skipped = []
+    started = time.time()
+    records = collect(skipped=skipped)
+    elapsed = time.time() - started
+    write_atomic(
+        output,
+        render(records, elapsed, int(time.time()), skipped=len(skipped)),
+    )
+    return len(records)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Write per-container metrics for the node_exporter textfile collector"
+    )
+    parser.add_argument(
+        "-l",
+        "--loop",
+        type=int,
+        metavar="INTERVAL",
+        help="Run forever, refreshing every INTERVAL seconds",
+    )
+    parser.add_argument(
+        "-o", "--output", default=DEFAULT_OUTPUT, help="Output file path"
+    )
+    arguments = parser.parse_args()
+
+    # A non-positive interval means single-pass, matching how
+    # refresh-node-info's "if [[ $interval -gt 0 ]]" treats zero and
+    # negative values uniformly.
+    if arguments.loop is None or arguments.loop <= 0:
+        refresh(arguments.output)
+        return 0
+
+    while True:
+        try:
+            refresh(arguments.output)
+        except Exception:
+            # Keep the previous file in place and try again on the next tick:
+            # a transient failure must not blank out the metrics. Log the
+            # traceback, not just the message: str(ex) alone is close to
+            # undiagnosable for the failures this can see.
+            print(traceback.format_exc(), file=sys.stderr, end="")
+        time.sleep(arguments.loop)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/imageroot/var/lib/nethserver/node/bin/refresh-volume-metrics
+++ b/core/imageroot/var/lib/nethserver/node/bin/refresh-volume-metrics
@@ -10,8 +10,8 @@
 Podman volumes are plain directory trees, and the root filesystem carries no
 per-directory accounting: NS8 nodes mount it "noquota", so a size can only be
 obtained by walking the tree. The walk is expensive on a node holding mail or
-file shares, which is why this runs as its own unit on a slow interval instead
-of inside refresh-container-metrics.
+file shares, which is why this runs as its own unit, triggered daily by a
+systemd timer, instead of inside refresh-container-metrics.
 
 Each module is walked once and the result is split into three non-overlapping
 buckets -- named volumes, the container image store, and everything else, the
@@ -517,41 +517,11 @@ def main():
         description="Write per-volume disk usage for the node_exporter textfile collector"
     )
     parser.add_argument(
-        "-l",
-        "--loop",
-        type=int,
-        metavar="INTERVAL",
-        help="Run forever, refreshing every INTERVAL seconds",
-    )
-    parser.add_argument(
         "-o", "--output", default=DEFAULT_OUTPUT, help="Output file path"
     )
     arguments = parser.parse_args()
-
-    # A non-positive interval means single-pass, matching how
-    # refresh-container-metrics and refresh-node-info treat zero and negative
-    # values uniformly.
-    if arguments.loop is None or arguments.loop <= 0:
-        refresh(arguments.output)
-        return 0
-
-    while True:
-        started = time.time()
-        try:
-            refresh(arguments.output)
-        except Exception:
-            # Keep the previous file in place and try again on the next tick:
-            # a transient failure must not blank out the metrics. Log the
-            # traceback, not just the message: str(ex) alone is close to
-            # undiagnosable for the failures this can see.
-            print(traceback.format_exc(), file=sys.stderr, end="")
-        # Rest at least as long as the pass took, so the walk never occupies
-        # more than half the wall clock however large the trees grow. The
-        # walk cannot be given a deadline instead: abandoning it would leave
-        # the biggest module -- the one whose size matters most -- either
-        # permanently unmeasured or reported as a partial sum that reads as
-        # a share shrinking. A slower sample rate loses no data at all.
-        time.sleep(max(arguments.loop, time.time() - started))
+    refresh(arguments.output)
+    return 0
 
 
 if __name__ == "__main__":

--- a/core/imageroot/var/lib/nethserver/node/bin/refresh-volume-metrics
+++ b/core/imageroot/var/lib/nethserver/node/bin/refresh-volume-metrics
@@ -1,0 +1,558 @@
+#!/usr/local/agent/pyenv/bin/python3
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+"""Write per-volume disk usage for the node_exporter textfile collector.
+
+Podman volumes are plain directory trees, and the root filesystem carries no
+per-directory accounting: NS8 nodes mount it "noquota", so a size can only be
+obtained by walking the tree. The walk is expensive on a node holding mail or
+file shares, which is why this runs as its own unit on a slow interval instead
+of inside refresh-container-metrics.
+
+Each module is walked once and the result is split into three non-overlapping
+buckets -- named volumes, the container image store, and everything else, the
+module state -- so the three metric families cost a single traversal.
+"""
+
+import argparse
+import os
+import os.path
+import pwd
+import re
+import sys
+import time
+import traceback
+
+DEFAULT_OUTPUT = "./node_exporter/volumes.prom"
+
+ROOTFULL_STORAGE_ROOT = "/var/lib/containers/storage"
+NETHSERVER_ROOT = "/var/lib/nethserver"
+# The core's own state trees. They are not modules, so the module discovery
+# below skips them, but their contents are real disk usage and belong in
+# the "core" state bucket -- without them module="core" was the only entry
+# with no ns8_module_state_bytes series at all.
+CORE_STATE_DIRS = ("cluster", "node", "api-server")
+ROOTLESS_STORAGE_SUFFIX = ".local/share/containers/storage"
+# What makes a local user an NS8 module, as runagent decides it too. The
+# presence of a container storage directory is not enough: any account that
+# has ever run podman by hand has one, and would then get module series of
+# its own and have its whole home walked on every pass.
+MODULE_MARKER = ".config/state/agent.env"
+
+# A rootfull module directory is <name><number>, as created by
+# add-module. The core's own directories -- cluster, node, api-server --
+# carry no trailing digits, so the shape alone tells them apart and no list
+# of reserved names has to be kept in sync.
+_MODULE_DIR_RE = re.compile(r"^[a-z][a-z0-9-]*[0-9]+$")
+
+
+def walk_tree(root, seen, exclude=(), same_device=False):
+    """Return (bytes, objects) under root, following du's accounting.
+
+    Sizes are st_blocks * 512, the space actually occupied, not the apparent
+    size: a sparse or compressed file must not be reported as bigger than the
+    room it takes. Directories count too, again like du.
+
+    ``seen`` collects the (device, inode) pairs of multiply linked files, so a
+    hardlinked file is charged once per module however many names it has.
+    Pass the same set across a module's buckets to keep them disjoint.
+
+    Paths in ``exclude`` are not descended into. Unreadable directories are
+    skipped: root can normally read everything here, and losing a subtree is
+    still worth more than losing the module.
+
+    ``same_device`` confines the walk to the filesystem of ``root``, like
+    "du -x". The image store needs it: a running rootfull container has its
+    union view mounted at overlay/<layer>/merged, inside the store, and
+    counting that re-counts the whole container rootfs on top of the layers
+    it is built from. The lower-layer files carry st_nlink == 1, so the
+    hardlink dedupe below does not catch them.
+    """
+    excluded = set(os.path.normpath(path) for path in exclude)
+    try:
+        stat = os.lstat(root)
+    except OSError:
+        return None
+    # os.stat(), not the lstat above: scandir() resolves the path, so a
+    # storage root that is a symlink onto another filesystem -- one way to
+    # relocate container storage -- would otherwise leave root_device set to
+    # the device holding the link, and every entry would be skipped as
+    # off-device. The bucket would then publish a zero that the docs promise
+    # is a real measurement.
+    try:
+        root_device = os.stat(root).st_dev
+    except OSError:
+        return None
+    total = stat.st_blocks * 512
+    objects = 1
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = list(os.scandir(current))
+        except OSError:
+            continue
+        for entry in entries:
+            if os.path.normpath(entry.path) in excluded:
+                continue
+            try:
+                stat = entry.stat(follow_symlinks=False)
+            except OSError:
+                continue
+            if same_device and stat.st_dev != root_device:
+                continue
+            is_dir = entry.is_dir(follow_symlinks=False)
+            if not is_dir and stat.st_nlink > 1:
+                key = (stat.st_dev, stat.st_ino)
+                if key in seen:
+                    continue
+                seen.add(key)
+            total += stat.st_blocks * 512
+            objects += 1
+            if is_dir:
+                stack.append(entry.path)
+    return (total, objects)
+
+
+def mark_skipped(skipped, module_id):
+    """Record a module whose usage could not be measured, at most once.
+
+    walk_tree() reports a failure by returning None rather than by raising,
+    so a bare "continue" on None would leave the skipped counter at zero
+    while the module's series silently disappeared -- a fault that looks
+    exactly like a module having nothing to measure.
+    """
+    if skipped is not None and module_id not in skipped:
+        skipped.append(module_id)
+
+
+def list_rootfull_modules(nethserver_root=NETHSERVER_ROOT):
+    """Return the rootfull module ids installed on this node."""
+    try:
+        names = os.listdir(nethserver_root)
+    except OSError:
+        return []
+    ids = [
+        name
+        for name in names
+        if _MODULE_DIR_RE.match(name)
+        and os.path.isdir(os.path.join(nethserver_root, name))
+    ]
+    ids.sort()
+    return ids
+
+
+def list_rootless_modules(passwd_entries=pwd.getpwall):
+    """Return (module id, home) for every rootless module user.
+
+    Membership is decided by the agent state file that every module user
+    has, not by the user id range and not by owning a container storage
+    directory. The storage directory is the wrong test: an administrator who
+    once ran podman by hand has one too, and would be reported as a module.
+    This test keeps a module in even while all of its containers are
+    stopped, which a discovery based on running cgroups would not.
+    """
+    modules = []
+    try:
+        entries = passwd_entries()
+    except Exception:
+        return []
+    for entry in entries:
+        home = entry.pw_dir
+        if not home:
+            continue
+        if not os.path.isfile(os.path.join(home, MODULE_MARKER)):
+            continue
+        modules.append((entry.pw_name, home))
+    modules.sort()
+    return modules
+
+
+def list_volumes(storage_root):
+    """Return (name, path) for every named volume under a storage root."""
+    volumes_dir = os.path.join(storage_root, "volumes")
+    try:
+        names = sorted(os.listdir(volumes_dir))
+    except OSError:
+        return []
+    return [
+        (name, os.path.join(volumes_dir, name))
+        for name in names
+        if os.path.isdir(os.path.join(volumes_dir, name))
+    ]
+
+
+def resolve_volume_module(name, module_ids):
+    """Return the rootfull module owning a volume, by name.
+
+    Rootfull modules share one storage root, and podman records the
+    volume-to-container link only inside its own database, which is not
+    readable without libpod. The volume name is the one durable clue left:
+    add-module names a module's volumes after it, so "crowdsec1-data" belongs
+    to "crowdsec1". A volume matching no module -- redis-data, rclone-cache --
+    belongs to a core container, and is reported as "core", the same way
+    resolve_module() reports core containers in refresh-container-metrics.
+    """
+    for module_id in sorted(module_ids, key=lambda value: (-len(value), value)):
+        if name == module_id or name.startswith(module_id + "-"):
+            return module_id
+    return "core"
+
+
+def collect_rootfull(
+    rootfull_storage_root=ROOTFULL_STORAGE_ROOT,
+    nethserver_root=NETHSERVER_ROOT,
+    skipped=None,
+):
+    """Collect the shared rootfull storage root and the module state trees."""
+    module_ids = list_rootfull_modules(nethserver_root)
+    # One set of visited inodes per attributed module, so a hardlinked file
+    # is charged once per module rather than once per node. A single shared
+    # set would give the file to whichever module was walked first and hide
+    # it from the other, and the split would flip if a volume were renamed.
+    # collect_rootless() gets this for free: it walks one module at a time.
+    seens = {}
+    volumes = []
+    modules = {}
+
+    for name, path in list_volumes(rootfull_storage_root):
+        module = resolve_volume_module(name, module_ids)
+        measured = walk_tree(path, seens.setdefault(module, set()))
+        if measured is None:
+            mark_skipped(skipped, module)
+            continue
+        volumes.append(
+            {
+                "module": module,
+                "volume": name,
+                "bytes": measured[0],
+                "objects": measured[1],
+            }
+        )
+        entry = modules.setdefault(module, {})
+        entry["volumes"] = entry.get("volumes", 0) + measured[0]
+        entry["total"] = entry.get("total", 0) + measured[0]
+
+    # The image store is one overlay tree shared by every rootfull module, so
+    # no module can be charged for its own share of it. It is reported once,
+    # under "core", instead of being split by a guess.
+    images = walk_tree(
+        rootfull_storage_root,
+        set(),
+        exclude=[os.path.join(rootfull_storage_root, "volumes")],
+        same_device=True,
+    )
+    if images is None:
+        mark_skipped(skipped, "core")
+    else:
+        entry = modules.setdefault("core", {})
+        entry["images"] = images[0]
+        entry["total"] = entry.get("total", 0) + images[0]
+
+    for module_id in module_ids:
+        try:
+            state = walk_tree(
+                os.path.join(nethserver_root, module_id),
+                seens.setdefault(module_id, set()),
+            )
+        except Exception:
+            mark_skipped(skipped, module_id)
+            print(
+                "collect_rootfull(): skipping module %s:\n%s"
+                % (module_id, traceback.format_exc()),
+                file=sys.stderr,
+                end="",
+            )
+            continue
+        if state is None:
+            mark_skipped(skipped, module_id)
+            continue
+        entry = modules.setdefault(module_id, {})
+        entry["state"] = state[0]
+        entry["total"] = entry.get("total", 0) + state[0]
+
+    core_seen = seens.setdefault("core", set())
+    core_state = None
+    for name in CORE_STATE_DIRS:
+        measured = walk_tree(os.path.join(nethserver_root, name), core_seen)
+        if measured is None:
+            mark_skipped(skipped, "core")
+            continue
+        core_state = (core_state or 0) + measured[0]
+    if core_state is not None:
+        entry = modules.setdefault("core", {})
+        entry["state"] = core_state
+        entry["total"] = entry.get("total", 0) + core_state
+
+    return volumes, modules
+
+
+def collect_rootless(passwd_entries=pwd.getpwall, skipped=None):
+    """Collect volumes, image store and state for every rootless module."""
+    volumes = []
+    modules = {}
+
+    for module_id, home in list_rootless_modules(passwd_entries):
+        # One unreadable module must never cost us the whole node's metrics:
+        # log it, skip it, keep collecting the rest.
+        try:
+            storage_root = os.path.join(home, ROOTLESS_STORAGE_SUFFIX)
+            seen = set()
+            entry = modules.setdefault(module_id, {})
+            for name, path in list_volumes(storage_root):
+                measured = walk_tree(path, seen)
+                if measured is None:
+                    mark_skipped(skipped, module_id)
+                    continue
+                volumes.append(
+                    {
+                        "module": module_id,
+                        "volume": name,
+                        "bytes": measured[0],
+                        "objects": measured[1],
+                    }
+                )
+                entry["volumes"] = entry.get("volumes", 0) + measured[0]
+                entry["total"] = entry.get("total", 0) + measured[0]
+
+            images = None
+            if os.path.isdir(storage_root):
+                images = walk_tree(
+                    storage_root,
+                    seen,
+                    exclude=[os.path.join(storage_root, "volumes")],
+                    same_device=True,
+                )
+                if images is None:
+                    mark_skipped(skipped, module_id)
+            if images is not None:
+                entry["images"] = images[0]
+                entry["total"] = entry.get("total", 0) + images[0]
+
+            state = walk_tree(home, seen, exclude=[storage_root])
+            if state is None:
+                mark_skipped(skipped, module_id)
+            else:
+                entry["state"] = state[0]
+                entry["total"] = entry.get("total", 0) + state[0]
+        except Exception:
+            mark_skipped(skipped, module_id)
+            modules.pop(module_id, None)
+            volumes = [item for item in volumes if item["module"] != module_id]
+            print(
+                "collect_rootless(): skipping module %s:\n%s"
+                % (module_id, traceback.format_exc()),
+                file=sys.stderr,
+                end="",
+            )
+
+    return volumes, modules
+
+
+def collect(
+    rootfull_storage_root=ROOTFULL_STORAGE_ROOT,
+    nethserver_root=NETHSERVER_ROOT,
+    passwd_entries=pwd.getpwall,
+    skipped=None,
+):
+    """Build the volume records and the per-module buckets for this node."""
+    volumes, modules = collect_rootfull(
+        rootfull_storage_root, nethserver_root, skipped=skipped
+    )
+    rootless_volumes, rootless_modules = collect_rootless(
+        passwd_entries, skipped=skipped
+    )
+    volumes.extend(rootless_volumes)
+    # Merge rather than update(): a module id present in both maps would
+    # otherwise lose its rootfull buckets outright. No module is both today
+    # -- rootfull state lives in /var/lib/nethserver/<id> and rootless state
+    # in the user's home -- but silently dropping a bucket is not the way to
+    # find out that changed.
+    for module_id, buckets in rootless_modules.items():
+        entry = modules.setdefault(module_id, {})
+        for key, value in buckets.items():
+            entry[key] = entry.get(key, 0) + value
+    volumes.sort(key=lambda record: (record["module"], record["volume"]))
+    return volumes, modules
+
+
+def escape_label(value):
+    """Escape a label value for the Prometheus text exposition format."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+class _Exposition(object):
+    """Accumulate samples, keeping every family's samples contiguous."""
+
+    def __init__(self):
+        self._families = {}
+        self._order = []
+
+    def add(self, name, kind, help_text, labels, value):
+        if name not in self._families:
+            self._families[name] = {"kind": kind, "help": help_text, "samples": []}
+            self._order.append(name)
+        if labels:
+            rendered = ",".join(
+                '%s="%s"' % (key, escape_label(val)) for key, val in labels
+            )
+            sample = "%s{%s} %s" % (name, rendered, value)
+        else:
+            sample = "%s %s" % (name, value)
+        self._families[name]["samples"].append(sample)
+
+    def render(self):
+        lines = []
+        for name in self._order:
+            family = self._families[name]
+            lines.append("# HELP %s %s" % (name, family["help"]))
+            lines.append("# TYPE %s %s" % (name, family["kind"]))
+            lines.extend(family["samples"])
+        return "\n".join(lines) + "\n"
+
+
+_MODULE_GAUGES = (
+    ("volumes", "ns8_module_volumes_bytes", "Named volume disk usage of the module"),
+    ("images", "ns8_module_images_bytes", "Container image store disk usage"),
+    ("state", "ns8_module_state_bytes", "Module state and configuration disk usage"),
+    ("total", "ns8_module_total_bytes", "Module disk usage, volumes and images included"),
+)
+
+
+def render(volumes, modules, duration_seconds, timestamp, skipped=0):
+    """Render the collected usage as a Prometheus text exposition document."""
+    exposition = _Exposition()
+
+    for record in volumes:
+        exposition.add(
+            "ns8_volume_size_bytes",
+            "gauge",
+            "Volume disk usage",
+            (("module", record["module"]), ("volume", record["volume"])),
+            "%d" % record["bytes"],
+        )
+
+    for record in volumes:
+        exposition.add(
+            "ns8_volume_files",
+            "gauge",
+            "Filesystem objects in the volume, directories included",
+            (("module", record["module"]), ("volume", record["volume"])),
+            "%d" % record["objects"],
+        )
+
+    for key, name, help_text in _MODULE_GAUGES:
+        for module_id in sorted(modules):
+            value = modules[module_id].get(key)
+            # A tree that could not be measured is left out rather than
+            # published as zero: an absent series and a zero series mean
+            # different things, and zero would assert a measurement that was
+            # never taken.
+            if value is None:
+                continue
+            exposition.add(
+                name, "gauge", help_text, (("module", module_id),), "%d" % value
+            )
+
+    exposition.add(
+        "ns8_volume_collector_duration_seconds",
+        "gauge",
+        "Duration of the last volume metrics collection",
+        (),
+        "%.6f" % duration_seconds,
+    )
+    # Without this, a fault that skips every module looks identical to a node
+    # with no modules: collect() returns empty, the file is still valid and
+    # the success timestamp keeps advancing, so nothing alerts.
+    exposition.add(
+        "ns8_volume_collector_skipped_modules",
+        "gauge",
+        "Modules that could not be collected in the last collection",
+        (),
+        "%d" % skipped,
+    )
+    exposition.add(
+        "ns8_volume_collector_last_success_timestamp_seconds",
+        "gauge",
+        "Unix timestamp of the last successful collection",
+        (),
+        "%d" % timestamp,
+    )
+    return exposition.render()
+
+
+def write_atomic(path, text):
+    """Write text to path through a temporary file, then rename it in place.
+
+    The temporary name is fixed rather than carrying the pid: a process
+    killed between the write and the rename leaves it behind, and the unit
+    can only clean up a name it knows. It stays outside node_exporter's
+    *.prom glob either way, so it is never scraped.
+    """
+    temporary = "%s.tmp" % path
+    with open(temporary, "w") as fp:
+        fp.write(text)
+    os.rename(temporary, path)
+
+
+def refresh(output):
+    os.makedirs(os.path.dirname(output) or ".", exist_ok=True)
+    skipped = []
+    started = time.time()
+    volumes, modules = collect(skipped=skipped)
+    elapsed = time.time() - started
+    write_atomic(
+        output,
+        render(volumes, modules, elapsed, int(time.time()), skipped=len(skipped)),
+    )
+    return len(volumes)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Write per-volume disk usage for the node_exporter textfile collector"
+    )
+    parser.add_argument(
+        "-l",
+        "--loop",
+        type=int,
+        metavar="INTERVAL",
+        help="Run forever, refreshing every INTERVAL seconds",
+    )
+    parser.add_argument(
+        "-o", "--output", default=DEFAULT_OUTPUT, help="Output file path"
+    )
+    arguments = parser.parse_args()
+
+    # A non-positive interval means single-pass, matching how
+    # refresh-container-metrics and refresh-node-info treat zero and negative
+    # values uniformly.
+    if arguments.loop is None or arguments.loop <= 0:
+        refresh(arguments.output)
+        return 0
+
+    while True:
+        started = time.time()
+        try:
+            refresh(arguments.output)
+        except Exception:
+            # Keep the previous file in place and try again on the next tick:
+            # a transient failure must not blank out the metrics. Log the
+            # traceback, not just the message: str(ex) alone is close to
+            # undiagnosable for the failures this can see.
+            print(traceback.format_exc(), file=sys.stderr, end="")
+        # Rest at least as long as the pass took, so the walk never occupies
+        # more than half the wall clock however large the trees grow. The
+        # walk cannot be given a deadline instead: abandoning it would leave
+        # the biggest module -- the one whose size matters most -- either
+        # permanently unmeasured or reported as a partial sum that reads as
+        # a share shrinking. A slower sample rate loses no data at all.
+        time.sleep(max(arguments.loop, time.time() - started))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/imageroot/var/lib/nethserver/node/uninstall.sh
+++ b/core/imageroot/var/lib/nethserver/node/uninstall.sh
@@ -81,7 +81,8 @@ systemctl disable --now \
   send-heartbeat.service \
   send-inventory.timer \
   send-backup.timer \
-  password-warning.timer
+  password-warning.timer \
+  refresh-volume-metrics.timer
   # end of unit list
 rm -vf /etc/wireguard/wg0.conf
 userdel -r api-server

--- a/docs/core/container_metrics.md
+++ b/docs/core/container_metrics.md
@@ -106,25 +106,12 @@ Rootless modules run under `user@<uid>.service`, which by default
 delegates only `memory` and `pids`. The core update that ships this
 feature installs a drop-in,
 `/etc/systemd/system/user@.service.d/50-ns8-delegate.conf`, that adds
-`io` to the delegated controller set (`cpu` is left out on purpose —
-see the comment in that file for why). This drop-in only takes effect
-the next time a rootless module's user manager restarts, which happens
-on the module's own restart or on a node reboot. Until then,
-`ns8_container_blkio_*` is absent for that module's containers, while
-CPU, memory and PID metrics are complete. This is expected, not a
-fault: an update deliberately does not bounce every rootless container
-on a node just to enable a monitoring feature.
+`io` gives disk stats access to rootless modules.
 
 The drop-in applies to every local user manager on the node, not only
 NethServer module users — a `user@.service.d` drop-in can't be scoped
 to particular user ids. Root's own manager is the exception, masked by
 an empty `/etc/systemd/system/user@0.service.d/50-ns8-delegate.conf`.
-
-To roll it back: remove
-`/etc/systemd/system/user@.service.d/50-ns8-delegate.conf`, run
-`systemctl daemon-reload`, then restart the affected user managers or
-reboot the node. Block I/O metrics disappear again for rootless
-modules once it's removed.
 
 ## Network
 

--- a/docs/core/container_metrics.md
+++ b/docs/core/container_metrics.md
@@ -1,0 +1,165 @@
+---
+layout: default
+title: Container metrics
+nav_order: 18
+parent: Core
+---
+
+# Container metrics
+
+NS8 exposes per-container CPU, memory, PIDs, block I/O and network metrics
+on each node's existing `node_exporter` endpoint. The metrics are produced
+by `refresh-container-metrics.service`, a collector that runs on every
+node, writes a Prometheus text file into `node_exporter`'s textfile
+collector directory every 60 seconds, and is bound to the lifecycle of
+`node_exporter.service` itself. No new port is opened and no new scrape
+job is needed: the series appear on the node's `/metrics` endpoint like
+any other `node_exporter` metric and are collected into the `metrics`
+module's Prometheus on the leader node with the rest of the cluster's
+metrics.
+
+The collector reads cgroup v2 accounting files directly, instead of
+querying the systemd unit that started the container. NS8 starts
+containers with `podman run --detach --cgroups=no-conmon`, so the
+systemd unit's own cgroup only accounts for the `conmon` supervisor
+process, not the container payload (on a test node: 770 KB reported by
+the unit vs. 165 MB in the container's real `libpod-<CID>.scope`
+cgroup). The collector reads that scope cgroup instead.
+
+## Metrics
+
+Counters:
+
+| Metric | Labels | Meaning |
+|---|---|---|
+| `ns8_container_cpu_seconds_total` | `module`, `container`, `mode="user\|system"` | Container CPU time spent, in seconds |
+| `ns8_container_blkio_bytes_total` | `module`, `container`, `device`, `op="read\|write"` | Container block I/O transferred, in bytes |
+| `ns8_container_blkio_ops_total` | `module`, `container`, `device`, `op="read\|write"` | Container block I/O operations |
+| `ns8_container_network_receive_bytes_total` | `module`, `container`, `device` | Container bytes received |
+| `ns8_container_network_transmit_bytes_total` | `module`, `container`, `device` | Container bytes transmitted |
+| `ns8_container_network_receive_packets_total` | `module`, `container`, `device` | Container packets received |
+| `ns8_container_network_transmit_packets_total` | `module`, `container`, `device` | Container packets transmitted |
+| `ns8_container_oom_kills_total` | `module`, `container` | Processes killed by the container OOM killer |
+
+Gauges:
+
+| Metric | Labels | Meaning |
+|---|---|---|
+| `ns8_container_memory_usage_bytes` | `module`, `container` | Container memory usage |
+| `ns8_container_memory_peak_bytes` | `module`, `container` | Container peak memory usage |
+| `ns8_container_memory_limit_bytes` | `module`, `container` | Container memory limit |
+| `ns8_container_memory_swap_bytes` | `module`, `container` | Container swap usage |
+| `ns8_container_memory_anon_bytes` | `module`, `container` | Container anonymous memory |
+| `ns8_container_memory_file_bytes` | `module`, `container` | Container page cache memory |
+| `ns8_container_pids` | `module`, `container` | Processes running in the container |
+| `ns8_container_pids_limit` | `module`, `container` | Container process limit |
+| `ns8_container_start_time_seconds` | `module`, `container` | Container creation time |
+| `ns8_container_info` | `module`, `container`, `id`, `image`, `unit`, `rootless` | Container metadata, always `1` |
+| `ns8_container_collector_duration_seconds` | none | Duration of the last container metrics collection |
+| `ns8_container_collector_skipped_containers` | none | Containers that could not be collected in the last collection |
+| `ns8_container_collector_last_success_timestamp_seconds` | none | Unix timestamp of the last successful collection |
+
+## Labels
+
+`container` is the container name, and `module` is the id of the module
+that owns it. Core containers that are not part of an installed module,
+such as `redis`, `promtail`, `node_exporter` and `rclone-gateway`, are
+reported with `module="core"`.
+
+A container whose owner cannot be determined is reported with
+`module="unknown"` instead. That happens while a container is exiting,
+when one was started outside a service unit (`podman run` by hand), or
+when a rootless container belongs to a local account that is not a
+module. Module users are recognised by the agent state file
+`~/.config/state/agent.env` (the same test `runagent` uses), not by
+owning a container storage directory — any account that has ever run
+rootless podman has one of those too. `module="unknown"` is kept
+separate from `module="core"` so a failed attribution is never mistaken
+for a core container.
+
+Modules that run their containers in a pod also report the pod's infra
+container, named `<pod>-infra`. It is a real container with its own
+cgroup, and it is attributed to the module that owns the pod.
+
+`ns8_container_start_time_seconds` is podman's own creation timestamp
+for the container. NS8 units start their containers with `--replace`, so
+a container is recreated on every restart and its creation time is also
+its start time. The cgroup directory mtime is used only as a fallback,
+when the index carries no timestamp — it's weaker, since a cgroup's
+mtime also advances whenever a child cgroup appears or goes away.
+
+The container id (truncated to 12 characters) appears only on
+`ns8_container_info`, not on every series: a container gets a new id on
+each restart, so putting it everywhere would churn the label set and
+break `rate()` across restarts. Use the stable `container` name to
+select or aggregate a container across restarts.
+
+## Block I/O
+
+`ns8_container_blkio_bytes_total` and `ns8_container_blkio_ops_total`
+depend on the `io` cgroup controller being delegated to the container's
+cgroup. Rootfull containers, which run under `machine.slice`, already
+have the `io` controller delegated, so block I/O is reported
+immediately.
+
+Rootless modules run under `user@<uid>.service`, which by default
+delegates only `memory` and `pids`. The core update that ships this
+feature installs a drop-in,
+`/etc/systemd/system/user@.service.d/50-ns8-delegate.conf`, that adds
+`io` to the delegated controller set (`cpu` is left out on purpose —
+see the comment in that file for why). This drop-in only takes effect
+the next time a rootless module's user manager restarts, which happens
+on the module's own restart or on a node reboot. Until then,
+`ns8_container_blkio_*` is absent for that module's containers, while
+CPU, memory and PID metrics are complete. This is expected, not a
+fault: an update deliberately does not bounce every rootless container
+on a node just to enable a monitoring feature.
+
+The drop-in applies to every local user manager on the node, not only
+NethServer module users — a `user@.service.d` drop-in can't be scoped
+to particular user ids. Root's own manager is the exception, masked by
+an empty `/etc/systemd/system/user@0.service.d/50-ns8-delegate.conf`.
+
+To roll it back: remove
+`/etc/systemd/system/user@.service.d/50-ns8-delegate.conf`, run
+`systemctl daemon-reload`, then restart the affected user managers or
+reboot the node. Block I/O metrics disappear again for rootless
+modules once it's removed.
+
+## Network
+
+`ns8_container_network_*` is reported once per network namespace, not
+once per container.
+
+Every container in a pod shares the pod's network namespace, so they
+all read the same interface counters. To avoid multiplying the pod's
+traffic by its container count in a `sum by (module)`, it's reported
+once, with `container` set to `<pod>-infra` (podman's name for the
+pod's infra container). Other pod members carry no
+`ns8_container_network_*` series. Group by `module`, or select
+`<pod>-infra`, to get a pod's traffic.
+
+Beyond that, the family is reported only for a container that has its
+own network namespace. Most NS8 containers run with `--network=host`
+and share the node's namespace instead, so their traffic shows up in
+the node's own `node_network_*` metrics, not here.
+
+Loopback (`lo`) is excluded: it's the container talking to itself, not
+real traffic in or out, and on a test node it was 98% of all bytes
+received — large enough to hide everything else. When a container's
+network family is absent from `ns8_container_network_*`, that means
+"not applicable", not "zero traffic".
+
+More generally, the collector omits a metric rather than reporting it as
+zero whenever the value could not be measured, for example when a
+cgroup file is missing. Prometheus treats an absent series and a zero
+series differently, and reporting zero would assert a measurement that
+was never actually taken.
+
+## Example query
+
+Top 5 modules by CPU usage over the last 5 minutes:
+
+```
+topk(5, sum by (module) (rate(ns8_container_cpu_seconds_total[5m])))
+```

--- a/docs/core/volume_metrics.md
+++ b/docs/core/volume_metrics.md
@@ -1,0 +1,177 @@
+---
+layout: default
+title: Volume metrics
+nav_order: 19
+parent: Core
+---
+
+# Volume metrics
+
+NS8 exposes per-volume and per-module disk usage on each node's existing
+`node_exporter` endpoint. The metrics are produced by
+`refresh-volume-metrics.service`, a collector that runs on every node,
+writes a Prometheus text file into `node_exporter`'s textfile collector
+directory every 15 minutes, and is bound to the lifecycle of
+`node_exporter.service` itself. Like the [container
+metrics](container_metrics.md), the series appear on the node's
+`/metrics` endpoint and are collected into the `metrics` module's
+Prometheus on the leader node, with no new port and no new scrape job.
+
+The collector walks the directory trees, because there's nothing
+cheaper to read: podman volumes are plain directories, and the root
+filesystem is mounted `noquota`, so a size can only be obtained by
+visiting every inode. That walk is expensive on a node holding mail or
+file shares, which is why it runs as its own unit on a slow interval
+instead of another pass inside `refresh-container-metrics.service` — a
+slow walk never delays the container samples, and a failure in one
+collector doesn't take the other down. The unit also runs with
+`Nice=10` and `IOSchedulingClass=idle`, so a monitoring pass never
+makes a busy server feel slow.
+
+Sizes are the space actually occupied on disk, `st_blocks * 512`, not
+the apparent file size, and a hardlinked file is charged once per
+module. Both match `du -s -B1`; `ns8_volume_files` matches
+`du -s --inodes`.
+
+The image-store walk stays on one filesystem, like `du -x` (compare
+against `du -sx -B1`). It skips a running rootfull container's union
+view, mounted inside the store at `overlay/<layer>/merged` — counting
+it would re-count the whole container rootfs on top of the layers it's
+built from, and hardlink dedupe doesn't catch it since lower-layer
+files have a link count of one. The volume and state walks do cross
+filesystems, so a volume backed by its own mount is still measured.
+
+## Metrics
+
+All gauges:
+
+| Metric | Labels | Meaning |
+|---|---|---|
+| `ns8_volume_size_bytes` | `module`, `volume` | Volume disk usage |
+| `ns8_volume_files` | `module`, `volume` | Filesystem objects in the volume, directories included |
+| `ns8_module_volumes_bytes` | `module` | Named volume disk usage of the module |
+| `ns8_module_images_bytes` | `module` | Container image store disk usage |
+| `ns8_module_state_bytes` | `module` | Module state and configuration disk usage |
+| `ns8_module_total_bytes` | `module` | Module disk usage, volumes and images included |
+| `ns8_volume_collector_duration_seconds` | none | Duration of the last volume metrics collection |
+| `ns8_volume_collector_skipped_modules` | none | Modules that could not be collected in the last collection |
+| `ns8_volume_collector_last_success_timestamp_seconds` | none | Unix timestamp of the last successful collection |
+
+## Buckets
+
+Each module is walked once, and the result is split into three
+non-overlapping buckets, reported per module by
+`ns8_module_volumes_bytes`, `ns8_module_images_bytes` and
+`ns8_module_state_bytes`. `ns8_module_total_bytes` is their sum, emitted
+because adding three families up in PromQL is awkward.
+
+`ns8_module_volumes_bytes` is the same figure as
+`sum by (module) (ns8_volume_size_bytes)`, kept as its own series so
+that a per-module view needs no aggregation.
+
+Hardlink accounting is per module: each module's buckets share one set
+of visited inodes, so a file with several names inside one module is
+charged once, and two modules that share a hardlinked file are each
+charged for it. Summing `ns8_module_total_bytes` across modules can
+therefore exceed the space actually occupied, which is the same
+behaviour as running `du -s` on each module separately.
+
+| Bucket | Rootless module | Rootfull module |
+|---|---|---|
+| volumes | `~/.local/share/containers/storage/volumes/<volume>` | `/var/lib/containers/storage/volumes/<volume>` |
+| images | `~/.local/share/containers/storage`, volumes excluded | `/var/lib/containers/storage`, volumes excluded |
+| state | the home directory, container storage excluded | `/var/lib/nethserver/<module>` |
+
+A rootless module is any local user whose home holds the agent state
+file `.config/state/agent.env` (the same test `runagent` uses), not
+just any owner of a `.local/share/containers/storage` directory —
+an administrator who has ever run rootless podman owns one of those
+too. This test also keeps a module counted while all its containers
+are stopped, unlike a discovery based on running cgroups.
+
+A rootfull module is a `/var/lib/nethserver/<name><number>` directory.
+The core's own directories -- `cluster`, `node`, `api-server` -- carry
+no trailing digits, so the shape alone tells them apart. Those three are
+not modules, but their contents are real disk usage: they are summed
+into `ns8_module_state_bytes{module="core"}`.
+
+## Rootfull attribution
+
+Rootfull modules share a single storage root, which constrains what can
+be attributed to whom.
+
+The image store is one overlay tree with shared layers, so no rootfull
+module can be charged for its own part of it. It is reported once, as
+`ns8_module_images_bytes{module="core"}`, rather than split by a guess.
+Rootfull modules therefore have no `ns8_module_images_bytes` series of
+their own, and their `ns8_module_total_bytes` covers their volumes and
+state only.
+
+Rootfull volumes are attributed by name, longest match first:
+`crowdsec1-data` belongs to `crowdsec1`. Podman's volume-to-container
+link lives only in its own database, unreadable without libpod, so the
+name is the only durable clue available. A volume matching no module
+(`redis-data`, `rclone-cache`) belongs to a core container and is
+reported with `module="core"`, same as the container metrics.
+
+The core's own directories are not modules, so `core` has no
+`ns8_module_state_bytes` series: its total is the shared image store
+plus the volumes of the core containers.
+
+Volume names are unique per module, not per node: `openldap1` and
+`samba1` both own a volume named `data`. Always select on both labels.
+
+## Missing values
+
+As with the container metrics, the collector omits a metric rather than
+reporting it as zero whenever a value could not be measured. Prometheus
+treats an absent series and a zero series differently, and reporting
+zero would assert a measurement that was never taken. A zero in
+`ns8_volume_size_bytes` is a real measurement: an empty volume whose
+directory fits inside its inode occupies no blocks at all.
+
+If one of a module's trees can't be walked, that bucket is left out and
+the module is counted once in `ns8_volume_collector_skipped_modules`.
+The module's other buckets are still reported — this gauge is what
+tells a partial pass from a complete one, since an absent
+`ns8_module_state_bytes` alone could just mean the module has no state
+tree. A pass that fails outright leaves the previous file in place, so
+metrics go stale rather than disappearing; check
+`ns8_volume_collector_last_success_timestamp_seconds` to tell the two
+cases apart.
+
+## Alerting
+
+`ns8_volume_collector_skipped_modules` above zero means the last pass
+could not measure something, and the module it belongs to is named in
+the journal of `refresh-volume-metrics.service`.
+
+`ns8_volume_collector_duration_seconds` approaching the 900-second
+interval is the other signal worth watching. The walk has no deadline —
+abandoning it would leave the largest module (the one whose size
+matters most) either unmeasured or reported as a shrinking partial sum.
+Instead, the collector bounds how much of the wall clock it may
+occupy: it rests at least as long as the pass took, so a slow pass
+stretches the sampling period rather than crowding the node, and the
+walk never takes more than half the time. Figures stay complete, just
+sampled less often than every 15 minutes; this gauge shows when that's
+happening. The walk also yields to real work throughout, via
+`Nice=10` and `IOSchedulingClass=idle`.
+
+```
+ns8_volume_collector_duration_seconds > 900
+```
+
+## Example queries
+
+Top 5 modules by disk usage:
+
+```
+topk(5, ns8_module_total_bytes)
+```
+
+Volumes that grew more than 1 GB in the last day:
+
+```
+(ns8_volume_size_bytes - ns8_volume_size_bytes offset 1d) > 1e9
+```

--- a/docs/core/volume_metrics.md
+++ b/docs/core/volume_metrics.md
@@ -10,18 +10,18 @@ parent: Core
 NS8 exposes per-volume and per-module disk usage on each node's existing
 `node_exporter` endpoint. The metrics are produced by
 `refresh-volume-metrics.service`, a collector that runs on every node,
-writes a Prometheus text file into `node_exporter`'s textfile collector
-directory every 15 minutes, and is bound to the lifecycle of
-`node_exporter.service` itself. Like the [container
-metrics](container_metrics.md), the series appear on the node's
-`/metrics` endpoint and are collected into the `metrics` module's
-Prometheus on the leader node, with no new port and no new scrape job.
+writing a Prometheus text file into `node_exporter`'s textfile collector
+directory once a day, triggered by `refresh-volume-metrics.timer`. Like
+the [container metrics](container_metrics.md), the series appear on the
+node's `/metrics` endpoint and are collected into the `metrics`
+module's Prometheus on the leader node, with no new port and no new
+scrape job.
 
 The collector walks the directory trees, because there's nothing
 cheaper to read: podman volumes are plain directories, and the root
 filesystem is mounted `noquota`, so a size can only be obtained by
 visiting every inode. That walk is expensive on a node holding mail or
-file shares, which is why it runs as its own unit on a slow interval
+file shares, which is why it runs as its own unit on a slow schedule
 instead of another pass inside `refresh-container-metrics.service` — a
 slow walk never delays the container samples, and a failure in one
 collector doesn't take the other down. The unit also runs with
@@ -140,38 +140,9 @@ metrics go stale rather than disappearing; check
 `ns8_volume_collector_last_success_timestamp_seconds` to tell the two
 cases apart.
 
-## Alerting
-
-`ns8_volume_collector_skipped_modules` above zero means the last pass
-could not measure something, and the module it belongs to is named in
+Also pay attention to the following:
+- `ns8_volume_collector_skipped_modules` above zero means the last pass
+could not measure something
 the journal of `refresh-volume-metrics.service`.
-
-`ns8_volume_collector_duration_seconds` approaching the 900-second
-interval is the other signal worth watching. The walk has no deadline —
-abandoning it would leave the largest module (the one whose size
-matters most) either unmeasured or reported as a shrinking partial sum.
-Instead, the collector bounds how much of the wall clock it may
-occupy: it rests at least as long as the pass took, so a slow pass
-stretches the sampling period rather than crowding the node, and the
-walk never takes more than half the time. Figures stay complete, just
-sampled less often than every 15 minutes; this gauge shows when that's
-happening. The walk also yields to real work throughout, via
-`Nice=10` and `IOSchedulingClass=idle`.
-
-```
-ns8_volume_collector_duration_seconds > 900
-```
-
-## Example queries
-
-Top 5 modules by disk usage:
-
-```
-topk(5, ns8_module_total_bytes)
-```
-
-Volumes that grew more than 1 GB in the last day:
-
-```
-(ns8_volume_size_bytes - ns8_volume_size_bytes offset 1d) > 1e9
-```
+- `ns8_volume_collector_duration_seconds` approaching a day is the other
+signal worth watching


### PR DESCRIPTION
Issue: https://github.com/NethServer/dev/issues/8158

Add 2 new textfile exporter that are collected by node_exporter:
- container metrics — CPU, memory, PID, OOM, block I/O and network for each container, labelled with the module that owns it. The counters come from the container cgroups 
- disk usage metrics — size and file count of every named volume, plus each module's volume, image-store and state usage. This runs once a day via a systemd timer, with `Nice=10` and `IOSchedulingClass=idle` to avoid load on the server

Files are saved as:
- /var/lib/nethserver/node/state/node_exporter/containers.prom
- /var/lib/nethserver/node/state/node_exporter/volumes.prom

Use Grafana Drilldown to explore all *ns8_* metrics.

## Manual install on a single node (without updating ns8-core)

To try it on a live node without going through `update-node`, fetch the branch's files directly onto the node with curl:

```bash
# run directly on the node, as root
RAW=https://raw.githubusercontent.com/NethServer/ns8-core/container_monitor

curl -sf -o /var/lib/nethserver/node/bin/refresh-container-metrics \
    "$RAW/core/imageroot/var/lib/nethserver/node/bin/refresh-container-metrics"
curl -sf -o /var/lib/nethserver/node/bin/refresh-volume-metrics \
    "$RAW/core/imageroot/var/lib/nethserver/node/bin/refresh-volume-metrics"
chmod +x /var/lib/nethserver/node/bin/refresh-container-metrics
chmod +x /var/lib/nethserver/node/bin/refresh-volume-metrics

curl -sf -o /etc/systemd/system/refresh-container-metrics.service \
    "$RAW/core/imageroot/etc/systemd/system/refresh-container-metrics.service"
curl -sf -o /etc/systemd/system/refresh-volume-metrics.service \
    "$RAW/core/imageroot/etc/systemd/system/refresh-volume-metrics.service"
curl -sf -o /etc/systemd/system/refresh-volume-metrics.timer \
    "$RAW/core/imageroot/etc/systemd/system/refresh-volume-metrics.timer"

mkdir -p /etc/systemd/system/user@.service.d
curl -sf -o /etc/systemd/system/user@.service.d/50-ns8-delegate.conf \
    "$RAW/core/imageroot/etc/systemd/system/user@.service.d/50-ns8-delegate.conf"

systemctl daemon-reload
systemctl start refresh-container-metrics
systemctl enable --now refresh-volume-metrics.timer
systemctl start refresh-volume-metrics.service  # trigger a first run now

# Verification
curl -s http://127.0.0.1:9100/metrics | grep ^ns8_container_
curl -s http://127.0.0.1:9100/metrics | grep -E '^ns8_volume_|^ns8_module_'
curl -s http://127.0.0.1:9100/metrics | grep node_textfile_scrape_error
journalctl -u refresh-container-metrics.service -u refresh-volume-metrics.service -u refresh-volume-metrics.timer -f
```

### Rolling back the manual install

```bash
systemctl stop refresh-container-metrics.service
systemctl disable --now refresh-volume-metrics.timer
rm -f /etc/systemd/system/refresh-container-metrics.service
rm -f /etc/systemd/system/refresh-volume-metrics.service
rm -f /etc/systemd/system/refresh-volume-metrics.timer
rm -f /var/lib/nethserver/node/bin/refresh-container-metrics
rm -f /var/lib/nethserver/node/bin/refresh-volume-metrics
rm -f /etc/systemd/system/user@.service.d/50-ns8-delegate.conf
# revert the two Wants= lines added to node_exporter.service
systemctl daemon-reload
systemctl restart node_exporter.service
rm -f /var/lib/nethserver/node/state/node_exporter/containers.prom
rm -f /var/lib/nethserver/node/state/node_exporter/volumes.prom
```
