### PR TITLE
feat(cluster): add cluster uuid to inventory facts

### DIFF
--- a/core/imageroot/var/lib/nethserver/cluster/bin/print-inventory-ns
+++ b/core/imageroot/var/lib/nethserver/cluster/bin/print-inventory-ns
@@ -112,6 +112,10 @@ def _get_os_release():
 
     return os_release
 
+def _get_cluster_uuid():
+    rdb = agent.redis_connect(use_replica=True)
+    return rdb.get('cluster/uuid') or ''
+
 def _get_cluster_views():
     rdb = agent.redis_connect(use_replica=True)
     hmodule_domains = rdb.hgetall('cluster/module_domains') or {}
@@ -241,6 +245,7 @@ os_release = _get_os_release()
 data = {
     "public_ip": _get_public_ip(),
     "arp_macs": _run('grep -v IP /proc/net/arp | wc -l'),
+    "cluster_uuid": _get_cluster_uuid(),
     "dmi": { "product": { "name": dmi_product, "uuid": _run("cat /sys/class/dmi/id/product_uuid") }, "bios": { "version": _run("cat /sys/devices/virtual/dmi/id/bios_version"), "vendor": _run("cat /sys/devices/virtual/dmi/id/bios_vendor")}, "board": { "product": board, "manufacturer": _run("cat /sys/devices/virtual/dmi/id/sys_vendor") }},
     "virtual": _get_cpu_field("Hypervisor vendor", cpu_info) if _get_cpu_field("Hypervisor vendor", cpu_info) else 'physical',
     "kernel": _run('uname'),


### PR DESCRIPTION
## Summary

Include the `cluster/uuid` Redis key in the `print-inventory-ns` output
as a new `cluster_uuid` fact. This value is only ever transmitted
off-system by `send-inventory`, which runs exclusively when a
subscription is active, so no privacy concern is introduced for
non-subscribed systems.

This new fact will help correlate phonehome and inventory data to
analyze custom Dovecot configuration usage, ahead of the planned
Alpine/Dovecot 2.4 upgrade (which is incompatible with the current
Dovecot 2.3 configuration format).

## Related issue

NethServer/dev#7741

## How to test

1. On a subscribed NS8 leader node, run
   `/var/lib/nethserver/cluster/bin/print-inventory-ns` and check the
   JSON output contains a `cluster_uuid` field matching the Redis key
   `cluster/uuid`.
2. Confirm the value only appears in outbound data sent by
   `send-inventory` when a subscription is active.