### PR TITLE
Document Redis options in the Python agent

### DIFF
--- a/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
+++ b/core/imageroot/usr/local/agent/pypkg/agent/__init__.py
@@ -79,9 +79,9 @@ def redis_connect(privileged=False, use_replica=False, **kwargs):
     kwargs.setdefault('db', 0)
     kwargs.setdefault('username', redis_username)
     kwargs.setdefault('password', redis_password)
-    #  we assume Redis keys and value strings are encoded UTF-8. Enabling this
-    #  option implicitly converts to UTF-8 strings instead of binary strings
-    #  (e.g. {b'key': b'value'} != {'key':'value'})
+    # Redis keys and values are assumed to be UTF-8 by default. Callers can
+    # override this default with decode_responses=False in kwargs to receive
+    # raw bytes unchanged.
     kwargs.setdefault('decode_responses', True)
 
     return redis.Redis(**kwargs)

--- a/docs/modules/database.md
+++ b/docs/modules/database.md
@@ -43,3 +43,33 @@ import agent
 rdb = agent.redis_connect(use_replica=True)
 cluster_network = rdb.get('cluster/network')
 ```
+
+Any additional keyword argument supported by the installed Redis Python
+library's `redis.Redis()` constructor can be passed to
+`agent.redis_connect()`. These arguments are forwarded to the Redis client and
+can configure options such as socket timeouts, retries, TLS, database selection,
+and response decoding.
+
+```python
+rdb = agent.redis_connect(
+    use_replica=True,
+    socket_timeout=10,
+    socket_connect_timeout=5,
+)
+```
+
+`decode_responses` is one of these additional arguments. Redis responses are
+decoded from UTF-8 to strings by default. Consumers that need to validate or
+process each Redis bulk string independently can request the original bytes:
+
+```python
+import agent
+
+raw_rdb = agent.redis_connect(
+    use_replica=True,
+    decode_responses=False,
+)
+for key in raw_rdb.scan_iter('cluster/*'):
+    raw_hash = raw_rdb.hgetall(key)
+    # key, raw_hash field names, and raw_hash values are bytes
+```


### PR DESCRIPTION
Clarify that `agent.redis_connect()` forwards additional keyword
arguments to the installed Redis Python library's `redis.Redis()`
constructor. Module authors can therefore configure supported client
options such as socket timeouts, retries, TLS, database selection, and
response decoding without dedicated agent API parameters.

The module developer guide now demonstrates both general connection
options and `decode_responses=False` for callers that need raw Redis bulk
strings. The function documentation and inline comment also make this
existing behavior explicit.
