### PR TITLE
Revert "fix(applications): show the logo shipped with the app"

### DIFF
--- a/core/ui/src/views/ApplicationsCenter.vue
+++ b/core/ui/src/views/ApplicationsCenter.vue
@@ -254,10 +254,13 @@
                   <cv-data-table-cell>
                     <a @click="showAppInfo(row.appInfoData)">
                       <img
-                        :src="getLogo(row)"
+                        :src="
+                          row.logo
+                            ? row.logo
+                            : require('@/assets/module_default_logo.png')
+                        "
                         :alt="row.name + ' logo'"
                         class="module-logo"
-                        @error="onLogoError(row)"
                       />
                       <span class="app-name">{{ row.module }}</span>
                     </a>
@@ -715,18 +718,6 @@ export default {
   },
   methods: {
     ...mapActions(["setUpdateInProgressInStore", "setAppDrawerShownInStore"]),
-    getLogo(row) {
-      return (
-        row.logoCandidates[row.logoIndex] ||
-        require("@/assets/module_default_logo.png")
-      );
-    },
-    onLogoError(row) {
-      // walk down to the next candidate, ending on the shipped asset
-      if (row.logoIndex < row.logoCandidates.length) {
-        row.logoIndex++;
-      }
-    },
     showAppInfo(app) {
       this.appInfo.isShown = true;
       this.appInfo.app = app;
@@ -1053,13 +1044,11 @@ export default {
           const installedData = updateEntry || item;
           extractedModules.push({
             id: installedData.id || "",
-            // the repository logo first, then the one the app published with
-            // its own bundle: a candidate can also fail to load, so keep the
-            // whole chain and walk it in getLogo()
-            logoCandidates: [
-              ...new Set([moduleData.logo, installedData.logo].filter(Boolean)),
-            ],
-            logoIndex: 0,
+            // Use module logo URL if available, else fallback to instance logo later in the template
+            logo:
+              moduleData.logo && moduleData.logo.startsWith("http")
+                ? moduleData.logo
+                : "",
             module: moduleData.name || "", // we want a humanized module name
             node: installedData.node || "",
             node_ui_name: installedData.node_ui_name || "",


### PR DESCRIPTION
Reverts NethServer/ns8-core#1281

That PR kept a chain of logo candidates in the Applications table: the
repository logo first, then the logo the app published with its own UI
bundle, then the shipped default asset, walking down the chain on an image
load error.

We agreed on a different design with @DavidePrincipi, see
https://github.com/NethServer/dev/issues/8139.

`list-modules` was designed for Software Center. Software Center lists
remote resources, because its job is installing applications that are not
in the cluster yet, so remote calls and remote absolute URLs belong there.
The Applications page lists what is already inside the cluster. It reused
the Software Center API, and that is the real mismatch.

The fix is a new local-only action, `list-applications`, that never does
remote calls and returns the local logo. The Applications page and Cluster
status then load progressively: `list-applications` first for a fast local
list, `list-modules` afterwards to merge in the available updates. Outside
Software Center the UI should not fetch absolute URLs from remote
locations.

So the candidate chain becomes dead code once that lands, and it keeps the
remote logo as the first choice, which is the opposite of what we want. I
revert it now to get a clean base.

What this gives back until `list-applications` lands: an app installed
outside any repository, or one whose repository is disabled, shows the
generic logo again on the Applications page. The backend already returns
the right relative path, the table drops it because it is not absolute.